### PR TITLE
clean-private-state-initialization

### DIFF
--- a/src/Famix-Deprecated/MooseEntityState.extension.st
+++ b/src/Famix-Deprecated/MooseEntityState.extension.st
@@ -7,6 +7,14 @@ MooseEntityState >> allProperties [
 ]
 
 { #category : #'*Famix-Deprecated' }
+MooseEntityState >> cache: selector initializer: aBlock [
+	self
+		deprecated: 'Uses #cacheAt:ifAbsentPut: instead'
+		transformWith: '`@receiver cache: `@arg1 initializer: `@arg2' -> '`@receiver cacheAt: `@arg1 ifAbsentPut: `@arg2'.
+	^ self cacheAt: selector ifAbsentPut: aBlock
+]
+
+{ #category : #'*Famix-Deprecated' }
 MooseEntityState >> flushGroups [
 	self deprecated: 'Use #flush instead' transformWith: '`@receiver flushGroups' -> '`@receiver flush'.
 	self flush

--- a/src/Moose-Core/BlockClosure.extension.st
+++ b/src/Moose-Core/BlockClosure.extension.st
@@ -5,12 +5,3 @@ BlockClosure >> asSortBlock [
 
 	^ [:a :b | (self value: a) <= (self value: b)]
 ]
-
-{ #category : #'*moose-core' }
-BlockClosure >> cullValue: arguments [
-	"Evaluates the receiver with as many arguments as requiered."
-
-	self numArgs = 0 ifTrue: [ ^self value ].
-	self numArgs = 1 ifTrue: [ ^self value: arguments first ].
-	^self valueWithArguments: (arguments  copyFrom: 1 to: self numArgs).
-]

--- a/src/Moose-Core/MooseEntityState.class.st
+++ b/src/Moose-Core/MooseEntityState.class.st
@@ -64,11 +64,6 @@ MooseEntityState >> attributes [
 ]
 
 { #category : #'accessing cache' }
-MooseEntityState >> cache: selector initializer: aBlock [
-	^ self cacheAt: selector ifAbsentPut: [ aBlock cullValue: self entity ]
-]
-
-{ #category : #'accessing cache' }
 MooseEntityState >> cacheAt: name ifAbsent: aBlock [
 	^ cache at: name ifAbsent: [ aBlock value ]
 ]

--- a/src/Moose-Core/MooseObject.class.st
+++ b/src/Moose-Core/MooseObject.class.st
@@ -294,9 +294,8 @@ MooseObject >> isOfType: aClassFAMIX [
 ]
 
 { #category : #properties }
-MooseObject >> lookUpPropertyNamed: selector computedAs: aBlock [ 
-	 
-	^self privateState cache: selector initializer: aBlock
+MooseObject >> lookUpPropertyNamed: selector computedAs: aBlock [
+	^ self privateState cacheAt: selector ifAbsentPut: aBlock
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
Clean private state initialization

Deprecate usuless methods that can be replaced with the rest of the API in a more efficient way