### PR TITLE
Rename MQScopeAbstractTypeStrategy to stop strategy

### DIFF
--- a/src/Moose-Query/MQScopeAbstractStopStrategy.class.st
+++ b/src/Moose-Query/MQScopeAbstractStopStrategy.class.st
@@ -7,42 +7,42 @@ I am a strategy used by the scoping queries to define on which kind of entity th
 I am moslty here for performance reasons.
 "
 Class {
-	#name : #MQScopeAbstractTypeStrategy,
+	#name : #MQScopeAbstractStopStrategy,
 	#superclass : #Object,
 	#category : #'Moose-Query-Scoping'
 }
 
 { #category : #testing }
-MQScopeAbstractTypeStrategy class >> isAbstract [
-	^ self = MQScopeAbstractTypeStrategy
+MQScopeAbstractStopStrategy class >> isAbstract [
+	^ self = MQScopeAbstractStopStrategy
 ]
 
 { #category : #accessing }
-MQScopeAbstractTypeStrategy class >> strategies [
+MQScopeAbstractStopStrategy class >> strategies [
 	^ self allSubclasses reject: #isAbstract
 ]
 
 { #category : #comparing }
-MQScopeAbstractTypeStrategy >> = anObject [
+MQScopeAbstractStopStrategy >> = anObject [
 	super = anObject ifTrue: [ ^ true ].
 
 	^ self class = anObject class
 ]
 
 { #category : #comparing }
-MQScopeAbstractTypeStrategy >> hash [
+MQScopeAbstractStopStrategy >> hash [
 	"Answer an integer value that is related to the identity of the receiver."
 
 	^ self class hash
 ]
 
 { #category : #testing }
-MQScopeAbstractTypeStrategy >> isOfRightType: anEntity [
+MQScopeAbstractStopStrategy >> shouldBeSelected: anEntity [
 	^ self subclassResponsibility
 ]
 
 { #category : #printing }
-MQScopeAbstractTypeStrategy >> storeOn: aStream [
+MQScopeAbstractStopStrategy >> storeOn: aStream [
 	aStream
 		nextPutAll: self class name;
 		nextPutAll: ' new'

--- a/src/Moose-Query/MQScopeAllTypesStrategy.class.st
+++ b/src/Moose-Query/MQScopeAllTypesStrategy.class.st
@@ -8,11 +8,11 @@ I am moslty here for performance reasons.
 "
 Class {
 	#name : #MQScopeAllTypesStrategy,
-	#superclass : #MQScopeAbstractTypeStrategy,
+	#superclass : #MQScopeAbstractStopStrategy,
 	#category : #'Moose-Query-Scoping'
 }
 
 { #category : #testing }
-MQScopeAllTypesStrategy >> isOfRightType: anEntity [
+MQScopeAllTypesStrategy >> shouldBeSelected: anEntity [
 	^ true
 ]

--- a/src/Moose-Query/MQScopePropertyStrategy.class.st
+++ b/src/Moose-Query/MQScopePropertyStrategy.class.st
@@ -1,6 +1,14 @@
+"
+Description
+--------------------
+
+I am a strategy used by the scoping queries to define the query should match any of the entities that satisfy the property selector.
+
+I am moslty here for performance reasons.
+"
 Class {
 	#name : #MQScopePropertyStrategy,
-	#superclass : #MQScopeAbstractTypeStrategy,
+	#superclass : #MQScopeAbstractStopStrategy,
 	#instVars : [
 		'property'
 	],
@@ -27,13 +35,6 @@ MQScopePropertyStrategy >> hash [
 ]
 
 { #category : #accessing }
-MQScopePropertyStrategy >> isOfRightType: anEntity [
-	^ [ anEntity perform: self property ]
-		on: MessageNotUnderstood
-		do: [ false ]
-]
-
-{ #category : #accessing }
 MQScopePropertyStrategy >> property [
 	^ property
 ]
@@ -41,4 +42,11 @@ MQScopePropertyStrategy >> property [
 { #category : #accessing }
 MQScopePropertyStrategy >> property: anObject [
 	property := anObject
+]
+
+{ #category : #accessing }
+MQScopePropertyStrategy >> shouldBeSelected: anEntity [
+	^ [ anEntity perform: self property ]
+		on: MessageNotUnderstood
+		do: [ false ]
 ]

--- a/src/Moose-Query/MQScopeQuery.class.st
+++ b/src/Moose-Query/MQScopeQuery.class.st
@@ -34,7 +34,7 @@ Class {
 		'until',
 		'isRecursive',
 		'direction',
-		'typeStrategy'
+		'stopStrategy'
 	],
 	#category : #'Moose-Query-Scoping'
 }
@@ -70,7 +70,7 @@ MQScopeQuery class >> recursivelyScopes: aCollectionOfType direction: aClass unt
 { #category : #'instance creation' }
 MQScopeQuery class >> scope: aFamixType direction: aClass [
 	^ self new
-		typeStrategy: (MQScopeTypeStrategy scope: aFamixType);
+		stopStrategy: (MQScopeTypeStrategy scope: aFamixType);
 		direction: aClass;
 		yourself
 ]
@@ -85,7 +85,7 @@ MQScopeQuery class >> scope: aFamixType direction: aClass until: aValuable [
 { #category : #'instance creation' }
 MQScopeQuery class >> scopes: aCollectionOfType direction: aClass [
 	^ self new
-		typeStrategy: (MQScopeTypesStrategy scopes: aCollectionOfType);
+		stopStrategy: (MQScopeTypesStrategy scopes: aCollectionOfType);
 		direction: aClass;
 		yourself
 ]
@@ -141,19 +141,19 @@ MQScopeQuery >> isRecursive: anObject [
 
 { #category : #DSL }
 MQScopeQuery >> ofAnyType [
-	typeStrategy := MQScopeAllTypesStrategy new.
+	stopStrategy := MQScopeAllTypesStrategy new.
 	^ self execute
 ]
 
 { #category : #DSL }
 MQScopeQuery >> ofAnyType: aCollection [
-	typeStrategy := MQScopeTypesStrategy scopes: aCollection.
+	stopStrategy := MQScopeTypesStrategy scopes: aCollection.
 	^ self execute
 ]
 
 { #category : #DSL }
 MQScopeQuery >> ofType: aFamixType [
-	typeStrategy := MQScopeTypeStrategy scope: aFamixType.
+	stopStrategy := MQScopeTypeStrategy scope: aFamixType.
 	^ self execute
 ]
 
@@ -165,7 +165,7 @@ MQScopeQuery >> recursively [
 { #category : #execution }
 MQScopeQuery >> scopeFor: anEntity direction: aDirection [
 	| selectors |
-	(self typeStrategy shouldBeSelected: anEntity)
+	(self stopStrategy shouldBeSelected: anEntity)
 		ifTrue: [ self add: anEntity.
 			self isRecursive ifFalse: [ ^ self result ] ].
 
@@ -181,13 +181,13 @@ MQScopeQuery >> shouldStopOn: anEntity [
 ]
 
 { #category : #accessing }
-MQScopeQuery >> typeStrategy [
-	^ typeStrategy
+MQScopeQuery >> stopStrategy [
+	^ stopStrategy
 ]
 
 { #category : #accessing }
-MQScopeQuery >> typeStrategy: anObject [
-	typeStrategy := anObject
+MQScopeQuery >> stopStrategy: anObject [
+	stopStrategy := anObject
 ]
 
 { #category : #accessing }
@@ -202,6 +202,6 @@ MQScopeQuery >> until: anObject [
 
 { #category : #DSL }
 MQScopeQuery >> withProperty: aSymbol [
-	typeStrategy := MQScopePropertyStrategy property: aSymbol. 
+	stopStrategy := MQScopePropertyStrategy property: aSymbol. 
 	^ self execute
 ]

--- a/src/Moose-Query/MQScopeQuery.class.st
+++ b/src/Moose-Query/MQScopeQuery.class.st
@@ -165,7 +165,7 @@ MQScopeQuery >> recursively [
 { #category : #execution }
 MQScopeQuery >> scopeFor: anEntity direction: aDirection [
 	| selectors |
-	(self typeStrategy isOfRightType: anEntity)
+	(self typeStrategy shouldBeSelected: anEntity)
 		ifTrue: [ self add: anEntity.
 			self isRecursive ifFalse: [ ^ self result ] ].
 

--- a/src/Moose-Query/MQScopeTypeStrategy.class.st
+++ b/src/Moose-Query/MQScopeTypeStrategy.class.st
@@ -8,7 +8,7 @@ I am moslty here for performance reasons.
 "
 Class {
 	#name : #MQScopeTypeStrategy,
-	#superclass : #MQScopeAbstractTypeStrategy,
+	#superclass : #MQScopeAbstractStopStrategy,
 	#instVars : [
 		'scope'
 	],
@@ -34,11 +34,6 @@ MQScopeTypeStrategy >> hash [
 	^ super hash bitXor: scope hash
 ]
 
-{ #category : #testing }
-MQScopeTypeStrategy >> isOfRightType: anEntity [
-	^ anEntity isOfType: scope
-]
-
 { #category : #accessing }
 MQScopeTypeStrategy >> scope [
 	^ scope
@@ -47,6 +42,11 @@ MQScopeTypeStrategy >> scope [
 { #category : #accessing }
 MQScopeTypeStrategy >> scope: anObject [
 	scope := anObject
+]
+
+{ #category : #testing }
+MQScopeTypeStrategy >> shouldBeSelected: anEntity [
+	^ anEntity isOfType: scope
 ]
 
 { #category : #printing }

--- a/src/Moose-Query/MQScopeTypesStrategy.class.st
+++ b/src/Moose-Query/MQScopeTypesStrategy.class.st
@@ -8,7 +8,7 @@ I am moslty here for performance reasons.
 "
 Class {
 	#name : #MQScopeTypesStrategy,
-	#superclass : #MQScopeAbstractTypeStrategy,
+	#superclass : #MQScopeAbstractStopStrategy,
 	#instVars : [
 		'scopes'
 	],
@@ -34,11 +34,6 @@ MQScopeTypesStrategy >> hash [
 	^ super hash bitXor: scopes hash
 ]
 
-{ #category : #testing }
-MQScopeTypesStrategy >> isOfRightType: anEntity [
-	^ scopes anySatisfy: [ :aType | anEntity isOfType: aType ]
-]
-
 { #category : #accessing }
 MQScopeTypesStrategy >> scopes [
 	^ scopes
@@ -47,6 +42,11 @@ MQScopeTypesStrategy >> scopes [
 { #category : #accessing }
 MQScopeTypesStrategy >> scopes: anObject [
 	scopes := anObject
+]
+
+{ #category : #testing }
+MQScopeTypesStrategy >> shouldBeSelected: anEntity [
+	^ scopes anySatisfy: [ :aType | anEntity isOfType: aType ]
 ]
 
 { #category : #printing }


### PR DESCRIPTION
fix #151 

Rename MQScopeAbstractTypeStrategy to stop strategy
+ rename its attributes and getter and setter