### PR TITLE
Some properties of FAMIXBehaviouralEntity are not derived (but should be)

### DIFF
--- a/src/Famix-Compatibility-Entities/FAMIXBehaviouralEntity.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXBehaviouralEntity.class.st
@@ -25,6 +25,7 @@ FAMIXBehaviouralEntity >> clientBehaviours [
 { #category : #'Famix-Extensions' }
 FAMIXBehaviouralEntity >> cyclomaticComplexity [
 	<FMProperty: #cyclomaticComplexity type: #Number>
+	<derived>
 	<FMComment: 'The number of linear-independent paths through a method.'>
 	^ self
 		lookUpPropertyNamed: #cyclomaticComplexity
@@ -86,6 +87,7 @@ FAMIXBehaviouralEntity >> numberOfComments [
 { #category : #'Famix-Extensions' }
 FAMIXBehaviouralEntity >> numberOfConditionals [
 	<FMProperty: #numberOfConditionals type: #Number>
+	<derived>
 	<FMComment: 'The number of conditionals in a method'>
 	^ self
 		lookUpPropertyNamed: #numberOfConditionals
@@ -121,6 +123,7 @@ FAMIXBehaviouralEntity >> numberOfOutgoingInvocations [
 { #category : #'Famix-Extensions' }
 FAMIXBehaviouralEntity >> numberOfStatements [
 	<FMProperty: #numberOfStatements type: #Number>
+	<derived>
 	<FMComment: 'The number of statements in a method'>
 	^ self
 		lookUpPropertyNamed: #numberOfStatements
@@ -129,8 +132,9 @@ FAMIXBehaviouralEntity >> numberOfStatements [
 
 { #category : #'Famix-Extensions' }
 FAMIXBehaviouralEntity >> providerBehaviours [
-	<FMProperty: #providerBehaviours type: #FAMIXBehaviouralEntity> <derived> <multivalued>
+	<FMProperty: #providerBehaviours type: #FAMIXBehaviouralEntity>
+	<derived>
+	<multivalued>
 	<FMComment: 'All behaviours that the receiver depends on'>
-
-	^ self invokedBehaviours 
+	^ self invokedBehaviours
 ]

--- a/src/Famix-Compatibility-Entities/FAMIXBehaviouralEntity.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXBehaviouralEntity.class.st
@@ -25,7 +25,6 @@ FAMIXBehaviouralEntity >> clientBehaviours [
 { #category : #'Famix-Extensions' }
 FAMIXBehaviouralEntity >> cyclomaticComplexity [
 	<FMProperty: #cyclomaticComplexity type: #Number>
-	<derived>
 	<FMComment: 'The number of linear-independent paths through a method.'>
 	^ self
 		lookUpPropertyNamed: #cyclomaticComplexity


### PR DESCRIPTION
those properties should be derived:

- cyclomaticComplexity 
- numberOfConditionals 
- numberOfStatements 
- providerBehaviours 