### PR TITLE
push-up-local-moose-model-to-be-usable-on-groups

### DIFF
--- a/src/Famix-CommentAnalyzer/FamixCAAnalyzer.class.st
+++ b/src/Famix-CommentAnalyzer/FamixCAAnalyzer.class.st
@@ -100,9 +100,7 @@ FamixCAAnalyzer >> model: anObject [
 
 { #category : #accessing }
 FamixCAAnalyzer >> mooseModel [
-	^ self model isMooseModel
-		ifTrue: [ self model ]
-		ifFalse: [ self model mooseModel ]
+	^ self model localMooseModel
 ]
 
 { #category : #computation }

--- a/src/Moose-Core/MooseEntity.class.st
+++ b/src/Moose-Core/MooseEntity.class.st
@@ -213,11 +213,6 @@ MooseEntity >> isStub: aBoolean [
 ]
 
 { #category : #accessing }
-MooseEntity >> localMooseModel [
-	^ self mooseModel
-]
-
-{ #category : #accessing }
 MooseEntity >> mooseModel [
 	"Answers the model containing the current entity"
 

--- a/src/Moose-Core/MooseObject.class.st
+++ b/src/Moose-Core/MooseObject.class.st
@@ -275,6 +275,11 @@ MooseObject >> isOfType: aClassFAMIX [
 	^ self class isOfType: aClassFAMIX
 ]
 
+{ #category : #accessing }
+MooseObject >> localMooseModel [
+	^ self mooseModel
+]
+
 { #category : #properties }
 MooseObject >> lookUpPropertyNamed: selector computedAs: aBlock [
 	^ self privateState cacheAt: selector ifAbsentPut: aBlock


### PR DESCRIPTION
Push up #localMooseModel to be usable on groups.

My goal is to avoid code such as:

(aMooseGroup isMooseModel
		ifTrue: [ aMooseGroup ]
		ifFalse: [ aMooseGroup mooseModel ])