### PR TITLE
fix importing references for compatibility model

### DIFF
--- a/src/Famix-Compatibility-Entities/FAMIXReference.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXReference.class.st
@@ -15,6 +15,19 @@ FAMIXReference class >> annotation [
 	^self
 ]
 
+{ #category : #'as yet unclassified' }
+FAMIXReference >> handleFameProperty: aSymbol value: anObject [
+	"Handle correctly the source and target properties"
+
+	| value |
+	value := (anObject isCollection and: [ anObject size = 1 ])
+		ifTrue: [ anObject anyOne ]
+		ifFalse: [ anObject ].
+	(aSymbol = #source or: [ aSymbol = #target ])
+		ifTrue: [ self perform: aSymbol asSymbol asMutator with: value ]
+		ifFalse: [ super handleFameProperty: aSymbol value: value ]
+]
+
 { #category : #'Famix-Implementation' }
 FAMIXReference >> mooseNameOn: aStream [
 	"aStream nextPutAll: 'Reference'."

--- a/src/Famix-Compatibility-Entities/FAMIXReference.class.st
+++ b/src/Famix-Compatibility-Entities/FAMIXReference.class.st
@@ -15,7 +15,7 @@ FAMIXReference class >> annotation [
 	^self
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #properties }
 FAMIXReference >> handleFameProperty: aSymbol value: anObject [
 	"Handle correctly the source and target properties"
 


### PR DESCRIPTION
Right now, the references are stored in private state.
Thus, we cannot access them from primary entities (method/classes/etc.)

This will fix the problem for the compatibility model (And the problem will not exists in the future model since we will update parser)