### PR TITLE
move-cyclomatic-complexity-property-on-TWithStatements

### DIFF
--- a/src/Famix-Compatibility-Entities/FAMIXBehaviouralEntity.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXBehaviouralEntity.class.st
@@ -23,12 +23,10 @@ FAMIXBehaviouralEntity >> clientBehaviours [
 ]
 
 { #category : #'Famix-Extensions' }
-FAMIXBehaviouralEntity >> cyclomaticComplexity [
-	<FMProperty: #cyclomaticComplexity type: #Number>
-	<FMComment: 'The number of linear-independent paths through a method.'>
-	^ self
-		lookUpPropertyNamed: #cyclomaticComplexity
-		computedAs: [ self mooseModel isSmalltalk ifTrue: [ (RBVisitorForFAMIXMetrics for: self) cyclomaticNumber ] ifFalse: [ self notExistentMetricValue ] ]
+FAMIXBehaviouralEntity >> computeCyclomaticComplexity [
+	^ self mooseModel isSmalltalk
+		ifTrue: [ (RBVisitorForFAMIXMetrics for: self) cyclomaticNumber ]
+		ifFalse: [ self notExistentMetricValue ]
 ]
 
 { #category : #'Famix-Extensions' }

--- a/src/Famix-PharoSmalltalk-Entities/FamixStMethod.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStMethod.class.st
@@ -45,10 +45,8 @@ FamixStMethod >> compiledMethod [
 ]
 
 { #category : #'Famix-Extensions-private' }
-FamixStMethod >> cyclomaticComplexity [
-	<FMProperty: #cyclomaticComplexity type: #Number>
-	<FMComment: 'The number of linear-independent paths through a method.'>
-	^ self lookUpPropertyNamed: #cyclomaticComplexity computedAs: [ (RBVisitorForFAMIXMetrics for: self) cyclomaticNumber ]
+FamixStMethod >> computeCyclomaticComplexity [
+	^ (RBVisitorForFAMIXMetrics for: self) cyclomaticNumber
 ]
 
 { #category : #'Famix-Extensions-private' }

--- a/src/Famix-Traits/FamixTMethod.trait.st
+++ b/src/Famix-Traits/FamixTMethod.trait.st
@@ -12,6 +12,7 @@ Trait {
 		'#parentType => FMOne type: #FamixTWithMethods opposite: #methods'
 	],
 	#traits : '(FamixTHasSignature + FamixTInvocable + FamixTNamedEntity + FamixTTypedEntity + FamixTWithClassScope + FamixTWithImplicitVariables + FamixTWithLocalVariables + FamixTWithParameters + FamixTWithReferences + FamixTWithStatements + TOODependencyQueries withPrecedenceOf: FamixTWithStatements)',
+	#classTraits : '(FamixTHasSignature classTrait + FamixTInvocable classTrait + FamixTNamedEntity classTrait + FamixTTypedEntity classTrait + FamixTWithClassScope classTrait + FamixTWithImplicitVariables classTrait + FamixTWithLocalVariables classTrait + FamixTWithParameters classTrait + FamixTWithReferences classTrait + FamixTWithStatements classTrait + TOODependencyQueries classTrait withPrecedenceOf: FamixTWithStatements classTrait)',
 	#category : #'Famix-Traits-Behavioral'
 }
 
@@ -29,20 +30,6 @@ FamixTMethod classSide >> annotationFamixMethodGroup [
 	<generated>
 	<mooseGroup>
 	^ FamixMethodGroup
-]
-
-{ #category : #metrics }
-FamixTMethod >> cyclomaticComplexity [
-	<FMProperty: #cyclomaticComplexity type: #Number>
-	<FMComment: 'The number of linear-independent paths through a method.'>
-	^ self
-		lookUpPropertyNamed:  #cyclomaticComplexity
-		computedAs: [ self notExistentMetricValue ]
-]
-
-{ #category : #metrics }
-FamixTMethod >> cyclomaticComplexity: aNumber [
-	self privateState cacheAt: #cyclomaticComplexity put: aNumber
 ]
 
 { #category : #metrics }

--- a/src/Famix-Traits/FamixTType.trait.st
+++ b/src/Famix-Traits/FamixTType.trait.st
@@ -12,7 +12,6 @@ Trait {
 		'#typedEntities => FMMany type: #FamixTTypedEntity opposite: #declaredType'
 	],
 	#traits : 'FamixTNamedEntity + FamixTReferenceable',
-	#classTraits : 'FamixTNamedEntity classTrait + FamixTReferenceable classTrait',
 	#category : #'Famix-Traits-Type'
 }
 

--- a/src/Famix-Traits/FamixTWithStatements.trait.st
+++ b/src/Famix-Traits/FamixTWithStatements.trait.st
@@ -1,6 +1,7 @@
 Trait {
 	#name : #FamixTWithStatements,
 	#traits : 'FamixTSourceEntity + FamixTWithAccesses + FamixTWithInvocations',
+	#classTraits : 'FamixTSourceEntity classTrait + FamixTWithAccesses classTrait + FamixTWithInvocations classTrait',
 	#category : #'Famix-Traits-Behavioral'
 }
 
@@ -11,6 +12,23 @@ FamixTWithStatements classSide >> annotation [
 	<package: #'Famix-Traits'>
 	<generated>
 	^self
+]
+
+{ #category : #metrics }
+FamixTWithStatements >> computeCyclomaticComplexity [
+	^ self notExistentMetricValue
+]
+
+{ #category : #metrics }
+FamixTWithStatements >> cyclomaticComplexity [
+	<FMProperty: #cyclomaticComplexity type: #Number>
+	<FMComment: 'The number of linear-independent paths through a method.'>
+	^ self lookUpPropertyNamed: #cyclomaticComplexity computedAs: [ self computeCyclomaticComplexity ]
+]
+
+{ #category : #metrics }
+FamixTWithStatements >> cyclomaticComplexity: aNumber [
+	self privateState cacheAt: #cyclomaticComplexity put: aNumber
 ]
 
 { #category : #testing }


### PR DESCRIPTION
Move cyclomatic complexity property from TMethod to TWithStatements. 

For example, TFunction should also have a cyclomatic complexity.
I also remove a little duplication.