### PR TITLE
deprecate-unused-MoosePropertyGroup

### DIFF
--- a/src/Famix-Deprecated/LANMooseGroupTest.extension.st
+++ b/src/Famix-Deprecated/LANMooseGroupTest.extension.st
@@ -1,0 +1,9 @@
+Extension { #name : #LANMooseGroupTest }
+
+{ #category : #'*Famix-Deprecated' }
+LANMooseGroupTest >> testSelectTopTwentyForMetric [
+	| top remaining |
+	top := self model allMethods selectTopTwentyForMetric: #numberOfLinesOfCode.
+	remaining := self model allMethods entities copyWithoutAll: top.
+	self assert: (remaining allSatisfy: [ :m | top noneSatisfy: [ :m2 | m2 numberOfLinesOfCode <= m numberOfLinesOfCode ] ])
+]

--- a/src/Famix-Deprecated/MooseGroup.extension.st
+++ b/src/Famix-Deprecated/MooseGroup.extension.st
@@ -5,3 +5,35 @@ MooseGroup >> selectByExpression: anExpression [
 	self deprecated: 'Use #select: instead' transformWith: '`@receiver selectByExpression: `@statements1' -> '`@receiver select: `@statements1'.
 	^ self select: anExpression
 ]
+
+{ #category : #'*Famix-Deprecated' }
+MooseGroup >> selectTop: aFraction forMetric: aSymbolOrBlock [
+	"select top xx entities with highest metric value in the group. Useful to easily check the 80/20 rule.
+	For example:
+		self selectTop: 0.20 forMetric: #numberOfLinesOfCode
+	returns the top 20% entities in number of lines of code"
+
+	| topsSize sorted tops cutValue i |
+	self deprecated: 'This feature is barelly used and will be removed in a future version of Moose. If you use it, feel free to copy it yourself as an extension.'.
+	self assert: (aFraction >= 0 and: [ aFraction <= 1 ]).
+	topsSize := (self size * aFraction) ceiling.	"number of entities to select"
+	topsSize isZero ifTrue: [ ^ MooseGroup new ].
+	sorted := self asSortedCollection: [ :a :b | (aSymbolOrBlock value: a) > (aSymbolOrBlock value: b) ].
+	tops := sorted copyFrom: 1 to: topsSize.
+
+	"We check whether next elements should be retrieved, because their value matches the one of the last element which made the cut."
+	cutValue := aSymbolOrBlock value: (sorted at: topsSize).
+	i := topsSize + 1.
+	[ i <= sorted size and: [ (aSymbolOrBlock value: (sorted at: i)) = cutValue ] ]
+		whileTrue: [ tops add: (sorted at: i).
+			i := i + 1 ].
+	^ MoosePropertyGroup withAll: tops from: self using: aSymbolOrBlock
+]
+
+{ #category : #'*Famix-Deprecated' }
+MooseGroup >> selectTopTwentyForMetric: aSymbolOrBlock [
+	"Return the 20% top most methods for the metric aSymbolOrBlock"
+
+	self deprecated: 'This feature is barelly used and will be removed in a future version of Moose. If you use it, feel free to copy it yourself as an extension.'.
+	^ self selectTop: 0.20 forMetric: aSymbolOrBlock
+]

--- a/src/Famix-Deprecated/MoosePropertyGroup.class.st
+++ b/src/Famix-Deprecated/MoosePropertyGroup.class.st
@@ -12,13 +12,20 @@ Class {
 		'originalGroup',
 		'propertySymbolOrBlock'
 	],
-	#category : #'Moose-Core'
+	#category : #'Famix-Deprecated'
 }
 
 { #category : #meta }
 MoosePropertyGroup class >> annotation [
 	<FMClass: #PropertyGroup super: #MooseGroup>
 	<package: #Moose>
+]
+
+{ #category : #testing }
+MoosePropertyGroup class >> isDeprecated [
+	"This class seems unused and will be removed in the next version of Moose."
+
+	^ true
 ]
 
 { #category : #'instance creation' }

--- a/src/Famix-Deprecated/MoosePropertyGroupTest.class.st
+++ b/src/Famix-Deprecated/MoosePropertyGroupTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #MoosePropertyGroupTest,
 	#superclass : #TestCase,
-	#category : #'Moose-Core-Tests'
+	#category : #'Famix-Deprecated'
 }
 
 { #category : #tests }

--- a/src/Moose-Core/MooseGroup.class.st
+++ b/src/Moose-Core/MooseGroup.class.st
@@ -265,37 +265,6 @@ MooseGroup >> selectEightyCoverForMetric: aSymbolOrBlock [
 ]
 
 { #category : #'public interface' }
-MooseGroup >> selectTop: aFraction forMetric: aSymbolOrBlock [
-	"select top xx entities with highest metric value in the group. Useful to easily check the 80/20 rule.
-	For example:
-		self selectTop: 0.20 forMetric: #numberOfLinesOfCode
-	returns the top 20% entities in number of lines of code"
-	
-	| topsSize sorted tops cutValue i |
-	self assert: (aFraction >= 0 and: [aFraction <= 1]).
-	topsSize := (self size * aFraction) ceiling. "number of entities to select"
-	topsSize isZero ifTrue: [ ^ MooseGroup new ].
-	sorted := self asSortedCollection: [:a :b | (aSymbolOrBlock value: a) > (aSymbolOrBlock value: b)].
-	tops := sorted copyFrom: 1 to: topsSize.
-
-	"We check whether next elements should be retrieved, because their value matches the one of the last element which made the cut."
-	cutValue := aSymbolOrBlock value: (sorted at: topsSize).
-	i := topsSize + 1.
-	[ i <= sorted size and: [ (aSymbolOrBlock value: (sorted at: i)) = cutValue ]]
-		whileTrue: [
-			tops add: (sorted at: i).
-			i := i + 1 ].
-	^ MoosePropertyGroup withAll: tops from: self using: aSymbolOrBlock
-]
-
-{ #category : #'public interface' }
-MooseGroup >> selectTopTwentyForMetric: aSymbolOrBlock [
-	"Return the 20% top most methods for the metric aSymbolOrBlock"
-
-	^ self selectTop: 0.20 forMetric: aSymbolOrBlock
-]
-
-{ #category : #'public interface' }
 MooseGroup >> sort: aBlock [ 
 	 
 	self entities: (self entities sorted: aBlock)

--- a/src/Moose-SmalltalkImporter-LAN-Tests/LANMooseGroupTest.class.st
+++ b/src/Moose-SmalltalkImporter-LAN-Tests/LANMooseGroupTest.class.st
@@ -193,14 +193,6 @@ LANMooseGroupTest >> testSelectGroupType [
 ]
 
 { #category : #tests }
-LANMooseGroupTest >> testSelectTopTwentyForMetric [
-	| top remaining |
-	top := self model allMethods selectTopTwentyForMetric: #numberOfLinesOfCode.
-	remaining := self model allMethods entities copyWithoutAll: top.
-	self assert: (remaining allSatisfy: [ :m | top noneSatisfy: [ :m2 | m2 numberOfLinesOfCode <= m numberOfLinesOfCode ] ])
-]
-
-{ #category : #tests }
 LANMooseGroupTest >> testSum [
 	self assert: (self model allModelClasses sumNumbers: #numberOfAttributes) equals: 16
 ]


### PR DESCRIPTION
Deprecated MoosePropertyGroup

MoosePropertyGroup is unused in Moose and most of the tools we are aware of. It's extra complexity for few gain. 
We discussed with Benoit and decided to deprecate it.