### PR TITLE
dependnecy-finder-should-stop-at-first-parent-found

### DIFF
--- a/src/Famix-Test3-Tests/FamixDependencyDetectorTest.class.st
+++ b/src/Famix-Test3-Tests/FamixDependencyDetectorTest.class.st
@@ -93,6 +93,13 @@ FamixDependencyDetectorTest >> testClientsMethodFromClasses [
 	self assertCollection: (self m2 allClientsIn: model allModelClasses) hasSameElements: { self c1 }
 ]
 
+{ #category : #'tests-clients' }
+FamixDependencyDetectorTest >> testDependenciesStopAtFirstParent [
+	"The dependency finder should stop at the first found parent and not go all the way up in the containment tree if it is found."
+
+	self assertCollection: (self m2 allClientsIn: {self c1 . self p1}) hasSameElements: {self c1}
+]
+
 { #category : #'tests-providers' }
 FamixDependencyDetectorTest >> testProviderClassesToMethods [
 	self assertCollection: (self c1 allProvidersIn: model allModelMethods) hasSameElements: { self m2 }

--- a/src/Moose-Core/FamixDependenciesDetector.class.st
+++ b/src/Moose-Core/FamixDependenciesDetector.class.st
@@ -62,11 +62,16 @@ FamixDependenciesDetector >> detectDependencies [
 
 { #category : #'links-computation' }
 FamixDependenciesDetector >> detectDependenciesAtAllScopesOfPossibleDependencies [
-	"this method computes dependencies at all possible scopes for a give moose group. For FAMIX entities, it collects the dependencies of the recevier at all the scopes of entities in the group. Tags contain themselves recursively, hence we need to see if the any one has an incoming connection from the current entity"
+	"Here we compute the dependencies of an entity and we try to find in the list of possible dependencies the closest fitting for the ones we found. 
+	
+	In order to do that, we iterate over all found dependencies and, starting from the dependency found, we check go up in the containment tree until we find an entity present in the list of potential dependencies.
+	
+	Then we add to the list of dependencies those we found."
 
-	| dependenciesAssociations |
-	dependenciesAssociations := self directionStrategy dependenciesOf: self entity.
-	self selectMatchingEntitiesFrom: ((potentialDependencies collectAsSet: #class) flatCollect: [ :aScope | dependenciesAssociations atScope: aScope ])
+	((self directionStrategy dependenciesOf: self entity) flatCollect: #asCollection)
+		do: [ :dep | 
+			self
+				selectMatchingEntitiesFrom: (dep query ancestors recursively until: [ :e | (potentialDependencies includes: e) or: [ dependencies includes: e ] ]) ofAnyType ]
 ]
 
 { #category : #'links-computation' }


### PR DESCRIPTION
Fix bug in dependency finder where it matched too many entities.

The dependency finder was matching all potential dependencies who where parent of a dependent entity. But this is not what we want. We want to stop at the first ancestor present in the list of dependencies.