### PR TITLE
make-specialization-of-moose-groups-an-option

### DIFF
--- a/src/Famix-Compatibility-Entities/FAMIXScopingEntity.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXScopingEntity.class.st
@@ -152,7 +152,7 @@ FAMIXScopingEntity >> parentScope: anObject [
 FAMIXScopingEntity >> parentScopeGroup [
 	<generated>
 	<navigation: 'ParentScope'>
-	^ MooseGroup with: self parentScope
+	^ MooseSpecializedGroup with: self parentScope
 ]
 
 { #category : #'Famix-Extensions' }

--- a/src/Famix-Deprecated/LANMooseGroupTest.extension.st
+++ b/src/Famix-Deprecated/LANMooseGroupTest.extension.st
@@ -1,6 +1,13 @@
 Extension { #name : #LANMooseGroupTest }
 
 { #category : #'*Famix-Deprecated' }
+LANMooseGroupTest >> testSelectEightyCoverForMetric [
+	| top |
+	top := self model allMethods selectEightyCoverForMetric: #numberOfLinesOfCode.
+	self denyEmpty: top
+]
+
+{ #category : #'*Famix-Deprecated' }
 LANMooseGroupTest >> testSelectTopTwentyForMetric [
 	| top remaining |
 	top := self model allMethods selectTopTwentyForMetric: #numberOfLinesOfCode.

--- a/src/Famix-Deprecated/MooseGroup.extension.st
+++ b/src/Famix-Deprecated/MooseGroup.extension.st
@@ -7,6 +7,33 @@ MooseGroup >> selectByExpression: anExpression [
 ]
 
 { #category : #'*Famix-Deprecated' }
+MooseGroup >> selectCover: aFraction forMetric: aSymbolOrBlock [
+	"select biggest entities which cover aFraction of the metric property for the whole group. Useful to easily check the 80/20 rule for example:
+		self selectCover: 0.80 forMetric: #numberOfLinesOfCode
+	returns the entities which cover 80% of the code base in number of lines of code"
+
+	| cutValue sorted tops sum i |
+	self deprecated: 'This feature is barelly used and will be removed in a future version of Moose. If you use it, feel free to copy it yourself as an extension.'.
+	self assert: (aFraction >= 0 and: [ aFraction <= 1 ]).
+	cutValue := (self sumNumbers: aSymbolOrBlock) * aFraction.
+	sorted := self asSortedCollection: [ :a :b | (aSymbolOrBlock value: a) > (aSymbolOrBlock value: b) ].
+	tops := OrderedCollection new.
+	sum := 0.
+	i := 1.
+	[ sum < cutValue and: [ i <= self size ] ]
+		whileTrue: [ tops add: (sorted at: i).
+			sum := sum + (aSymbolOrBlock value: (sorted at: i)).
+			i := i + 1 ].
+	^ MoosePropertyGroup withAll: tops from: self using: aSymbolOrBlock
+]
+
+{ #category : #'*Famix-Deprecated' }
+MooseGroup >> selectEightyCoverForMetric: aSymbolOrBlock [
+	self deprecated: 'This feature is barelly used and will be removed in a future version of Moose. If you use it, feel free to copy it yourself as an extension.'.
+	^ self selectCover: 0.80 forMetric: aSymbolOrBlock
+]
+
+{ #category : #'*Famix-Deprecated' }
 MooseGroup >> selectTop: aFraction forMetric: aSymbolOrBlock [
 	"select top xx entities with highest metric value in the group. Useful to easily check the 80/20 rule.
 	For example:

--- a/src/Famix-Deprecated/MoosePropertyGroup.class.st
+++ b/src/Famix-Deprecated/MoosePropertyGroup.class.st
@@ -30,8 +30,10 @@ MoosePropertyGroup class >> isDeprecated [
 
 { #category : #'instance creation' }
 MoosePropertyGroup class >> withAll: aCollection from: aMooseGroup using: aSymbolOrBlock [
-
-	^ (self withAll: aCollection) originalGroup: aMooseGroup; property: aSymbolOrBlock; yourself
+	^ (self withAll: aCollection)
+		originalGroup: aMooseGroup;
+		property: aSymbolOrBlock;
+		yourself
 ]
 
 { #category : #accessing }

--- a/src/Famix-Deprecated/MoosePropertyGroup.class.st
+++ b/src/Famix-Deprecated/MoosePropertyGroup.class.st
@@ -7,7 +7,7 @@ Instance Variables:
 "
 Class {
 	#name : #MoosePropertyGroup,
-	#superclass : #MooseGroup,
+	#superclass : #MooseSpecializedGroup,
 	#instVars : [
 		'originalGroup',
 		'propertySymbolOrBlock'

--- a/src/Famix-Deprecated/MoosePropertyGroupTest.class.st
+++ b/src/Famix-Deprecated/MoosePropertyGroupTest.class.st
@@ -14,7 +14,7 @@ MoosePropertyGroupTest >> testBasic [
 	self assert: propertyGroup property identicalTo: #numberOfLinesOfCode.
 	self assert: propertyGroup propertyRatio equals: 0.5.
 	self assert: propertyGroup propertyTotal equals: 30.
-	self assert: propertyGroup asMooseGroup class identicalTo: FamixClassGroup.
+	self assert: propertyGroup asMooseGroup specialize class identicalTo: FamixClassGroup.
 	self assert: propertyGroup propertyTotalOriginal equals: 60.
 	self assert: (propertyGroup sizeRatio * 100) asInteger equals: 66.
 	self assert: propertyGroup sizeOriginal equals: allClasses size

--- a/src/Famix-Java-Entities/FamixJavaNamespace.class.st
+++ b/src/Famix-Java-Entities/FamixJavaNamespace.class.st
@@ -324,7 +324,7 @@ FamixJavaNamespace >> parentNamespace: anObject [
 FamixJavaNamespace >> parentNamespaceGroup [
 	<generated>
 	<navigation: 'ParentNamespace'>
-	^ MooseGroup with: self parentNamespace
+	^ MooseSpecializedGroup with: self parentNamespace
 ]
 
 { #category : #printing }

--- a/src/Famix-MetamodelBuilder-Core/FmxMBBehavior.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxMBBehavior.class.st
@@ -206,11 +206,11 @@ FmxMBBehavior >> generateNavigationGroupsFor: aClass [
 						ifTrue: [ '{1}
 	<generated>
 	<navigation: ''{2}''>
-	^ MooseGroup withAll: self {3} asSet' ]
+	^ MooseSpecializedGroup withAll: self {3} asSet' ]
 						ifFalse: [ '{1}
 	<generated>
 	<navigation: ''{2}''>
-	^ MooseGroup with: self {3}' ]) format: {(sideName , 'Group') . sideName capitalized . sideName})
+	^ MooseSpecializedGroup with: self {3}' ]) format: {(sideName , 'Group') . sideName capitalized . sideName})
 				in: aClass instanceSide
 				classified: #navigation ]
 ]

--- a/src/Famix-MetamodelBuilder-Core/FmxMBConfiguration.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxMBConfiguration.class.st
@@ -76,7 +76,7 @@ FmxMBConfiguration >> classTag: anObject [
 { #category : #'settings - default' }
 FmxMBConfiguration >> defaultBasicGroupSuperclassName [
 
-	^ #MooseGroup
+	^ #MooseSpecializedGroup
 ]
 
 { #category : #'settings - default' }

--- a/src/Famix-Test3-Entities/FamixTest3TypeGroup.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3TypeGroup.class.st
@@ -1,13 +1,13 @@
 Class {
 	#name : #FamixTest3TypeGroup,
-	#superclass : #MooseGroup,
+	#superclass : #MooseSpecializedGroup,
 	#category : #'Famix-Test3-Entities-Entities'
 }
 
 { #category : #meta }
 FamixTest3TypeGroup class >> annotation [
 
-	<FMClass: #TypeGroup super: #MooseGroup>
+	<FMClass: #TypeGroup super: #MooseSpecializedGroup>
 	<package: #'Famix-Test3-Entities'>
 	<generated>
 	^self

--- a/src/Famix-Test3-Tests/FamixTest3GroupTest.class.st
+++ b/src/Famix-Test3-Tests/FamixTest3GroupTest.class.st
@@ -16,6 +16,6 @@ FamixTest3GroupTest >> testGroupsAreGenerated [
 ]
 
 { #category : #tests }
-FamixTest3GroupTest >> testMooseGroupAllWith [
-	self assert: (model allUsing: FamixTClass) class equals: self classGroup
+FamixTest3GroupTest >> testMooseSpecializedGroupAllWith [
+	self assert: (model allUsing: FamixTClass) specialize class equals: self classGroup
 ]

--- a/src/Famix-Test4-Entities/FamixTest4Book.class.st
+++ b/src/Famix-Test4-Entities/FamixTest4Book.class.st
@@ -36,5 +36,5 @@ FamixTest4Book >> person: anObject [
 FamixTest4Book >> personGroup [
 	<generated>
 	<navigation: 'Person'>
-	^ MooseGroup with: self person
+	^ MooseSpecializedGroup with: self person
 ]

--- a/src/Famix-Test4-Entities/FamixTest4Person.class.st
+++ b/src/Famix-Test4-Entities/FamixTest4Person.class.st
@@ -42,5 +42,5 @@ FamixTest4Person >> books: anObject [
 FamixTest4Person >> booksGroup [
 	<generated>
 	<navigation: 'Books'>
-	^ MooseGroup withAll: self books asSet
+	^ MooseSpecializedGroup withAll: self books asSet
 ]

--- a/src/Famix-Test4-Entities/FamixTest4Principal.class.st
+++ b/src/Famix-Test4-Entities/FamixTest4Principal.class.st
@@ -36,5 +36,5 @@ FamixTest4Principal >> school: anObject [
 FamixTest4Principal >> schoolGroup [
 	<generated>
 	<navigation: 'School'>
-	^ MooseGroup with: self school
+	^ MooseSpecializedGroup with: self school
 ]

--- a/src/Famix-Test4-Entities/FamixTest4Room.class.st
+++ b/src/Famix-Test4-Entities/FamixTest4Room.class.st
@@ -36,5 +36,5 @@ FamixTest4Room >> school: anObject [
 FamixTest4Room >> schoolGroup [
 	<generated>
 	<navigation: 'School'>
-	^ MooseGroup with: self school
+	^ MooseSpecializedGroup with: self school
 ]

--- a/src/Famix-Test4-Entities/FamixTest4School.class.st
+++ b/src/Famix-Test4-Entities/FamixTest4School.class.st
@@ -57,7 +57,7 @@ FamixTest4School >> principal: anObject [
 FamixTest4School >> principalGroup [
 	<generated>
 	<navigation: 'Principal'>
-	^ MooseGroup with: self principal
+	^ MooseSpecializedGroup with: self principal
 ]
 
 { #category : #accessing }
@@ -80,7 +80,7 @@ FamixTest4School >> rooms: anObject [
 FamixTest4School >> roomsGroup [
 	<generated>
 	<navigation: 'Rooms'>
-	^ MooseGroup withAll: self rooms asSet
+	^ MooseSpecializedGroup withAll: self rooms asSet
 ]
 
 { #category : #accessing }
@@ -103,7 +103,7 @@ FamixTest4School >> students: anObject [
 FamixTest4School >> studentsGroup [
 	<generated>
 	<navigation: 'Students'>
-	^ MooseGroup withAll: self students asSet
+	^ MooseSpecializedGroup withAll: self students asSet
 ]
 
 { #category : #accessing }
@@ -126,5 +126,5 @@ FamixTest4School >> teachers: anObject [
 FamixTest4School >> teachersGroup [
 	<generated>
 	<navigation: 'Teachers'>
-	^ MooseGroup withAll: self teachers asSet
+	^ MooseSpecializedGroup withAll: self teachers asSet
 ]

--- a/src/Famix-Test4-Entities/FamixTest4Student.class.st
+++ b/src/Famix-Test4-Entities/FamixTest4Student.class.st
@@ -43,7 +43,7 @@ FamixTest4Student >> school: anObject [
 FamixTest4Student >> schoolGroup [
 	<generated>
 	<navigation: 'School'>
-	^ MooseGroup with: self school
+	^ MooseSpecializedGroup with: self school
 ]
 
 { #category : #accessing }
@@ -66,5 +66,5 @@ FamixTest4Student >> teachers: anObject [
 FamixTest4Student >> teachersGroup [
 	<generated>
 	<navigation: 'Teachers'>
-	^ MooseGroup withAll: self teachers asSet
+	^ MooseSpecializedGroup withAll: self teachers asSet
 ]

--- a/src/Famix-Test4-Entities/FamixTest4Teacher.class.st
+++ b/src/Famix-Test4-Entities/FamixTest4Teacher.class.st
@@ -43,7 +43,7 @@ FamixTest4Teacher >> school: anObject [
 FamixTest4Teacher >> schoolGroup [
 	<generated>
 	<navigation: 'School'>
-	^ MooseGroup with: self school
+	^ MooseSpecializedGroup with: self school
 ]
 
 { #category : #accessing }
@@ -65,5 +65,5 @@ FamixTest4Teacher >> students: anObject [
 FamixTest4Teacher >> studentsGroup [
 	<generated>
 	<navigation: 'Students'>
-	^ MooseGroup withAll: self students asSet
+	^ MooseSpecializedGroup withAll: self students asSet
 ]

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedCustomEntity1.class.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedCustomEntity1.class.st
@@ -63,5 +63,5 @@ FamixTestComposedCustomEntity1 >> customEntity1: anObject [
 FamixTestComposedCustomEntity1 >> customEntity1Group [
 	<generated>
 	<navigation: 'CustomEntity1'>
-	^ MooseGroup with: self customEntity1
+	^ MooseSpecializedGroup with: self customEntity1
 ]

--- a/src/Famix-Traits/FamixAnnotationInstanceGroup.class.st
+++ b/src/Famix-Traits/FamixAnnotationInstanceGroup.class.st
@@ -1,13 +1,13 @@
 Class {
 	#name : #FamixAnnotationInstanceGroup,
-	#superclass : #MooseGroup,
+	#superclass : #MooseSpecializedGroup,
 	#category : #'Famix-Traits-Entities'
 }
 
 { #category : #meta }
 FamixAnnotationInstanceGroup class >> annotation [
 
-	<FMClass: #AnnotationInstanceGroup super: #MooseGroup>
+	<FMClass: #AnnotationInstanceGroup super: #MooseSpecializedGroup>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixAnnotationTypeGroup.class.st
+++ b/src/Famix-Traits/FamixAnnotationTypeGroup.class.st
@@ -1,13 +1,13 @@
 Class {
 	#name : #FamixAnnotationTypeGroup,
-	#superclass : #MooseGroup,
+	#superclass : #MooseSpecializedGroup,
 	#category : #'Famix-Traits-Entities'
 }
 
 { #category : #meta }
 FamixAnnotationTypeGroup class >> annotation [
 
-	<FMClass: #AnnotationTypeGroup super: #MooseGroup>
+	<FMClass: #AnnotationTypeGroup super: #MooseSpecializedGroup>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixFileGroup.class.st
+++ b/src/Famix-Traits/FamixFileGroup.class.st
@@ -1,13 +1,13 @@
 Class {
 	#name : #FamixFileGroup,
-	#superclass : #MooseGroup,
+	#superclass : #MooseSpecializedGroup,
 	#category : #'Famix-Traits-Entities'
 }
 
 { #category : #meta }
 FamixFileGroup class >> annotation [
 
-	<FMClass: #FileGroup super: #MooseGroup>
+	<FMClass: #FileGroup super: #MooseSpecializedGroup>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixFolderGroup.class.st
+++ b/src/Famix-Traits/FamixFolderGroup.class.st
@@ -1,13 +1,13 @@
 Class {
 	#name : #FamixFolderGroup,
-	#superclass : #MooseGroup,
+	#superclass : #MooseSpecializedGroup,
 	#category : #'Famix-Traits-Entities'
 }
 
 { #category : #meta }
 FamixFolderGroup class >> annotation [
 
-	<FMClass: #FolderGroup super: #MooseGroup>
+	<FMClass: #FolderGroup super: #MooseSpecializedGroup>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixGlobalVariableGroup.class.st
+++ b/src/Famix-Traits/FamixGlobalVariableGroup.class.st
@@ -1,13 +1,13 @@
 Class {
 	#name : #FamixGlobalVariableGroup,
-	#superclass : #MooseGroup,
+	#superclass : #MooseSpecializedGroup,
 	#category : #'Famix-Traits-Entities'
 }
 
 { #category : #meta }
 FamixGlobalVariableGroup class >> annotation [
 
-	<FMClass: #GlobalVariableGroup super: #MooseGroup>
+	<FMClass: #GlobalVariableGroup super: #MooseSpecializedGroup>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixInvocationGroup.class.st
+++ b/src/Famix-Traits/FamixInvocationGroup.class.st
@@ -1,13 +1,13 @@
 Class {
 	#name : #FamixInvocationGroup,
-	#superclass : #MooseGroup,
+	#superclass : #MooseSpecializedGroup,
 	#category : #'Famix-Traits-Entities'
 }
 
 { #category : #meta }
 FamixInvocationGroup class >> annotation [
 
-	<FMClass: #InvocationGroup super: #MooseGroup>
+	<FMClass: #InvocationGroup super: #MooseSpecializedGroup>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixMethodGroup.class.st
+++ b/src/Famix-Traits/FamixMethodGroup.class.st
@@ -1,13 +1,13 @@
 Class {
 	#name : #FamixMethodGroup,
-	#superclass : #MooseGroup,
+	#superclass : #MooseSpecializedGroup,
 	#category : #'Famix-Traits-Entities'
 }
 
 { #category : #meta }
 FamixMethodGroup class >> annotation [
 
-	<FMClass: #MethodGroup super: #MooseGroup>
+	<FMClass: #MethodGroup super: #MooseSpecializedGroup>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixNamespaceGroup.class.st
+++ b/src/Famix-Traits/FamixNamespaceGroup.class.st
@@ -1,13 +1,13 @@
 Class {
 	#name : #FamixNamespaceGroup,
-	#superclass : #MooseGroup,
+	#superclass : #MooseSpecializedGroup,
 	#category : #'Famix-Traits-Entities'
 }
 
 { #category : #meta }
 FamixNamespaceGroup class >> annotation [
 
-	<FMClass: #NamespaceGroup super: #MooseGroup>
+	<FMClass: #NamespaceGroup super: #MooseSpecializedGroup>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixPackageGroup.class.st
+++ b/src/Famix-Traits/FamixPackageGroup.class.st
@@ -1,13 +1,13 @@
 Class {
 	#name : #FamixPackageGroup,
-	#superclass : #MooseGroup,
+	#superclass : #MooseSpecializedGroup,
 	#category : #'Famix-Traits-Entities'
 }
 
 { #category : #meta }
 FamixPackageGroup class >> annotation [
 
-	<FMClass: #PackageGroup super: #MooseGroup>
+	<FMClass: #PackageGroup super: #MooseSpecializedGroup>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Famix-Traits/FamixTAnnotationInstance.trait.st
+++ b/src/Famix-Traits/FamixTAnnotationInstance.trait.st
@@ -17,6 +17,7 @@ Trait {
 		'#annotatedEntity => FMOne type: #FamixTWithAnnotationInstances opposite: #annotationInstances'
 	],
 	#traits : 'TEntityMetaLevelDependency',
+	#classTraits : 'TEntityMetaLevelDependency classTrait',
 	#category : #'Famix-Traits-AnnotationInstance'
 }
 
@@ -57,5 +58,5 @@ FamixTAnnotationInstance >> annotatedEntity: anObject [
 FamixTAnnotationInstance >> annotatedEntityGroup [
 	<generated>
 	<navigation: 'AnnotatedEntity'>
-	^ MooseGroup with: self annotatedEntity
+	^ MooseSpecializedGroup with: self annotatedEntity
 ]

--- a/src/Famix-Traits/FamixTAnnotationInstance.trait.st
+++ b/src/Famix-Traits/FamixTAnnotationInstance.trait.st
@@ -17,7 +17,6 @@ Trait {
 		'#annotatedEntity => FMOne type: #FamixTWithAnnotationInstances opposite: #annotationInstances'
 	],
 	#traits : 'TEntityMetaLevelDependency',
-	#classTraits : 'TEntityMetaLevelDependency classTrait',
 	#category : #'Famix-Traits-AnnotationInstance'
 }
 

--- a/src/Famix-Traits/FamixTAnnotationInstanceAttribute.trait.st
+++ b/src/Famix-Traits/FamixTAnnotationInstanceAttribute.trait.st
@@ -16,7 +16,6 @@ Trait {
 		'#value => FMProperty'
 	],
 	#traits : 'TEntityMetaLevelDependency',
-	#classTraits : 'TEntityMetaLevelDependency classTrait',
 	#category : #'Famix-Traits-AnnotationInstanceAttribute'
 }
 

--- a/src/Famix-Traits/FamixTAnnotationInstanceAttribute.trait.st
+++ b/src/Famix-Traits/FamixTAnnotationInstanceAttribute.trait.st
@@ -16,6 +16,7 @@ Trait {
 		'#value => FMProperty'
 	],
 	#traits : 'TEntityMetaLevelDependency',
+	#classTraits : 'TEntityMetaLevelDependency classTrait',
 	#category : #'Famix-Traits-AnnotationInstanceAttribute'
 }
 
@@ -49,7 +50,7 @@ FamixTAnnotationInstanceAttribute >> parentAnnotationInstance: anObject [
 FamixTAnnotationInstanceAttribute >> parentAnnotationInstanceGroup [
 	<generated>
 	<navigation: 'ParentAnnotationInstance'>
-	^ MooseGroup with: self parentAnnotationInstance
+	^ MooseSpecializedGroup with: self parentAnnotationInstance
 ]
 
 { #category : #accessing }

--- a/src/Famix-Traits/FamixTAnnotationType.trait.st
+++ b/src/Famix-Traits/FamixTAnnotationType.trait.st
@@ -58,7 +58,7 @@ FamixTAnnotationType >> annotationTypesContainer: anObject [
 FamixTAnnotationType >> annotationTypesContainerGroup [
 	<generated>
 	<navigation: 'AnnotationTypesContainer'>
-	^ MooseGroup with: self annotationTypesContainer
+	^ MooseSpecializedGroup with: self annotationTypesContainer
 ]
 
 { #category : #accessing }

--- a/src/Famix-Traits/FamixTAttribute.trait.st
+++ b/src/Famix-Traits/FamixTAttribute.trait.st
@@ -9,7 +9,6 @@ Trait {
 		'#parentType => FMOne type: #FamixTWithAttributes opposite: #attributes'
 	],
 	#traits : 'FamixTStructuralEntity',
-	#classTraits : 'FamixTStructuralEntity classTrait',
 	#category : #'Famix-Traits-Attribute'
 }
 

--- a/src/Famix-Traits/FamixTAttribute.trait.st
+++ b/src/Famix-Traits/FamixTAttribute.trait.st
@@ -9,6 +9,7 @@ Trait {
 		'#parentType => FMOne type: #FamixTWithAttributes opposite: #attributes'
 	],
 	#traits : 'FamixTStructuralEntity',
+	#classTraits : 'FamixTStructuralEntity classTrait',
 	#category : #'Famix-Traits-Attribute'
 }
 
@@ -88,7 +89,7 @@ FamixTAttribute >> parentType: anObject [
 FamixTAttribute >> parentTypeGroup [
 	<generated>
 	<navigation: 'ParentType'>
-	^ MooseGroup with: self parentType
+	^ MooseSpecializedGroup with: self parentType
 ]
 
 { #category : #printing }

--- a/src/Famix-Traits/FamixTEnumValue.trait.st
+++ b/src/Famix-Traits/FamixTEnumValue.trait.st
@@ -62,7 +62,7 @@ FamixTEnumValue >> parentEnum: anObject [
 FamixTEnumValue >> parentEnumGroup [
 	<generated>
 	<navigation: 'ParentEnum'>
-	^ MooseGroup with: self parentEnum
+	^ MooseSpecializedGroup with: self parentEnum
 ]
 
 { #category : #accessing }

--- a/src/Famix-Traits/FamixTFileSystemEntity.trait.st
+++ b/src/Famix-Traits/FamixTFileSystemEntity.trait.st
@@ -115,7 +115,7 @@ FamixTFileSystemEntity >> parentFolder: anObject [
 FamixTFileSystemEntity >> parentFolderGroup [
 	<generated>
 	<navigation: 'ParentFolder'>
-	^ MooseGroup with: self parentFolder
+	^ MooseSpecializedGroup with: self parentFolder
 ]
 
 { #category : #accessing }

--- a/src/Famix-Traits/FamixTFunction.trait.st
+++ b/src/Famix-Traits/FamixTFunction.trait.st
@@ -7,7 +7,6 @@ Trait {
 		'#functionOwner => FMOne type: #FamixTWithFunctions opposite: #functions'
 	],
 	#traits : '(FamixTHasSignature + FamixTNamedEntity + FamixTTypedEntity + FamixTWithParameters + FamixTWithStatements withPrecedenceOf: FamixTWithStatements)',
-	#classTraits : '(FamixTHasSignature classTrait + FamixTNamedEntity classTrait + FamixTTypedEntity classTrait + FamixTWithParameters classTrait + FamixTWithStatements classTrait withPrecedenceOf: FamixTWithStatements classTrait)',
 	#category : #'Famix-Traits-Behavioral'
 }
 

--- a/src/Famix-Traits/FamixTFunction.trait.st
+++ b/src/Famix-Traits/FamixTFunction.trait.st
@@ -7,6 +7,7 @@ Trait {
 		'#functionOwner => FMOne type: #FamixTWithFunctions opposite: #functions'
 	],
 	#traits : '(FamixTHasSignature + FamixTNamedEntity + FamixTTypedEntity + FamixTWithParameters + FamixTWithStatements withPrecedenceOf: FamixTWithStatements)',
+	#classTraits : '(FamixTHasSignature classTrait + FamixTNamedEntity classTrait + FamixTTypedEntity classTrait + FamixTWithParameters classTrait + FamixTWithStatements classTrait withPrecedenceOf: FamixTWithStatements classTrait)',
 	#category : #'Famix-Traits-Behavioral'
 }
 
@@ -41,7 +42,7 @@ FamixTFunction >> functionOwner: anObject [
 FamixTFunction >> functionOwnerGroup [
 	<generated>
 	<navigation: 'FunctionOwner'>
-	^ MooseGroup with: self functionOwner
+	^ MooseSpecializedGroup with: self functionOwner
 ]
 
 { #category : #testing }

--- a/src/Famix-Traits/FamixTGlobalVariable.trait.st
+++ b/src/Famix-Traits/FamixTGlobalVariable.trait.st
@@ -8,7 +8,6 @@ Trait {
 		'#parentScope => FMOne type: #FamixTWithGlobalVariables opposite: #globalVariables'
 	],
 	#traits : 'FamixTStructuralEntity',
-	#classTraits : 'FamixTStructuralEntity classTrait',
 	#category : #'Famix-Traits-GlobalVariable'
 }
 

--- a/src/Famix-Traits/FamixTGlobalVariable.trait.st
+++ b/src/Famix-Traits/FamixTGlobalVariable.trait.st
@@ -8,6 +8,7 @@ Trait {
 		'#parentScope => FMOne type: #FamixTWithGlobalVariables opposite: #globalVariables'
 	],
 	#traits : 'FamixTStructuralEntity',
+	#classTraits : 'FamixTStructuralEntity classTrait',
 	#category : #'Famix-Traits-GlobalVariable'
 }
 
@@ -48,5 +49,5 @@ FamixTGlobalVariable >> parentScope: anObject [
 FamixTGlobalVariable >> parentScopeGroup [
 	<generated>
 	<navigation: 'ParentScope'>
-	^ MooseGroup with: self parentScope
+	^ MooseSpecializedGroup with: self parentScope
 ]

--- a/src/Famix-Traits/FamixTImplicitVariable.trait.st
+++ b/src/Famix-Traits/FamixTImplicitVariable.trait.st
@@ -7,7 +7,6 @@ Trait {
 		'#parentBehaviouralEntity => FMOne type: #FamixTWithImplicitVariables opposite: #implicitVariables'
 	],
 	#traits : 'FamixTStructuralEntity',
-	#classTraits : 'FamixTStructuralEntity classTrait',
 	#category : #'Famix-Traits-ImplicitVariable'
 }
 

--- a/src/Famix-Traits/FamixTImplicitVariable.trait.st
+++ b/src/Famix-Traits/FamixTImplicitVariable.trait.st
@@ -7,6 +7,7 @@ Trait {
 		'#parentBehaviouralEntity => FMOne type: #FamixTWithImplicitVariables opposite: #implicitVariables'
 	],
 	#traits : 'FamixTStructuralEntity',
+	#classTraits : 'FamixTStructuralEntity classTrait',
 	#category : #'Famix-Traits-ImplicitVariable'
 }
 
@@ -49,5 +50,5 @@ FamixTImplicitVariable >> parentBehaviouralEntity: anObject [
 FamixTImplicitVariable >> parentBehaviouralEntityGroup [
 	<generated>
 	<navigation: 'ParentBehaviouralEntity'>
-	^ MooseGroup with: self parentBehaviouralEntity
+	^ MooseSpecializedGroup with: self parentBehaviouralEntity
 ]

--- a/src/Famix-Traits/FamixTLocalVariable.trait.st
+++ b/src/Famix-Traits/FamixTLocalVariable.trait.st
@@ -7,6 +7,7 @@ Trait {
 		'#parentBehaviouralEntity => FMOne type: #FamixTWithLocalVariables opposite: #localVariables'
 	],
 	#traits : 'FamixTStructuralEntity',
+	#classTraits : 'FamixTStructuralEntity classTrait',
 	#category : #'Famix-Traits-LocalVariable'
 }
 
@@ -42,5 +43,5 @@ FamixTLocalVariable >> parentBehaviouralEntity: anObject [
 FamixTLocalVariable >> parentBehaviouralEntityGroup [
 	<generated>
 	<navigation: 'ParentBehaviouralEntity'>
-	^ MooseGroup with: self parentBehaviouralEntity
+	^ MooseSpecializedGroup with: self parentBehaviouralEntity
 ]

--- a/src/Famix-Traits/FamixTLocalVariable.trait.st
+++ b/src/Famix-Traits/FamixTLocalVariable.trait.st
@@ -7,7 +7,6 @@ Trait {
 		'#parentBehaviouralEntity => FMOne type: #FamixTWithLocalVariables opposite: #localVariables'
 	],
 	#traits : 'FamixTStructuralEntity',
-	#classTraits : 'FamixTStructuralEntity classTrait',
 	#category : #'Famix-Traits-LocalVariable'
 }
 

--- a/src/Famix-Traits/FamixTMethod.trait.st
+++ b/src/Famix-Traits/FamixTMethod.trait.st
@@ -12,6 +12,7 @@ Trait {
 		'#parentType => FMOne type: #FamixTWithMethods opposite: #methods'
 	],
 	#traits : '(FamixTHasSignature + FamixTInvocable + FamixTNamedEntity + FamixTTypedEntity + FamixTWithClassScope + FamixTWithImplicitVariables + FamixTWithLocalVariables + FamixTWithParameters + FamixTWithReferences + FamixTWithStatements + TOODependencyQueries withPrecedenceOf: FamixTWithStatements)',
+	#classTraits : '(FamixTHasSignature classTrait + FamixTInvocable classTrait + FamixTNamedEntity classTrait + FamixTTypedEntity classTrait + FamixTWithClassScope classTrait + FamixTWithImplicitVariables classTrait + FamixTWithLocalVariables classTrait + FamixTWithParameters classTrait + FamixTWithReferences classTrait + FamixTWithStatements classTrait + TOODependencyQueries classTrait withPrecedenceOf: FamixTWithStatements classTrait)',
 	#category : #'Famix-Traits-Behavioral'
 }
 
@@ -194,7 +195,7 @@ FamixTMethod >> parentType: anObject [
 FamixTMethod >> parentTypeGroup [
 	<generated>
 	<navigation: 'ParentType'>
-	^ MooseGroup with: self parentType
+	^ MooseSpecializedGroup with: self parentType
 ]
 
 { #category : #testing }

--- a/src/Famix-Traits/FamixTMethod.trait.st
+++ b/src/Famix-Traits/FamixTMethod.trait.st
@@ -12,7 +12,6 @@ Trait {
 		'#parentType => FMOne type: #FamixTWithMethods opposite: #methods'
 	],
 	#traits : '(FamixTHasSignature + FamixTInvocable + FamixTNamedEntity + FamixTTypedEntity + FamixTWithClassScope + FamixTWithImplicitVariables + FamixTWithLocalVariables + FamixTWithParameters + FamixTWithReferences + FamixTWithStatements + TOODependencyQueries withPrecedenceOf: FamixTWithStatements)',
-	#classTraits : '(FamixTHasSignature classTrait + FamixTInvocable classTrait + FamixTNamedEntity classTrait + FamixTTypedEntity classTrait + FamixTWithClassScope classTrait + FamixTWithImplicitVariables classTrait + FamixTWithLocalVariables classTrait + FamixTWithParameters classTrait + FamixTWithReferences classTrait + FamixTWithStatements classTrait + TOODependencyQueries classTrait withPrecedenceOf: FamixTWithStatements classTrait)',
 	#category : #'Famix-Traits-Behavioral'
 }
 

--- a/src/Famix-Traits/FamixTPackageable.trait.st
+++ b/src/Famix-Traits/FamixTPackageable.trait.st
@@ -41,5 +41,5 @@ FamixTPackageable >> parentPackage: anObject [
 FamixTPackageable >> parentPackageGroup [
 	<generated>
 	<navigation: 'ParentPackage'>
-	^ MooseGroup with: self parentPackage
+	^ MooseSpecializedGroup with: self parentPackage
 ]

--- a/src/Famix-Traits/FamixTParameter.trait.st
+++ b/src/Famix-Traits/FamixTParameter.trait.st
@@ -7,7 +7,6 @@ Trait {
 		'#parentBehaviouralEntity => FMOne type: #FamixTWithParameters opposite: #parameters'
 	],
 	#traits : 'FamixTStructuralEntity',
-	#classTraits : 'FamixTStructuralEntity classTrait',
 	#category : #'Famix-Traits-Parameter'
 }
 

--- a/src/Famix-Traits/FamixTParameter.trait.st
+++ b/src/Famix-Traits/FamixTParameter.trait.st
@@ -7,6 +7,7 @@ Trait {
 		'#parentBehaviouralEntity => FMOne type: #FamixTWithParameters opposite: #parameters'
 	],
 	#traits : 'FamixTStructuralEntity',
+	#classTraits : 'FamixTStructuralEntity classTrait',
 	#category : #'Famix-Traits-Parameter'
 }
 
@@ -41,5 +42,5 @@ FamixTParameter >> parentBehaviouralEntity: anObject [
 FamixTParameter >> parentBehaviouralEntityGroup [
 	<generated>
 	<navigation: 'ParentBehaviouralEntity'>
-	^ MooseGroup with: self parentBehaviouralEntity
+	^ MooseSpecializedGroup with: self parentBehaviouralEntity
 ]

--- a/src/Famix-Traits/FamixTType.trait.st
+++ b/src/Famix-Traits/FamixTType.trait.st
@@ -12,7 +12,6 @@ Trait {
 		'#typedEntities => FMMany type: #FamixTTypedEntity opposite: #declaredType'
 	],
 	#traits : 'FamixTNamedEntity + FamixTReferenceable',
-	#classTraits : 'FamixTNamedEntity classTrait + FamixTReferenceable classTrait',
 	#category : #'Famix-Traits-Type'
 }
 

--- a/src/Famix-Traits/FamixTType.trait.st
+++ b/src/Famix-Traits/FamixTType.trait.st
@@ -12,6 +12,7 @@ Trait {
 		'#typedEntities => FMMany type: #FamixTTypedEntity opposite: #declaredType'
 	],
 	#traits : 'FamixTNamedEntity + FamixTReferenceable',
+	#classTraits : 'FamixTNamedEntity classTrait + FamixTReferenceable classTrait',
 	#category : #'Famix-Traits-Type'
 }
 
@@ -128,7 +129,7 @@ FamixTType >> typeContainer: anObject [
 FamixTType >> typeContainerGroup [
 	<generated>
 	<navigation: 'TypeContainer'>
-	^ MooseGroup with: self typeContainer
+	^ MooseSpecializedGroup with: self typeContainer
 ]
 
 { #category : #accessing }

--- a/src/Famix-Traits/FamixTypeGroup.class.st
+++ b/src/Famix-Traits/FamixTypeGroup.class.st
@@ -1,13 +1,13 @@
 Class {
 	#name : #FamixTypeGroup,
-	#superclass : #MooseGroup,
+	#superclass : #MooseSpecializedGroup,
 	#category : #'Famix-Traits-Entities'
 }
 
 { #category : #meta }
 FamixTypeGroup class >> annotation [
 
-	<FMClass: #TypeGroup super: #MooseGroup>
+	<FMClass: #TypeGroup super: #MooseSpecializedGroup>
 	<package: #'Famix-Traits'>
 	<generated>
 	^self

--- a/src/Moose-Core-Tests/MooseGroupTest.class.st
+++ b/src/Moose-Core-Tests/MooseGroupTest.class.st
@@ -10,15 +10,6 @@ MooseGroupTest >> actualClass [
 ]
 
 { #category : #tests }
-MooseGroupTest >> testAllModelMethod [
-	| model |
-	model := self twoClasses.
-	self assert: model allModelMethods entities size equals: 3.
-	self assert: (model allModelMethods entities includesAll: model allMethods entities).
-	self flag: #todo. "Once this bug will be fixed, we should add an assertion with stubs methods.https://github.com/moosetechnology/Moose/issues/1800"
-]
-
-{ #category : #tests }
 MooseGroupTest >> testAsMooseGroup [
 	group := #(1 2 3) asMooseGroup.
 	self assert: (group isKindOf: MooseGroup).

--- a/src/Moose-Core-Tests/MooseObjectTest.class.st
+++ b/src/Moose-Core-Tests/MooseObjectTest.class.st
@@ -76,7 +76,7 @@ MooseObjectTest >> testGroupFor [
 	self assert: classGroup class identicalTo: FamixClassGroup.
 	self assert: (classGroup entities includesAll: {entity1 . entity2}).
 	methodGroup := model groupFor: #allMethods.
-	self assert: methodGroup class identicalTo: MooseGroup.
+	self assert: methodGroup class identicalTo: MooseSpecializedGroup.
 	self assertEmpty: methodGroup
 ]
 

--- a/src/Moose-Core-Tests/MooseSpecializedGroupTest.class.st
+++ b/src/Moose-Core-Tests/MooseSpecializedGroupTest.class.st
@@ -1,0 +1,19 @@
+Class {
+	#name : #MooseSpecializedGroupTest,
+	#superclass : #MooseGroupTest,
+	#category : #'Moose-Core-Tests'
+}
+
+{ #category : #helpers }
+MooseSpecializedGroupTest >> actualClass [
+	^ MooseSpecializedGroup
+]
+
+{ #category : #tests }
+MooseSpecializedGroupTest >> testAllModelMethod [
+	| model |
+	model := self twoClasses.
+	self assert: model allModelMethods entities size equals: 3.
+	self assert: (model allModelMethods entities includesAll: model allMethods entities).
+	self flag: #todo. "Once this bug will be fixed, we should add an assertion with stubs methods.https://github.com/moosetechnology/Moose/issues/1800"
+]

--- a/src/Moose-Core/Behavior.extension.st
+++ b/src/Moose-Core/Behavior.extension.st
@@ -14,7 +14,7 @@ Behavior >> mooseInheritsFrom: aClass [
 
 { #category : #'*Moose-Core' }
 Behavior >> relatedGroupType [
-	^ MooseGroup
+	^ MooseSpecializedGroup
 ]
 
 { #category : #'*Moose-Core' }

--- a/src/Moose-Core/MooseAbstractGroup.class.st
+++ b/src/Moose-Core/MooseAbstractGroup.class.st
@@ -51,10 +51,9 @@ MooseAbstractGroup >> \ aCollection [
 ]
 
 { #category : #'adding/removing' }
-MooseAbstractGroup >> add: anItem [ 
-
+MooseAbstractGroup >> add: anItem [
 	self entityStorage add: anItem.
-	self privateState flush. 
+	self privateState flush.
 	^ anItem
 ]
 
@@ -615,9 +614,8 @@ MooseAbstractGroup >> removeAll: aCollection [
 ]
 
 { #category : #'entity collection' }
-MooseAbstractGroup >> removeEntity: anEntity [ 
-	 
-	^self entityStorage remove: anEntity
+MooseAbstractGroup >> removeEntity: anEntity [
+	^ self entityStorage remove: anEntity
 ]
 
 { #category : #loading }

--- a/src/Moose-Core/MooseAbstractGroup.class.st
+++ b/src/Moose-Core/MooseAbstractGroup.class.st
@@ -26,7 +26,9 @@ MooseAbstractGroup class >> annotation [
 
 { #category : #'instance creation' }
 MooseAbstractGroup class >> with: anEntity [
-	^ anEntity ifNil: [ self new ] ifNotNil: [ self withAll: (Array with: anEntity) ]
+	^ anEntity
+		ifNil: [ self new ]
+		ifNotNil: [ self withAll: (Array with: anEntity) ]
 ]
 
 { #category : #'instance creation' }

--- a/src/Moose-Core/MooseGroup.class.st
+++ b/src/Moose-Core/MooseGroup.class.st
@@ -19,47 +19,27 @@ MooseGroup class >> annotation [
 ]
 
 { #category : #'instance creation' }
-MooseGroup class >> new [ 
-	 
-	^self new: 5
-]
-
-{ #category : #'instance creation' }
-MooseGroup class >> new: capacity [ 
-	 
-	^self basicNew initialize: capacity
-]
-
-{ #category : #'instance creation' }
-MooseGroup class >> with: anEntity withDescription: aDescription [ 
-	 
-	^(self with: anEntity) description: aDescription
+MooseGroup class >> with: anEntity withDescription: aDescription [
+	^ (self with: anEntity) description: aDescription
 ]
 
 { #category : #'instance creation' }
 MooseGroup class >> withAll: collection [
-	^ self = MooseGroup
-		ifTrue: [ | wantedClass |
-			wantedClass := collection commonSuperclass relatedGroupType.
-			self withKnownType: wantedClass withAll: collection ]
-		ifFalse: [ self withKnownType: self withAll: collection ]
+	^ (self = MooseGroup
+		ifTrue: [ collection commonSuperclass relatedGroupType ]
+		ifFalse: [ self ]) new
+		addAll: collection;
+		yourself
 ]
 
 { #category : #'instance creation' }
-MooseGroup class >> withAll: entities withDescription: aDescription [ 
-	 
-	^(self withAll: entities) description: aDescription
+MooseGroup class >> withAll: entities withDescription: aDescription [
+	^ (self withAll: entities) description: aDescription
 ]
 
 { #category : #'instance creation' }
-MooseGroup class >> withDescription: aDescription [ 
-	 
-	^self new description: aDescription
-]
-
-{ #category : #'instance creation' }
-MooseGroup class >> withKnownType: anSTClass withAll: collection [ 
-	^ (anSTClass new: collection size) initializeWithAll: collection
+MooseGroup class >> withDescription: aDescription [
+	^ self new description: aDescription
 ]
 
 { #category : #'adding/removing' }
@@ -153,15 +133,9 @@ MooseGroup >> indexOf: anEntity [
 ]
 
 { #category : #initialization }
-MooseGroup >> initialize: capacity [ 
-	 
-	self initialize. 
+MooseGroup >> initialize [
+	super initialize.
 	self description: 'Group'
-]
-
-{ #category : #initialization }
-MooseGroup >> initializeWithAll: aCollection [
-	self entityStorage addAll: aCollection.
 ]
 
 { #category : #'public interface' }

--- a/src/Moose-Core/MooseGroup.class.st
+++ b/src/Moose-Core/MooseGroup.class.st
@@ -1,9 +1,9 @@
 "
-MooseGroup adds on top of an abstract group the ability to change the type of a group when we change the entities inside. This is determined via class names.
+A Moose group is a concrete group of entites in Moose. 
 
-For example, a XYZGroup handles a group of XYZ entities. Thus, ""MooseGroup with: XYZ new"" will return a XYZGroup. The type changing behavior also works at runtime. Thus, ""MooseGroup new add: XYZ"" will also return a XYZGroup.
+It is able to use the caching mecanisme of its super class.
 
-The goal of this abstraction is to provide a home for behavior that is specific to groups of entities. For example, a visualization that makes sense for a group of XYZ entities will become a method in the XYZGroup class.
+A MooseGroup can be specailized by sending the message #specialize. Once it is specialized, its kind will change depending of its content. Check the comment of MooseSpecializedGroup for more infos.
 "
 Class {
 	#name : #MooseGroup,
@@ -24,15 +24,6 @@ MooseGroup class >> with: anEntity withDescription: aDescription [
 ]
 
 { #category : #'instance creation' }
-MooseGroup class >> withAll: collection [
-	^ (self = MooseGroup
-		ifTrue: [ collection commonSuperclass relatedGroupType ]
-		ifFalse: [ self ]) new
-		addAll: collection;
-		yourself
-]
-
-{ #category : #'instance creation' }
 MooseGroup class >> withAll: entities withDescription: aDescription [
 	^ (self withAll: entities) description: aDescription
 ]
@@ -44,39 +35,21 @@ MooseGroup class >> withDescription: aDescription [
 
 { #category : #'adding/removing' }
 MooseGroup >> , aGroup [
-	^ (self copy) 
-		addAll: aGroup; 
+	^ self copy
+		addAll: aGroup;
 		yourself
 ]
 
 { #category : #'adding/removing' }
-MooseGroup >> add: anElement [ 
-	 
-	super add: anElement. 
-	self updateTypeAccordingToEntities.
-	^ anElement 
-]
-
-{ #category : #'adding/removing' }
-MooseGroup >> addAll: collection [ 
-	 
-	self entityStorage addAll: collection. 
-	self updateTypeAccordingToEntities
+MooseGroup >> addAll: collection [
+	self entityStorage addAll: collection
 ]
 
 { #category : #private }
 MooseGroup >> changeTypeTo: aSmalltalkClass [
-	| group | 
-	self class == aSmalltalkClass ifTrue: [^ self].
+	self class == aSmalltalkClass ifTrue: [ ^ self ].
 
-	group := aSmalltalkClass withDescription: self description. 
-	group addAll: self entities. 
-	self become: group
-]
-
-{ #category : #private }
-MooseGroup >> changeTypeToDefaultType [
-	self changeTypeTo: MooseGroup
+	self become: (aSmalltalkClass withAll: self entities withDescription: self description)
 ]
 
 { #category : #enumerating }
@@ -84,33 +57,21 @@ MooseGroup >> collect: aBlock [
 	^ self species withAll: (self entities collect: aBlock)
 ]
 
-{ #category : #private }
-MooseGroup >> commonEntitiesClass [ 
-	 
-	^self entityStorage commonSuperclass
+{ #category : #'public interface' }
+MooseGroup >> copyFrom: startIndex to: endIndex [
+	^ self species withAll: (self entities copyFrom: startIndex to: endIndex)
 ]
 
 { #category : #'public interface' }
-MooseGroup >> copyFrom: startIndex to: endIndex [ 
-	| resultCollection result | 
-	resultCollection := self entities copyFrom: startIndex to: endIndex.
-	result := self species withAll: resultCollection. 
-	^ result	
-]
-
-{ #category : #'public interface' }
-MooseGroup >> distributionOverAGroupOfGroups: aGroupOfGroups [ 
-	 
-	| distribution | 
-	distribution := 0. 
-	aGroupOfGroups 
-		do: 
-			[:eachReferenceGroup |  
-			| intersection | 
-			intersection := self intersection: eachReferenceGroup. 
-			distribution := distribution 
-				+ (intersection size / eachReferenceGroup size)]. 
-	^distribution
+MooseGroup >> distributionOverAGroupOfGroups: aGroupOfGroups [
+	| distribution |
+	distribution := 0.
+	aGroupOfGroups
+		do: [ :eachReferenceGroup | 
+			| intersection |
+			intersection := self intersection: eachReferenceGroup.
+			distribution := distribution + (intersection size / eachReferenceGroup size) ].
+	^ distribution
 ]
 
 { #category : #'public interface' }
@@ -127,9 +88,8 @@ MooseGroup >> encapsulationOfAGroupOfGroups: aGroupOfGroups [
 ]
 
 { #category : #'public interface' }
-MooseGroup >> indexOf: anEntity [ 
-	 
-	^self entities indexOf: anEntity
+MooseGroup >> indexOf: anEntity [
+	^ self entities indexOf: anEntity
 ]
 
 { #category : #initialization }
@@ -139,19 +99,13 @@ MooseGroup >> initialize [
 ]
 
 { #category : #'public interface' }
-MooseGroup >> max: aSymbolOrBlock [ 
-	 
-	^self 
-		inject: (aSymbolOrBlock value: self first) 
-		into: [:max :each | max max: (aSymbolOrBlock value: each)]
+MooseGroup >> max: aSymbolOrBlock [
+	^ self inject: (aSymbolOrBlock value: self first) into: [ :max :each | max max: (aSymbolOrBlock value: each) ]
 ]
 
 { #category : #'public interface' }
-MooseGroup >> min: aSymbolOrBlock [ 
-	 
-	^self 
-		inject: (aSymbolOrBlock value: self first) 
-		into: [:min :each | min min: (aSymbolOrBlock value: each)]
+MooseGroup >> min: aSymbolOrBlock [
+	^ self inject: (aSymbolOrBlock value: self first) into: [ :min :each | min min: (aSymbolOrBlock value: each) ]
 ]
 
 { #category : #accessing }
@@ -163,15 +117,12 @@ MooseGroup >> mooseDescription [
 
 { #category : #accessing }
 MooseGroup >> name [
-
-	^self privateState attributeAt: #privateDescription ifAbsent:[#group]
-	
+	^ self privateState attributeAt: #privateDescription ifAbsent: [ #group ]
 ]
 
 { #category : #'public interface' }
-MooseGroup >> noneSatisfy: aBlock [ 
-	 
-	^self entities noneSatisfy: aBlock
+MooseGroup >> noneSatisfy: aBlock [
+	^ self entities noneSatisfy: aBlock
 ]
 
 { #category : #printing }
@@ -194,17 +145,13 @@ MooseGroup >> reject: aBlock [
 ]
 
 { #category : #'adding/removing' }
-MooseGroup >> remove: anItem [ 
-	 
-	self removeEntity: anItem. 
-	self updateTypeAccordingToEntities
+MooseGroup >> remove: anItem [
+	self removeEntity: anItem
 ]
 
 { #category : #'adding/removing' }
-MooseGroup >> removeAll: collection [ 
-	 
-	collection do: [:each | self removeEntity: each]. 
-	self updateTypeAccordingToEntities
+MooseGroup >> removeAll: collection [
+	collection do: [ :each | self removeEntity: each ]
 ]
 
 { #category : #enumerating }
@@ -213,34 +160,7 @@ MooseGroup >> select: aBlock [
 ]
 
 { #category : #'public interface' }
-MooseGroup >> selectCover: aFraction forMetric: aSymbolOrBlock [
-	"select biggest entities which cover aFraction of the metric property for the whole group. Useful to easily check the 80/20 rule for example:
-		self selectCover: 0.80 forMetric: #numberOfLinesOfCode
-	returns the entities which cover 80% of the code base in number of lines of code"
-	
-	| cutValue sorted tops sum i |
-	self assert: (aFraction >= 0 and: [aFraction <= 1]).
-	cutValue := (self sumNumbers: aSymbolOrBlock) * aFraction.
-	sorted := self asSortedCollection: [:a :b | (aSymbolOrBlock value: a) > (aSymbolOrBlock value: b)].
-	tops := OrderedCollection new.
-	sum := 0. i := 1.
-	[ sum < cutValue and: [ i <= self size ]]
-		whileTrue: [
-			tops add: (sorted at: i).
-			sum := sum + (aSymbolOrBlock value: (sorted at: i)).
-			i := i + 1].
-	^ MoosePropertyGroup withAll: tops from: self using: aSymbolOrBlock
-]
-
-{ #category : #'public interface' }
-MooseGroup >> selectEightyCoverForMetric: aSymbolOrBlock [
-
-	^ self selectCover: 0.80 forMetric: aSymbolOrBlock 
-]
-
-{ #category : #'public interface' }
-MooseGroup >> sort: aBlock [ 
-	 
+MooseGroup >> sort: aBlock [
 	self entities: (self entities sorted: aBlock)
 ]
 
@@ -249,33 +169,19 @@ MooseGroup >> sorted: aBlock [
 	^ self species withAll: (self entities sorted: aBlock)
 ]
 
+{ #category : #'public interface' }
+MooseGroup >> specialize [
+	"Once call, tranforme the MooseGroup into a MooseSpecializedGroup. This group will try to adapt its kind to its content to give more properties to the users to manipulate."
+
+	^ MooseSpecializedGroup withAll: self entities withDescription: self description
+]
+
 { #category : #private }
 MooseGroup >> species [
 	^ MooseGroup
 ]
 
 { #category : #properties }
-MooseGroup >> sumOfPropertyNamed: aPropertyName [ 
-	 
-	^self 
-		inject: 0 
-		into: 
-			[:sum :each |  
-			sum 
-				+ 
-					(each 
-						propertyNamed: aPropertyName 
-						ifNil: [0])]
-]
-
-{ #category : #private }
-MooseGroup >> updateTypeAccordingToEntities [
-	| common wantedType class |
-	common := self commonEntitiesClass.
-	wantedType := common relatedGroupType.
-	self name = wantedType ifTrue: [ ^ self ].
-	class := MooseAbstractGroup allSubclasses 
-		detect: [ :each | each name == wantedType name ]
-		ifNone: [ ^ self changeTypeToDefaultType ].
-	self changeTypeTo: class
+MooseGroup >> sumOfPropertyNamed: aPropertyName [
+	^ self inject: 0 into: [ :sum :each | sum + (each propertyNamed: aPropertyName ifNil: [ 0 ]) ]
 ]

--- a/src/Moose-Core/MooseObject.class.st
+++ b/src/Moose-Core/MooseObject.class.st
@@ -145,7 +145,7 @@ MooseObject class >> relatedGroupType [
 
 	| definingMethods selectedMethods selectedMethod |
 	definingMethods :=(Pragma allNamed: #mooseGroup from: self class to: Object) collect: #method.
-	definingMethods ifEmpty: [ ^ MooseGroup ].
+	definingMethods ifEmpty: [ ^ MooseSpecializedGroup ].
 
 	"We need to find the most specialized method, so we select the lower in the hierarchy."
 	selectedMethods := definingMethods groupedBy: [ :each | each methodClass withAllSuperclasses size ].
@@ -250,9 +250,9 @@ MooseObject >> groupFor: aSelector [
 
 	"aSelector = allPackages, allClasses, allMethods, ... "
 
-	| groupName |
-	groupName := aSelector asString capitalized , ' in ' , self mooseName.
-	^ MooseGroup withAll: (self perform: aSelector) asCollection withDescription: groupName
+	^ MooseSpecializedGroup
+		withAll: (self perform: aSelector) asCollection
+		withDescription: aSelector asString capitalized , ' in ' , self mooseName
 ]
 
 { #category : #printing }

--- a/src/Moose-Core/MooseSpecializedGroup.class.st
+++ b/src/Moose-Core/MooseSpecializedGroup.class.st
@@ -1,0 +1,12 @@
+Class {
+	#name : #MooseSpecializedGroup,
+	#superclass : #MooseGroup,
+	#category : #'Moose-Core'
+}
+
+{ #category : #meta }
+MooseSpecializedGroup class >> annotation [
+	<FMClass: #SpecializedGroup super: #MooseGroup>
+	<package: #Moose>
+
+]

--- a/src/Moose-Core/MooseSpecializedGroup.class.st
+++ b/src/Moose-Core/MooseSpecializedGroup.class.st
@@ -1,3 +1,10 @@
+"
+MooseSpecializedGroup adds on top of a group the ability to change the type of a group when we change the entities inside. This is determined via class names.
+
+For example, a XYZGroup handles a group of XYZ entities. Thus, ""MooseSpecializedGroup with: XYZ new"" will return a XYZGroup. The type changing behavior also works at runtime. Thus, ""MooseSpecializedGroup new add: XYZ"" will also return a XYZGroup.
+
+The goal of this abstraction is to provide a home for behavior that is specific to groups of entities. For example, a visualization that makes sense for a group of XYZ entities will become a method in the XYZGroup class.
+"
 Class {
 	#name : #MooseSpecializedGroup,
 	#superclass : #MooseGroup,
@@ -9,4 +16,70 @@ MooseSpecializedGroup class >> annotation [
 	<FMClass: #SpecializedGroup super: #MooseGroup>
 	<package: #Moose>
 
+]
+
+{ #category : #'instance creation' }
+MooseSpecializedGroup class >> withAll: collection [
+	^ (self = MooseSpecializedGroup
+		ifTrue: [ collection commonSuperclass relatedGroupType ]
+		ifFalse: [ self ]) new
+		initializeWithAll: collection;
+		yourself
+]
+
+{ #category : #'adding/removing' }
+MooseSpecializedGroup >> add: anElement [
+	super add: anElement.
+	self updateTypeAccordingToEntities.
+	^ anElement
+]
+
+{ #category : #'adding/removing' }
+MooseSpecializedGroup >> addAll: aCollection [
+	super addAll: aCollection.
+	self updateTypeAccordingToEntities
+]
+
+{ #category : #private }
+MooseSpecializedGroup >> changeTypeToDefaultType [
+	self changeTypeTo: MooseSpecializedGroup
+]
+
+{ #category : #private }
+MooseSpecializedGroup >> commonEntitiesClass [
+	^ self entityStorage commonSuperclass
+]
+
+{ #category : #initialization }
+MooseSpecializedGroup >> initializeWithAll: aCollection [
+	super addAll: aCollection
+]
+
+{ #category : #'adding/removing' }
+MooseSpecializedGroup >> remove: anEntity [
+	super remove: anEntity.
+	self updateTypeAccordingToEntities
+]
+
+{ #category : #'adding/removing' }
+MooseSpecializedGroup >> removeAll: aCollection [
+	super removeAll: aCollection.
+	self updateTypeAccordingToEntities
+]
+
+{ #category : #private }
+MooseSpecializedGroup >> species [
+	^ MooseSpecializedGroup
+]
+
+{ #category : #private }
+MooseSpecializedGroup >> updateTypeAccordingToEntities [
+	| common wantedType class |
+	common := self commonEntitiesClass.
+	wantedType := common relatedGroupType.
+	self name = wantedType ifTrue: [ ^ self ].
+	class := MooseAbstractGroup allSubclasses
+		detect: [ :each | each name == wantedType name ]
+		ifNone: [ ^ self changeTypeToDefaultType ].
+	self changeTypeTo: class
 ]

--- a/src/Moose-SmalltalkImporter-LAN-Tests/LANMooseGroupTest.class.st
+++ b/src/Moose-SmalltalkImporter-LAN-Tests/LANMooseGroupTest.class.st
@@ -7,7 +7,8 @@ Class {
 { #category : #utilities }
 LANMooseGroupTest >> model [
 	" to debug and avoid caching behavior: LANPackageTestResource reset."
-	^ LANPackageTestResource current model .
+
+	^ LANPackageTestResource current model
 ]
 
 { #category : #tests }
@@ -38,7 +39,7 @@ LANMooseGroupTest >> testClassGroupType [
 	| group aCollection numberOfClasses |
 	aCollection := self model allClasses asOrderedCollection.
 	numberOfClasses := aCollection size.
-	group := MooseGroup withAll: aCollection.
+	group := MooseSpecializedGroup withAll: aCollection.
 	self assert: (group isMemberOf: FamixClassGroup).
 	self assert: self model allClasses size equals: numberOfClasses
 ]
@@ -46,7 +47,7 @@ LANMooseGroupTest >> testClassGroupType [
 { #category : #tests }
 LANMooseGroupTest >> testCollectGroupType [
 	| collectedClasses |
-	collectedClasses := self model allMethods collect: #parentType.
+	collectedClasses := (self model allMethods collect: #parentType) specialize.
 	self assert: (collectedClasses isKindOf: FamixTypeGroup)
 ]
 
@@ -74,7 +75,7 @@ LANMooseGroupTest >> testFlatCollect [
 { #category : #tests }
 LANMooseGroupTest >> testFlatCollectType [
 	| allMethods |
-	allMethods := self model allClasses flatCollect: [:each | each methods ].
+	allMethods := (self model allClasses flatCollect: #methods) specialize.
 	self assert: (allMethods isKindOf: FamixMethodGroup)
 ]
 
@@ -97,17 +98,17 @@ LANMooseGroupTest >> testGroupType [
 	| group numberOfClasses numberOfMethods |
 	numberOfClasses := self model allClasses size.
 	numberOfMethods := self model allMethods size.
-	group := MooseGroup withAll: self model allClasses entities.
+	group := MooseSpecializedGroup withAll: self model allClasses entities.
 	self assert: (group isMemberOf: FamixClassGroup).
 	group addAll: self model allMethods.
-	self assert: (group isMemberOf: MooseGroup).
+	self assert: (group isMemberOf: MooseSpecializedGroup).
 	group removeAll: self model allMethods.
 	self assert: (group isMemberOf: FamixClassGroup).
 	group add: self model allMethods first.
-	self assert: (group isMemberOf: MooseGroup).
+	self assert: (group isMemberOf: MooseSpecializedGroup).
 	group remove: self model allMethods first.
 	self assert: (group isMemberOf: FamixClassGroup).
-	group := MooseGroup withAll: self model allMethods entities.
+	group := MooseSpecializedGroup withAll: self model allMethods entities.
 	self assert: (group isMemberOf: FamixMethodGroup).
 	self assert: self model allClasses size equals: numberOfClasses.
 	self assert: self model allMethods size equals: numberOfMethods
@@ -120,16 +121,16 @@ LANMooseGroupTest >> testHeterogeneousGroupType [
 	numberOfMethods := self model allMethods size.
 	aCollection := self model allClasses asOrderedCollection.
 	self assert: self model allClasses size equals: numberOfClasses.
-	group := MooseGroup withAll: aCollection.
-	self deny: (group isMemberOf: MooseGroup).
+	group := MooseSpecializedGroup withAll: aCollection.
+	self deny: (group isMemberOf: MooseSpecializedGroup).
 	self assert: (group isMemberOf: FamixClassGroup).
 	group addAll: self model allMethods asOrderedCollection.
 	self assert: self model allMethods size equals: numberOfMethods.
-	self assert: (group isMemberOf: MooseGroup).
+	self assert: (group isMemberOf: MooseSpecializedGroup).
 	aCollection := self model allMethods asOrderedCollection.
 	aCollection addAll: self model allClasses asOrderedCollection.
-	group := MooseGroup withAll: aCollection.
-	self assert: (group isMemberOf: MooseGroup).
+	group := MooseSpecializedGroup withAll: aCollection.
+	self assert: (group isMemberOf: MooseSpecializedGroup).
 	self assert: self model allClasses size equals: numberOfClasses.
 	self assert: self model allMethods size equals: numberOfMethods
 ]
@@ -161,13 +162,6 @@ LANMooseGroupTest >> testPrintOn [
 	| printOn |
 	printOn := String streamContents: [ :stream | self model allTypes printOn: stream ].
 	self assert: (printOn beginsWith: 'All famixttypes (' , self model allTypes size asString)
-]
-
-{ #category : #tests }
-LANMooseGroupTest >> testSelectEightyCoverForMetric [
-	| top |
-	top := self model allMethods selectEightyCoverForMetric: #numberOfLinesOfCode.
-	self denyEmpty: top
 ]
 
 { #category : #tests }


### PR DESCRIPTION
I proposed to not specialise the moose groups by default when we call #asMooseGroup. Instead we would create a MooseGroup. Then, if we want a specialised group, to get more info in the UI for example, we can call #specialize on it. From then on, when we will do #select:, #collect:, etc on it, it will keep trying to specialise it.