### PR TITLE
speed-up-creation-of-moose-groups

### DIFF
--- a/src/Moose-Core/MooseObject.class.st
+++ b/src/Moose-Core/MooseObject.class.st
@@ -44,7 +44,8 @@ Class {
 	#superclass : #Object,
 	#instVars : [
 		'state',
-		'mooseID'
+		'mooseID',
+		'mooseName'
 	],
 	#classVars : [
 		'DefaultState',
@@ -339,12 +340,11 @@ MooseObject >> mooseName [
 			stream := (String new: 64) writeStream.
 			self mooseNameOn: stream.
 			^ stream contents asSymbol ].
-	^ self privateState
-		cacheAt: #mooseName
-		ifAbsentPut: [ | stream |
+	^ mooseName
+		ifNil: [ | stream |
 			stream := (String new: 64) writeStream.
 			self mooseNameOn: stream.
-			stream contents asSymbol ]
+			mooseName := stream contents asSymbol ]
 ]
 
 { #category : #printing }
@@ -392,7 +392,7 @@ MooseObject >> printOn: aStream [
 MooseObject >> privateClearMooseName [
 	" this method causes the cache to fail if called directly. Use resetMooseName instead. "
 
-	self privateState removeCache: #mooseName
+	mooseName := nil
 ]
 
 { #category : #private }


### PR DESCRIPTION
Speed up creation of moose groups.

MooseGroup are long to create because they do a lot of accesses to caches to build a MooseName. 
Now the moose name is stored in a variable since it is something that will always be filled in MooseEntities. 

With this, the creation of a moose group of 411279 entities passed from 2.6sec to 0.4sec.