### PR TITLE
finish-tests-packages-renaming

### DIFF
--- a/src/BaselineOfFamix/BaselineOfFamix.class.st
+++ b/src/BaselineOfFamix/BaselineOfFamix.class.st
@@ -51,7 +51,7 @@ BaselineOfFamix >> baseline: spec [
 				package: 'Famix-Compatibility-Generator' with: [ spec requires: #('Basic') ];
 				package: 'Famix-Compatibility-Entities' with: [ spec requires: #('BasicTraits' 'Famix-Smalltalk-Utils') ];
 				package: 'Famix-Compatibility-Tests-C' with: [ spec requires: #('Famix-Compatibility-Entities') ];
-				package: 'Famix-Compatibility-Tests-Core' with: [ spec requires: #('Famix-Compatibility-Entities' 'Moose-Tests-SmalltalkImporter-LAN' 'Moose-SmalltalkImporter-KGB-Tests') ];
+				package: 'Famix-Compatibility-Tests-Core' with: [ spec requires: #('Famix-Compatibility-Entities' 'Moose-SmalltalkImporter-LAN-Tests' 'Moose-SmalltalkImporter-KGB-Tests') ];
 				package: 'Famix-VerveineJ-Tests' with: [ spec requires: #('Moose-Core-Tests' 'Famix-Compatibility-Entities') ];
 
 				package: 'Famix-PharoSmalltalk-Generator' with: [ spec requires: #('Basic') ];
@@ -73,7 +73,7 @@ BaselineOfFamix >> baseline: spec [
 				
 				package: 'Famix-Smalltalk-Utils-Tests' with: [ spec requires: #('Famix-Smalltalk-Utils' 'ReferenceTestResources') ];
 				package: 'Moose-SmalltalkImporter-Core-Tests' with: [ spec requires: #('Moose-Core-Tests' 'Moose-SmalltalkImporter' 'ReferenceTestResources') ];
-				package: 'Moose-Tests-SmalltalkImporter-LAN' with: [ spec requires: #('Moose-SmalltalkImporter-Core-Tests' 'Moose-TestResources-LAN') ];
+				package: 'Moose-SmalltalkImporter-LAN-Tests' with: [ spec requires: #('Moose-SmalltalkImporter-Core-Tests' 'Moose-TestResources-LAN') ];
 				package: 'Moose-SmalltalkImporter-KGB-Tests' with: [ spec requires: #('KGBTestResources' 'Moose-SmalltalkImporter-Core-Tests') ];
 
 				package: 'Famix-TestGenerators' with: [ spec requires: #('Basic') ];
@@ -116,7 +116,7 @@ BaselineOfFamix >> baseline: spec [
 				group: 'TestModels' with: #('Famix-Test1-Entities' 'Famix-Test2-Entities' 'Famix-Test3-Entities' 'Famix-Test4-Entities');
 				group: 'Tests' with: #(
 								'Famix-Tests' 'Moose-Query-Test' 'Moose-Core-Tests' 'Famix-Smalltalk-Utils-Tests'
-								'Moose-Tests-SmalltalkImporter-LAN' 'Moose-SmalltalkImporter-Core-Tests' 'Moose-SmalltalkImporter-KGB-Tests'
+								'Moose-SmalltalkImporter-LAN-Tests' 'Moose-SmalltalkImporter-Core-Tests' 'Moose-SmalltalkImporter-KGB-Tests'
 								'Famix-Java-Tests' 'Famix-Compatibility-Tests-C' 'Famix-VerveineJ-Tests'
 								'Famix-Compatibility-Tests-Core' 'Famix-PharoSmalltalk-Tests' 'Famix-TestGenerators'
 								'Famix-MetamodelBuilder-Tests' 'Famix-Test1-Tests' 'Famix-Test2-Tests' 'Famix-Test3-Tests'

--- a/src/Famix-Traits/FamixTAssociation.trait.st
+++ b/src/Famix-Traits/FamixTAssociation.trait.st
@@ -24,7 +24,6 @@ Trait {
 		'#previous => FMOne type: #FamixTAssociation opposite: #next'
 	],
 	#traits : 'FamixTSourceEntity + TAssociationMetaLevelDependency',
-	#classTraits : 'FamixTSourceEntity classTrait + TAssociationMetaLevelDependency classTrait',
 	#category : #'Famix-Traits-Association'
 }
 

--- a/src/Moose-SmalltalkImporter-LAN-Tests/FAMIXStepwiseImporterTest.class.st
+++ b/src/Moose-SmalltalkImporter-LAN-Tests/FAMIXStepwiseImporterTest.class.st
@@ -4,7 +4,7 @@ Class {
 	#classInstVars : [
 		'aVariable'
 	],
-	#category : #'Moose-Tests-SmalltalkImporter-LAN'
+	#category : #'Moose-SmalltalkImporter-LAN-Tests'
 }
 
 { #category : #accessing }

--- a/src/Moose-SmalltalkImporter-LAN-Tests/FamixInvocationsTest.class.st
+++ b/src/Moose-SmalltalkImporter-LAN-Tests/FamixInvocationsTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #FamixInvocationsTest,
 	#superclass : #LANAbstractImportTest,
-	#category : #'Moose-Tests-SmalltalkImporter-LAN'
+	#category : #'Moose-SmalltalkImporter-LAN-Tests'
 }
 
 { #category : #model }

--- a/src/Moose-SmalltalkImporter-LAN-Tests/FamixModelExtractionTest.class.st
+++ b/src/Moose-SmalltalkImporter-LAN-Tests/FamixModelExtractionTest.class.st
@@ -22,7 +22,7 @@ Class {
 		'msePrinterClass',
 		'nextNodeMethod'
 	],
-	#category : #'Moose-Tests-SmalltalkImporter-LAN'
+	#category : #'Moose-SmalltalkImporter-LAN-Tests'
 }
 
 { #category : #auxiliary }

--- a/src/Moose-SmalltalkImporter-LAN-Tests/FamixPropertiesTest.class.st
+++ b/src/Moose-SmalltalkImporter-LAN-Tests/FamixPropertiesTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #FamixPropertiesTest,
 	#superclass : #LANAbstractImportTest,
-	#category : #'Moose-Tests-SmalltalkImporter-LAN'
+	#category : #'Moose-SmalltalkImporter-LAN-Tests'
 }
 
 { #category : #testing }

--- a/src/Moose-SmalltalkImporter-LAN-Tests/ImportStubMethodSpecialTest.class.st
+++ b/src/Moose-SmalltalkImporter-LAN-Tests/ImportStubMethodSpecialTest.class.st
@@ -7,7 +7,7 @@ Class {
 	#instVars : [
 		'model'
 	],
-	#category : #'Moose-Tests-SmalltalkImporter-LAN'
+	#category : #'Moose-SmalltalkImporter-LAN-Tests'
 }
 
 { #category : #running }

--- a/src/Moose-SmalltalkImporter-LAN-Tests/LANAbstractImportTest.class.st
+++ b/src/Moose-SmalltalkImporter-LAN-Tests/LANAbstractImportTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #LANAbstractImportTest,
 	#superclass : #TestCase,
-	#category : #'Moose-Tests-SmalltalkImporter-LAN'
+	#category : #'Moose-SmalltalkImporter-LAN-Tests'
 }
 
 { #category : #resources }

--- a/src/Moose-SmalltalkImporter-LAN-Tests/LANImporterTest.class.st
+++ b/src/Moose-SmalltalkImporter-LAN-Tests/LANImporterTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #LANImporterTest,
 	#superclass : #LANAbstractImportTest,
-	#category : #'Moose-Tests-SmalltalkImporter-LAN'
+	#category : #'Moose-SmalltalkImporter-LAN-Tests'
 }
 
 { #category : #tests }

--- a/src/Moose-SmalltalkImporter-LAN-Tests/LANMooseGroupTest.class.st
+++ b/src/Moose-SmalltalkImporter-LAN-Tests/LANMooseGroupTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #LANMooseGroupTest,
 	#superclass : #TestCase,
-	#category : #'Moose-Tests-SmalltalkImporter-LAN'
+	#category : #'Moose-SmalltalkImporter-LAN-Tests'
 }
 
 { #category : #utilities }

--- a/src/Moose-SmalltalkImporter-LAN-Tests/LANMooseModelTest.class.st
+++ b/src/Moose-SmalltalkImporter-LAN-Tests/LANMooseModelTest.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'model'
 	],
-	#category : #'Moose-Tests-SmalltalkImporter-LAN'
+	#category : #'Moose-SmalltalkImporter-LAN-Tests'
 }
 
 { #category : #util }

--- a/src/Moose-SmalltalkImporter-LAN-Tests/LANPackageTestResource.class.st
+++ b/src/Moose-SmalltalkImporter-LAN-Tests/LANPackageTestResource.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #LANPackageTestResource,
 	#superclass : #SmalltalkModelTestResource,
-	#category : #'Moose-Tests-SmalltalkImporter-LAN'
+	#category : #'Moose-SmalltalkImporter-LAN-Tests'
 }
 
 { #category : #hook }

--- a/src/Moose-SmalltalkImporter-LAN-Tests/LANSmalltalkAccessTest.class.st
+++ b/src/Moose-SmalltalkImporter-LAN-Tests/LANSmalltalkAccessTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #LANSmalltalkAccessTest,
 	#superclass : #TestCase,
-	#category : #'Moose-Tests-SmalltalkImporter-LAN'
+	#category : #'Moose-SmalltalkImporter-LAN-Tests'
 }
 
 { #category : #tests }

--- a/src/Moose-SmalltalkImporter-LAN-Tests/MooseMorphicTestResource.class.st
+++ b/src/Moose-SmalltalkImporter-LAN-Tests/MooseMorphicTestResource.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #MooseMorphicTestResource,
 	#superclass : #SmalltalkModelTestResource,
-	#category : #'Moose-Tests-SmalltalkImporter-LAN'
+	#category : #'Moose-SmalltalkImporter-LAN-Tests'
 }
 
 { #category : #setup }

--- a/src/Moose-SmalltalkImporter-LAN-Tests/MooseSqueakClassPackageImporterTest.class.st
+++ b/src/Moose-SmalltalkImporter-LAN-Tests/MooseSqueakClassPackageImporterTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #MooseSqueakClassPackageImporterTest,
 	#superclass : #TestCase,
-	#category : #'Moose-Tests-SmalltalkImporter-LAN'
+	#category : #'Moose-SmalltalkImporter-LAN-Tests'
 }
 
 { #category : #'testing collecting classes' }

--- a/src/Moose-SmalltalkImporter-LAN-Tests/package.st
+++ b/src/Moose-SmalltalkImporter-LAN-Tests/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'Moose-SmalltalkImporter-LAN-Tests' }

--- a/src/Moose-Tests-SmalltalkImporter-LAN/package.st
+++ b/src/Moose-Tests-SmalltalkImporter-LAN/package.st
@@ -1,1 +1,0 @@
-Package { #name : #'Moose-Tests-SmalltalkImporter-LAN' }


### PR DESCRIPTION
Finish tests packages renaming.

Moose-Tests-SmalltalkImporter-LAN => Moose-SmalltalkImporter-LAN-Tests

Fixes https://github.com/moosetechnology/Moose/issues/1876