### PR TITLE
add-a-menu-item-to-reset-additional-properties

### DIFF
--- a/src/Famix-MetamodelBuilder-Core/FamixMetamodelGenerator.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FamixMetamodelGenerator.class.st
@@ -115,8 +115,7 @@ FamixMetamodelGenerator class >> menuCommandOn: aBuilder [
 	(aBuilder item: #'Reset metamodels')
 		order: 45;
 		parent: #Moose;
-		action: [ self resetMetamodels ];
-		withSeparatorAfter
+		action: [ self resetMetamodels ]
 ]
 
 { #category : #generation }
@@ -159,7 +158,7 @@ FamixMetamodelGenerator class >> prefix [
 { #category : #accessing }
 FamixMetamodelGenerator class >> resetMetamodels [
 	<script>
-	MooseModel allSubclassesDo: #resetMetamodel
+	MooseModel resetMetamodels
 ]
 
 { #category : #testing }

--- a/src/Moose-Core/MooseModel.class.st
+++ b/src/Moose-Core/MooseModel.class.st
@@ -184,9 +184,13 @@ MooseModel class >> importMetamodelFrom: aStream [
 MooseModel class >> menuCommandOn: aBuilder [
 	<worldMenu>
 	(aBuilder item: #Moose)
-		order: 6.0; 
+		order: 6.0;
 		withSeparatorAfter;
-		icon: MooseIcons mooseIcon
+		icon: MooseIcons mooseIcon;
+		with: [ (aBuilder item: #'Reset metamodels additional properties')
+				order: 50;
+				action: [ self resetMetamodelsAdditionalProperties ];
+				withSeparatorAfter ]
 ]
 
 { #category : #meta }
@@ -245,6 +249,12 @@ MooseModel class >> resetMetamodel [
 MooseModel class >> resetMetamodels [
 	<script>
 	self allSubclassesDo: #resetMetamodel
+]
+
+{ #category : #accessing }
+MooseModel class >> resetMetamodelsAdditionalProperties [
+	<script>
+	self allSubclassesDo: [ :each | each metamodel cleanAdditionalProperties ]
 ]
 
 { #category : #'root model' }


### PR DESCRIPTION
Add a menu item to reset additional MM properties

+ Remove duplication for resetMetamodels