### PR TITLE
speed-up-withoutSelfLoop

### DIFF
--- a/src/Moose-Query-Test/MooseObjectQueryResultTest.class.st
+++ b/src/Moose-Query-Test/MooseObjectQueryResultTest.class.st
@@ -23,7 +23,7 @@ MooseObjectQueryResultTest >> testWithoutSelfLoops [
 		yourself.
 	namespace2 := (FamixJavaNamespace named: 'namespace2')
 		mooseModel: model;
-		parentScope: namespace1;
+		parentNamespace: namespace1;
 		yourself.
 	class1 := (FamixJavaClass named: 'class1')
 		mooseModel: model;

--- a/src/Moose-Query-Test/MooseOutgoingQueryResultTest.class.st
+++ b/src/Moose-Query-Test/MooseOutgoingQueryResultTest.class.st
@@ -23,7 +23,7 @@ MooseOutgoingQueryResultTest >> testWithoutSelfLoops [
 		yourself.
 	namespace2 := (FamixJavaNamespace named: 'namespace2')
 		mooseModel: model;
-		parentScope: namespace1;
+		parentNamespace: namespace1;
 		yourself.
 	class1 := (FamixJavaClass named: 'class1')
 		mooseModel: model;

--- a/src/Moose-Query/MooseObjectQueryResult.class.st
+++ b/src/Moose-Query/MooseObjectQueryResult.class.st
@@ -90,5 +90,5 @@ MooseObjectQueryResult >> within: aFAMIXEntity [
 MooseObjectQueryResult >> withoutSelfLoops [
 	"exclude objects that match the receiver (modulo the scope)"
 
-	^ self reject: [ :obj | obj withAllParents includes: self receiver ]
+	^ self reject: [ :obj | obj isIncludedIn: self receiver ]
 ]

--- a/src/Moose-Query/TDependencyQueryResult.trait.st
+++ b/src/Moose-Query/TDependencyQueryResult.trait.st
@@ -156,5 +156,5 @@ TDependencyQueryResult >> within: aFamixEntity [
 TDependencyQueryResult >> withoutSelfLoops [
 	"exclude dependencies which loop back to the receiver"
 
-	^ self reject: [ :dep | (self opposite: dep) asCollection anySatisfy: [ :opp | opp withAllParents includes: self receiver ] ]
+	^ self reject: [ :dep | (self opposite: dep) asCollection anySatisfy: [ :opp | opp isIncludedIn: self receiver ] ]
 ]

--- a/src/Moose-Query/TEntityMetaLevelDependency.trait.st
+++ b/src/Moose-Query/TEntityMetaLevelDependency.trait.st
@@ -576,6 +576,15 @@ TEntityMetaLevelDependency >> incomingMSEProperties [
 	^ self class incomingMSEPropertiesIn: self metamodel
 ]
 
+{ #category : #testing }
+TEntityMetaLevelDependency >> isIncludedIn: anEntity [
+	self = anEntity ifTrue: [ ^ true ].
+
+	self parentsDo: [ :parent | (parent isIncludedIn: anEntity) ifTrue: [ ^ true ] ].
+
+	^ false
+]
+
 { #category : #accessing }
 TEntityMetaLevelDependency >> numberOfChildren [
 	<FMProperty: #numberOfChildren type: #Number>


### PR DESCRIPTION
Speed up #withoutSelfLoo[
	
Instead of collecting all the parents to find if it is the requested entity, we stop as soon as a parent matches.