### PR TITLE
avoid-shadowed-variables

### DIFF
--- a/src/Famix-Traits/FamixTSourceAnchor.trait.st
+++ b/src/Famix-Traits/FamixTSourceAnchor.trait.st
@@ -96,10 +96,10 @@ FamixTSourceAnchor >> sourceText [
 ]
 
 { #category : #accessing }
-FamixTSourceAnchor >> sourceTextFrom: startPos to: endPos [
-	self sourceText size < endPos ifTrue: [ ^ '' ].
+FamixTSourceAnchor >> sourceTextFrom: startPosition to: endPosition [
+	self sourceText size < endPosition ifTrue: [ ^ '' ].
 	
-	^ self sourceText copyFrom: startPos to: endPos
+	^ self sourceText copyFrom: startPosition to: endPosition
 ]
 
 { #category : #testing }


### PR DESCRIPTION
Avoid shadowed variables

```
SystemNotification: FamixTest1IndexedFileAnchor>>sourceTextFrom:to:(endPos is shadowed)

SystemNotification: FamixTest1IndexedFileAnchor>>sourceTextFrom:to:(startPos is shadowed)

SystemNotification: FamixTest1IndexedFileAnchor>>sourceTextFrom:to:(endPos is shadowed)

SystemNotification: FamixTest1IndexedFileAnchor>>sourceTextFrom:to:(startPos is shadowed)

SystemNotification: FamixTest1IndexedFileAnchor>>sourceTextFrom:to:(endPos is shadowed)
```