### PR TITLE
Fixing navigation of FAMIXException

### DIFF
--- a/src/Famix-Compatibility-Entities/FAMIXException.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXException.class.st
@@ -28,7 +28,8 @@ FAMIXException >> definingEntity: aMethod [
 
 { #category : #compatibility }
 FAMIXException >> definingMethod [
-
+	<FMProperty: #definingMethod type: #FAMIXMethod>
+	<FMComment: 'This property is for compatibility purpose. It is used by the old generator of MSE files'>
 	^ self definingEntity
 	
 
@@ -36,8 +37,6 @@ FAMIXException >> definingMethod [
 
 { #category : #compatibility }
 FAMIXException >> definingMethod: aMethod [
-	<FMProperty: #definingMethod type: #FAMIXMethod>
-	<FMComment: 'This property is for compatibility purpose. It is used by the old generator of MSE files'>
 	^ self definingEntity: aMethod
 ]
 


### PR DESCRIPTION
During the navigation, the inspector perform the selector of the property to get the value. So we have to put the pragma in the getter