### PR TITLE
Add asMooseSpecializedGroup 

### DIFF
--- a/src/Moose-Core/Collection.extension.st
+++ b/src/Moose-Core/Collection.extension.st
@@ -6,6 +6,11 @@ Collection >> asMooseGroup [
 ]
 
 { #category : #'*Moose-Core' }
+Collection >> asMooseSpecializedGroup [
+	^ MooseSpecializedGroup withAll: self
+]
+
+{ #category : #'*Moose-Core' }
 Collection >> commonSuperclass [
 	"Answer the most specific common super class of the receiver's
 	elements, returns Object on empty collections."

--- a/src/Moose-Core/Object.extension.st
+++ b/src/Moose-Core/Object.extension.st
@@ -14,6 +14,11 @@ Object >> asMooseGroup [
 ]
 
 { #category : #'*moose-core' }
+Object >> asMooseSpecializedGroup [
+	^ MooseSpecializedGroup with: self
+]
+
+{ #category : #'*moose-core' }
 Object >> hasUniqueMooseNameInModel [
 	^false
 ]


### PR DESCRIPTION
add asMooseSpecializedGroup to convert an OrderedCollection to a specialized group (it can be used for the special method for groups of a specialized kind of entities.

For example, I have an OrderedCollection of FamixJavaClass and I want to convert it into a FamixClassGroup.