### PR TITLE
remove-usage-of-scoping-entity-from-compatibility-MM

### DIFF
--- a/src/Famix-Compatibility-Entities/FAMIXScopingEntity.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXScopingEntity.class.st
@@ -1,8 +1,12 @@
 Class {
 	#name : #FAMIXScopingEntity,
 	#superclass : #FAMIXContainerEntity,
-	#traits : 'FamixTScopingEntity + FamixTWithGlobalVariables',
-	#classTraits : 'FamixTScopingEntity classTrait + FamixTWithGlobalVariables classTrait',
+	#traits : 'FamixTWithGlobalVariables',
+	#classTraits : 'FamixTWithGlobalVariables classTrait',
+	#instVars : [
+		'#childScopes => FMMany type: #FAMIXScopingEntity opposite: #parentScope',
+		'#parentScope => FMOne type: #FAMIXScopingEntity opposite: #childScopes'
+	],
 	#category : #'Famix-Compatibility-Entities-Entities'
 }
 
@@ -22,11 +26,36 @@ FAMIXScopingEntity >> abstractness [
 	self subclassResponsibility
 ]
 
+{ #category : #accessing }
+FAMIXScopingEntity >> addChildScope: aScopingEntity [ 
+	childScopes add: aScopingEntity
+]
+
 { #category : #'Famix-Extensions-metrics' }
 FAMIXScopingEntity >> afferentCoupling [
 	"Afferent coupling for a module is the number of modules that depend upon this module"
 	
 	^ self subclassResponsibility
+]
+
+{ #category : #accessing }
+FAMIXScopingEntity >> allChildScopes [
+	| result |
+	result := OrderedCollection new.
+	self allChildScopesDo: [ :each | result add: each].
+	^ result 
+]
+
+{ #category : #accessing }
+FAMIXScopingEntity >> allChildScopesDo: aBlock [
+	self childScopes do: [:each |
+		each withAllChildScopesDo: aBlock ]
+]
+
+{ #category : #accessing }
+FAMIXScopingEntity >> allChildScopesGroup [
+	<navigation: 'All child scopes'>
+	^ FamixNamespaceGroup withAll: self allChildScopes withDescription: 'All child scopes from ', self printString
 ]
 
 { #category : #'Famix-Extensions' }
@@ -57,6 +86,23 @@ FAMIXScopingEntity >> bunchCouplingWith: aScope [
 	^ self subclassResponsibility
 ]
 
+{ #category : #accessing }
+FAMIXScopingEntity >> childScopes [
+	"Relation named: #childScopes type: #FAMIXScopingEntity opposite: #parentScope"
+
+	<generated>
+	<FMComment: 'Child scopes embedded in this scope, if any.'>
+	<derived>
+	^ childScopes
+]
+
+{ #category : #accessing }
+FAMIXScopingEntity >> childScopes: anObject [
+
+	<generated>
+	childScopes value: anObject
+]
+
 { #category : #'Famix-Extensions' }
 FAMIXScopingEntity >> childrenOfMyKind [
 	"Polymorphic accessor to children of this scope in a hierarchical structure (package->subpackages, scope->subscopes)"
@@ -83,6 +129,30 @@ FAMIXScopingEntity >> instability [
 	"I =	Ce(P)/(Ce(P)+Ca(P)), in the range [0, 1]. 0 means package is maximally stable (i.e., no dependency to other packages and can not change without big consequences), 1 means it is unstable."
 	
 	self subclassResponsibility
+]
+
+{ #category : #accessing }
+FAMIXScopingEntity >> parentScope [
+	"Relation named: #parentScope type: #FAMIXScopingEntity opposite: #childScopes"
+
+	<generated>
+	<FMComment: 'Parent scope embedding this scope, if any.'>
+	<container>
+	^ parentScope
+]
+
+{ #category : #accessing }
+FAMIXScopingEntity >> parentScope: anObject [
+
+	<generated>
+	parentScope := anObject
+]
+
+{ #category : #navigation }
+FAMIXScopingEntity >> parentScopeGroup [
+	<generated>
+	<navigation: 'ParentScope'>
+	^ MooseGroup with: self parentScope
 ]
 
 { #category : #'Famix-Extensions' }

--- a/src/Famix-Compatibility-Generator/FamixCompatibilityGenerator.class.st
+++ b/src/Famix-Compatibility-Generator/FamixCompatibilityGenerator.class.st
@@ -336,7 +336,6 @@ FamixCompatibilityGenerator >> defineHierarchy [
 
 	scopingEntity --|> containerEntity.
 	scopingEntity --|> #TWithGlobalVariables.
-	scopingEntity --|> #TScopingEntity.
 
 	structuralEntity --|> leafEntity.
 	structuralEntity --|> #TStructuralEntity.
@@ -387,6 +386,17 @@ FamixCompatibilityGenerator >> defineHierarchy [
 	sourcedEntity --|> #TWithFiles
 	
 
+]
+
+{ #category : #definition }
+FamixCompatibilityGenerator >> defineProperties [
+	super defineProperties.
+	((scopingEntity property: #parentScope)
+			comment: 'Parent scope embedding this scope, if any.';
+			container)
+		*-
+	((scopingEntity property: #childScopes)
+			comment: 'Child scopes embedded in this scope, if any.').
 ]
 
 { #category : #definition }

--- a/src/Famix-Compatibility-Tests-Core/FAMIXNamespaceTest.class.st
+++ b/src/Famix-Compatibility-Tests-Core/FAMIXNamespaceTest.class.st
@@ -42,14 +42,3 @@ FAMIXNamespaceTest >> testMooseName [
 	self assert: child2 mooseName equals: 'a::d'.
 	self assert: child11 mooseName equals: 'a::b::c'
 ]
-
-{ #category : #testing }
-FAMIXNamespaceTest >> testWithChildScopesDo [
-	| result |
-	result := ''.
-	root withAllChildScopesDo: [ :each | result := result , each name ].
-	self assert: result equals: 'abcd'.
-	result := ''.
-	root allChildScopesDo: [ :each | result := result , each name ].
-	self assert: result equals: 'bcd'
-]

--- a/src/Famix-Deprecated/FAMIXScopingEntity.extension.st
+++ b/src/Famix-Deprecated/FAMIXScopingEntity.extension.st
@@ -1,0 +1,27 @@
+Extension { #name : #FAMIXScopingEntity }
+
+{ #category : #'*Famix-Deprecated' }
+FAMIXScopingEntity >> allParentScopesDo: aBlock [
+	self parentScope ifNotNil: [ :ps | ps withAllParentScopesDo: aBlock ]
+]
+
+{ #category : #'*Famix-Deprecated' }
+FAMIXScopingEntity >> root [
+	^ self isRoot 
+		ifTrue: [ self ]
+		ifFalse: [ ^ self parentScope root ]
+]
+
+{ #category : #'*Famix-Deprecated' }
+FAMIXScopingEntity >> withAllChildScopes [
+	| result |
+	result := OrderedCollection new.
+	self withAllChildScopesDo: [ :each | result add: each].
+	^ result 
+]
+
+{ #category : #'*Famix-Deprecated' }
+FAMIXScopingEntity >> withAllChildScopesDo: aBlock [
+	aBlock value: self.
+	self allChildScopesDo: aBlock
+]

--- a/src/Famix-Deprecated/FamixTScopingEntity.extension.st
+++ b/src/Famix-Deprecated/FamixTScopingEntity.extension.st
@@ -1,0 +1,23 @@
+Extension { #name : #FamixTScopingEntity }
+
+{ #category : #'*Famix-Deprecated' }
+FamixTScopingEntity >> allParentScopesDo: aBlock [
+	self deprecated: 'This will be removed'.
+	self parentScope ifNotNil: [ :ps | ps withAllParentScopesDo: aBlock ]
+]
+
+{ #category : #'*Famix-Deprecated' }
+FamixTScopingEntity >> withAllParentScopes [
+	| result |
+	self deprecated: 'This will be removed'.
+	result := OrderedCollection new.
+	self withAllParentScopesDo: [ :each | result add: each].
+	^ result 
+]
+
+{ #category : #'*Famix-Deprecated' }
+FamixTScopingEntity >> withAllParentScopesDo: aBlock [
+	self deprecated: 'This will be removed'.
+	aBlock value: self.
+	self allParentScopesDo: aBlock
+]

--- a/src/Famix-MetamodelGeneration/FamixGenerator.class.st
+++ b/src/Famix-MetamodelGeneration/FamixGenerator.class.st
@@ -49,7 +49,6 @@ Class {
 		'tPreprocessorIfdef',
 		'tReference',
 		'tReferenceable',
-		'tScopingEntity',
 		'tSourceAnchor',
 		'tSourceEntity',
 		'tSourceLanguage',

--- a/src/Famix-Traits/FamixTNamespace.trait.st
+++ b/src/Famix-Traits/FamixTNamespace.trait.st
@@ -8,7 +8,6 @@ When an entity is placed inside a namespace, the fully qualified name (mooseName
 Trait {
 	#name : #FamixTNamespace,
 	#traits : '(FamixTNamedEntity + TOODependencyQueries withPrecedenceOf: TOODependencyQueries)',
-	#classTraits : '(FamixTNamedEntity classTrait + TOODependencyQueries classTrait withPrecedenceOf: TOODependencyQueries classTrait)',
 	#category : #'Famix-Traits-Named'
 }
 

--- a/src/Famix-Traits/FamixTScopingEntity.trait.st
+++ b/src/Famix-Traits/FamixTScopingEntity.trait.st
@@ -10,6 +10,7 @@ Trait {
 		'#parentScope => FMOne type: #FamixTScopingEntity opposite: #childScopes'
 	],
 	#traits : '(FamixTNamedEntity + TOODependencyQueries withPrecedenceOf: TOODependencyQueries)',
+	#classTraits : '(FamixTNamedEntity classTrait + TOODependencyQueries classTrait withPrecedenceOf: TOODependencyQueries classTrait)',
 	#category : #'Famix-Traits-ScopingEntity'
 }
 
@@ -45,11 +46,6 @@ FamixTScopingEntity >> allChildScopesDo: aBlock [
 FamixTScopingEntity >> allChildScopesGroup [
 	<navigation: 'All child scopes'>
 	^ FamixNamespaceGroup withAll: self allChildScopes withDescription: 'All child scopes from ', self printString
-]
-
-{ #category : #accessing }
-FamixTScopingEntity >> allParentScopesDo: aBlock [
-	self parentScope ifNotNil: [ :ps | ps withAllParentScopesDo: aBlock ]
 ]
 
 { #category : #accessing }
@@ -113,18 +109,4 @@ FamixTScopingEntity >> withAllChildScopes [
 FamixTScopingEntity >> withAllChildScopesDo: aBlock [
 	aBlock value: self.
 	self allChildScopesDo: aBlock
-]
-
-{ #category : #accessing }
-FamixTScopingEntity >> withAllParentScopes [
-	| result |
-	result := OrderedCollection new.
-	self withAllParentScopesDo: [ :each | result add: each].
-	^ result 
-]
-
-{ #category : #accessing }
-FamixTScopingEntity >> withAllParentScopesDo: aBlock [
-	aBlock value: self.
-	self allParentScopesDo: aBlock
 ]


### PR DESCRIPTION
remove-usage-of-scoping-entity-from-compatibility-MM

Since we plan to kill the trait scoping entity, we copied its content in the compatibility MM. 
We do not remove FAMIXScopingEntity entirely because this is the compatibility MM and it will be removed in the future.