### PR TITLE
fix-wrong-return-type-of-objects-results

### DIFF
--- a/src/Moose-Core/MQNavigationIncomingDirectionStrategy.extension.st
+++ b/src/Moose-Core/MQNavigationIncomingDirectionStrategy.extension.st
@@ -7,5 +7,5 @@ MQNavigationIncomingDirectionStrategy class >> dependenciesAtReceiverScopeOf: an
 
 { #category : #'*Moose-Core' }
 MQNavigationIncomingDirectionStrategy class >> dependenciesOf: aMooseEntity [
-	^ aMooseEntity query incoming dependencies
+	^ aMooseEntity query incoming objects dependencies
 ]

--- a/src/Moose-Core/MQNavigationOutgoingDirectionStrategy.extension.st
+++ b/src/Moose-Core/MQNavigationOutgoingDirectionStrategy.extension.st
@@ -7,5 +7,5 @@ MQNavigationOutgoingDirectionStrategy class >> dependenciesAtReceiverScopeOf: an
 
 { #category : #'*Moose-Core' }
 MQNavigationOutgoingDirectionStrategy class >> dependenciesOf: aMooseEntity [
-	^ aMooseEntity query outgoing dependencies
+	^ aMooseEntity query outgoing objects dependencies
 ]

--- a/src/Moose-Query-Test/MooseQueryMockSpecializedInvocation.class.st
+++ b/src/Moose-Query-Test/MooseQueryMockSpecializedInvocation.class.st
@@ -6,6 +6,6 @@ A Mock invocation for MooseQuery's tests
 "
 Class {
 	#name : #MooseQueryMockSpecializedInvocation,
-	#superclass : #FAMIXInvocation,
+	#superclass : #FamixJavaInvocation,
 	#category : #'Moose-Query-Test'
 }

--- a/src/Moose-Query-Test/MooseQueryTest.class.st
+++ b/src/Moose-Query-Test/MooseQueryTest.class.st
@@ -508,6 +508,11 @@ MooseQueryTest >> testIncomingInvocationAtScope [
 ]
 
 { #category : #tests }
+MooseQueryTest >> testObjectsQueryResultsKind [
+	self assert: (method2 query incoming objects dependencies isKindOf: MooseObjectQueryResult)
+]
+
+{ #category : #tests }
 MooseQueryTest >> testOutgoingAccessAtScope [
 	self assert: ((method1 queryOutgoing: FamixTAccess) atScope: FamixJavaPackage) size equals: 1.
 	self

--- a/src/Moose-Query/MQNavigationAssociationKindStrategy.class.st
+++ b/src/Moose-Query/MQNavigationAssociationKindStrategy.class.st
@@ -14,3 +14,8 @@ Class {
 MQNavigationAssociationKindStrategy class >> collectResultFrom: aCollection query: aQuery [
 	^ aCollection
 ]
+
+{ #category : #running }
+MQNavigationAssociationKindStrategy class >> queryResultKindFor: aQuery [
+	^ aQuery directionStrategy queryResultClass
+]

--- a/src/Moose-Query/MQNavigationHasDependencyBooleanKindStrategy.class.st
+++ b/src/Moose-Query/MQNavigationHasDependencyBooleanKindStrategy.class.st
@@ -19,3 +19,8 @@ MQNavigationHasDependencyBooleanKindStrategy class >> collectResultFrom: aCollec
 MQNavigationHasDependencyBooleanKindStrategy class >> execute: aQuery [
 	^ aQuery executeHasQuery
 ]
+
+{ #category : #running }
+MQNavigationHasDependencyBooleanKindStrategy class >> queryResultKindFor: aQuery [
+	^ self shouldNotImplement
+]

--- a/src/Moose-Query/MQNavigationOppositeKindStrategy.class.st
+++ b/src/Moose-Query/MQNavigationOppositeKindStrategy.class.st
@@ -14,3 +14,8 @@ Class {
 MQNavigationOppositeKindStrategy class >> collectResultFrom: aCollection query: aQuery [
 	^ aCollection collect: [ :each | aQuery directionStrategy entityFor: each ]
 ]
+
+{ #category : #running }
+MQNavigationOppositeKindStrategy class >> queryResultKindFor: aQuery [
+	^ MooseObjectQueryResult
+]

--- a/src/Moose-Query/MQNavigationQuery.class.st
+++ b/src/Moose-Query/MQNavigationQuery.class.st
@@ -102,8 +102,8 @@ MQNavigationQuery >> executeHasQuery [
 ]
 
 { #category : #execution }
-MQNavigationQuery >> executeQuery [
-	result := directionStrategy queryResultClass on: receiver.
+MQNavigationQuery >> executeQueryForQueryResult: aQueryResultClass [
+	result := aQueryResultClass on: receiver.
 
 	self queryFor: receiver.
 

--- a/src/Moose-Query/MQNavigationResultKindStrategy.class.st
+++ b/src/Moose-Query/MQNavigationResultKindStrategy.class.st
@@ -25,12 +25,17 @@ MQNavigationResultKindStrategy class >> collectResultFrom: aCollection query: aQ
 
 { #category : #running }
 MQNavigationResultKindStrategy class >> execute: aQuery [
-	^ aQuery executeQuery
+	^ aQuery executeQueryForQueryResult: (self queryResultKindFor: aQuery)
 ]
 
 { #category : #testing }
 MQNavigationResultKindStrategy class >> isAbstract [
 	^ self = MQNavigationResultKindStrategy
+]
+
+{ #category : #running }
+MQNavigationResultKindStrategy class >> queryResultKindFor: aQuery [
+	^ self subclassResponsibility
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
Fix bug where moose query was returning the wrong kind of result

Objects queries were returning a MooseIncomingQueryResult or a MooseOutgoingQueryResult when it should return a MooseObjectQueryResult.