### PR TITLE
further-speedup-of-moose-group-creation

### DIFF
--- a/src/Moose-Core/Dictionary.extension.st
+++ b/src/Moose-Core/Dictionary.extension.st
@@ -1,0 +1,10 @@
+Extension { #name : #Dictionary }
+
+{ #category : #'*Moose-Core' }
+Dictionary >> atOrOrederedCollection: key [
+	"I exist only for performance reasons. I avoid to create a #ifAbsent: block. In moose we call this so much that the creation cost of the block and its garbage collection is too high :("
+
+	^ ((array at: (self findElementOrNil: key))
+		ifNil: [ self at: key put: OrderedCollection new ]
+		ifNotNil: [ :assoc | assoc ]) value
+]

--- a/src/Moose-Core/MooseGroupRuntimeStorage.class.st
+++ b/src/Moose-Core/MooseGroupRuntimeStorage.class.st
@@ -36,11 +36,6 @@ Class {
 	#category : #'Moose-Core'
 }
 
-{ #category : #'as yet unclassified' }
-MooseGroupRuntimeStorage class >> byTypeDefaultCollection [
-	^ OrderedCollection new
-]
-
 { #category : #adding }
 MooseGroupRuntimeStorage >> add: anElement [ 
 	self privateAdd: anElement.
@@ -121,7 +116,7 @@ MooseGroupRuntimeStorage >> selectAllWithType: aSmalltalkType [
 			byType keys
 				select: [ :aClass | aClass class = aSmalltalkType ]
 				thenDo: [ :aKey | (byType at: aKey) do: [ :anElement | result add: anElement ] ].
-			self class byTypeDefaultCollection addAll: result ]
+			OrderedCollection withAll: result ]
 ]
 
 { #category : #accessing }
@@ -131,26 +126,23 @@ MooseGroupRuntimeStorage >> size [
 
 { #category : #private }
 MooseGroupRuntimeStorage >> updateCacheOnAddingOf: anElement [
-	| group |
-	group := byType at: anElement class ifAbsentPut: [ self class byTypeDefaultCollection ].
-	group add: anElement.
-	anElement hasUniqueMooseNameInModel ifTrue: [ byName at: anElement mooseName asSymbol put: anElement ].
+	(byType atOrOrederedCollection: anElement class) add: anElement.
+	anElement hasUniqueMooseNameInModel ifTrue: [ byName at: anElement mooseName put: anElement ].
 	^ anElement
 ]
 
 { #category : #private }
 MooseGroupRuntimeStorage >> updateCacheOnRemovalOf: anElement [
-    | key group |
-    key := anElement class.
-    group := byType at: key ifAbsent: [ self class byTypeDefaultCollection ].
-    group remove: anElement ifAbsent: [ self error: 'Internal storage inconsistency' ].
-    anElement hasUniqueMooseNameInModel ifFalse: [ ^anElement ].
-    key := anElement mooseName asSymbol.
-    byName at: key ifAbsent: 
-            [ "In theory, objects are registered under their mooseName,
+	byType at: anElement class ifPresent: [ :group |
+		group remove: anElement ifAbsent: [ self error: 'Internal storage inconsistency' ] ].
+
+	anElement hasUniqueMooseNameInModel ifFalse: [ ^ anElement ].
+
+	byName
+		at: anElement mooseName
+		ifAbsent: [ "In theory, objects are registered under their mooseName,
             however some objects are still registered by their name
-            if #resetMooseName was not used when needed"
-            self resetMooseNameFor: anElement ].
-    byName removeKey: key ifAbsent: [ self error: 'Internal storage inconsistency' ].
-    ^anElement
+            if #resetMooseName was not used when needed" self resetMooseNameFor: anElement ].
+	byName removeKey: anElement mooseName ifAbsent: [ self error: 'Internal storage inconsistency' ].
+	^ anElement
 ]

--- a/src/Moose-Core/Object.extension.st
+++ b/src/Moose-Core/Object.extension.st
@@ -134,7 +134,7 @@ Object >> mooseModel [
 
 { #category : #'*moose-core' }
 Object >> mooseName [
-	^ self printString
+	^ self printString asSymbol
 ]
 
 { #category : #'*Moose-Core' }


### PR DESCRIPTION
Further speed up of moose group creations

Avoid the creation of some blocks in a method heavily used in moose to reduce the number of incr GC while creating a moose groupe.

This pass the creation of one of my group from 950ms to 500ms.