### PR TITLE
19-Calling-ifEmpty-on-a-non-empty-MooseGroup-returns-an-OrderedCollection

### DIFF
--- a/src/Moose-Core-Tests/MooseAbstractGroupTest.class.st
+++ b/src/Moose-Core-Tests/MooseAbstractGroupTest.class.st
@@ -303,6 +303,13 @@ MooseAbstractGroupTest >> testGroupedBy [
 ]
 
 { #category : #tests }
+MooseAbstractGroupTest >> testIfEmpty [
+	self assert: (group ifEmpty: [ true ]).
+	group add: MooseEntity new.
+	self assert: (group ifEmpty: [  ]) identicalTo: group
+]
+
+{ #category : #tests }
 MooseAbstractGroupTest >> testIndexOf [
 	| el1 el2 el3 |
 	group add: (el1 := MooseEntity new).

--- a/src/Moose-Core/MooseAbstractGroup.class.st
+++ b/src/Moose-Core/MooseAbstractGroup.class.st
@@ -429,9 +429,9 @@ MooseAbstractGroup >> groupedBy: aBlock [
 
 { #category : #testing }
 MooseAbstractGroup >> ifEmpty: emptyBlock [
-	self isEmpty
-		ifTrue: [ ^ emptyBlock value ]
-		ifFalse: [ ^ self ]
+	^ self isEmpty
+		ifTrue: [ emptyBlock value ]
+		ifFalse: [ self ]
 ]
 
 { #category : #testing }

--- a/src/Moose-Core/MooseAbstractGroup.class.st
+++ b/src/Moose-Core/MooseAbstractGroup.class.st
@@ -428,6 +428,13 @@ MooseAbstractGroup >> groupedBy: aBlock [
 ]
 
 { #category : #testing }
+MooseAbstractGroup >> ifEmpty: emptyBlock [
+	self isEmpty
+		ifTrue: [ ^ emptyBlock value ]
+		ifFalse: [ ^ self ]
+]
+
+{ #category : #testing }
 MooseAbstractGroup >> ifEmpty: emptyBlock ifNotEmpty: notEmptyBlock [
 	self ifEmpty: [ ^ emptyBlock value ].
 	^ notEmptyBlock cull: self


### PR DESCRIPTION
Adding an #ifEmpty: method to MooseAbstractGroupFix #19