### PR TITLE
implement generic source and target

### DIFF
--- a/src/Famix-Java-Entities/FamixJavaInvocation.class.st
+++ b/src/Famix-Java-Entities/FamixJavaInvocation.class.st
@@ -32,7 +32,7 @@ FamixJavaInvocation >> getReceivingFAMIXClass [
 
 { #category : #printing }
 FamixJavaInvocation >> gtDisplayOn: aStream [
-	self source ifNotNil: [ self source gtDisplayOn: aStream ].
+	self sender ifNotNil: [ self source gtDisplayOn: aStream ].
 	aStream nextPutAll: ' -> '.
 	self receiver ifNotNil: [ aStream nextPutAll: self receiver name ].
 	aStream nextPut: $#.

--- a/src/Famix-Traits/FamixTAccess.trait.st
+++ b/src/Famix-Traits/FamixTAccess.trait.st
@@ -20,6 +20,7 @@ Trait {
 		'#variable => FMOne type: #FamixTAccessible opposite: #incomingAccesses'
 	],
 	#traits : 'FamixTAssociation',
+	#classTraits : 'FamixTAssociation classTrait',
 	#category : #'Famix-Traits-Access'
 }
 
@@ -91,26 +92,6 @@ FamixTAccess >> isWrite: anObject [
 FamixTAccess >> printOn: aStream [
 	super printOn: aStream.
 	aStream nextPutAll: ' (Access)'
-]
-
-{ #category : #accessing }
-FamixTAccess >> source [
-	^ self accessor
-]
-
-{ #category : #accessing }
-FamixTAccess >> source: anAccessor [
-	self accessor: anAccessor 
-]
-
-{ #category : #accessing }
-FamixTAccess >> target [
-	^ self variable 
-]
-
-{ #category : #accessing }
-FamixTAccess >> target: aTarget [
-	self variable: aTarget
 ]
 
 { #category : #accessing }

--- a/src/Famix-Traits/FamixTAssociation.trait.st
+++ b/src/Famix-Traits/FamixTAssociation.trait.st
@@ -24,6 +24,7 @@ Trait {
 		'#previous => FMOne type: #FamixTAssociation opposite: #next'
 	],
 	#traits : 'FamixTSourceEntity + TAssociationMetaLevelDependency',
+	#classTraits : 'FamixTSourceEntity classTrait + TAssociationMetaLevelDependency classTrait',
 	#category : #'Famix-Traits-Association'
 }
 
@@ -117,20 +118,32 @@ FamixTAssociation >> previous: anObject [
 
 { #category : #accessing }
 FamixTAssociation >> source [
-	^ self explicitRequirement
+	^ self sourceSelector value: self
 ]
 
 { #category : #accessing }
 FamixTAssociation >> source: aSource [
-	self explicitRequirement
+	self perform: (self sourceSelector , ':') with: aSource
+]
+
+{ #category : #accessing }
+FamixTAssociation >> sourceSelector [
+	^ (self mooseDescription allComplexProperties detect: #isSource)
+		implementingSelector
 ]
 
 { #category : #accessing }
 FamixTAssociation >> target [
-	^ self explicitRequirement
+	^ self targetSelector value: self
 ]
 
 { #category : #accessing }
 FamixTAssociation >> target: aTarget [
-	self explicitRequirement
+	self perform: (self targetSelector , ':') with: aTarget
+]
+
+{ #category : #accessing }
+FamixTAssociation >> targetSelector [
+	^ (self mooseDescription allComplexProperties detect: #isTarget)
+		implementingSelector
 ]

--- a/src/Famix-Traits/FamixTInheritance.trait.st
+++ b/src/Famix-Traits/FamixTInheritance.trait.st
@@ -5,6 +5,7 @@ Trait {
 		'#superclass => FMOne type: #FamixTWithInheritances opposite: #subInheritances'
 	],
 	#traits : 'FamixTAssociation',
+	#classTraits : 'FamixTAssociation classTrait',
 	#category : #'Famix-Traits-Inheritance'
 }
 
@@ -22,16 +23,6 @@ FamixTInheritance >> isInheritance [
 
 	<generated>
 	^ true
-]
-
-{ #category : #accessing }
-FamixTInheritance >> source [
-	^ self subclass
-]
-
-{ #category : #accessing }
-FamixTInheritance >> source: aSubclass [
-	self subclass: aSubclass
 ]
 
 { #category : #accessing }
@@ -66,14 +57,4 @@ FamixTInheritance >> superclass: anObject [
 
 	<generated>
 	superclass := anObject
-]
-
-{ #category : #accessing }
-FamixTInheritance >> target [
-	^ self superclass
-]
-
-{ #category : #accessing }
-FamixTInheritance >> target: aSuperclass [
-	self superclass: aSuperclass
 ]

--- a/src/Famix-Traits/FamixTInvocation.trait.st
+++ b/src/Famix-Traits/FamixTInvocation.trait.st
@@ -18,6 +18,7 @@ Trait {
 		'#sender => FMOne type: #FamixTWithInvocations opposite: #outgoingInvocations'
 	],
 	#traits : 'FamixTAssociation',
+	#classTraits : 'FamixTAssociation classTrait',
 	#category : #'Famix-Traits-Invocation'
 }
 
@@ -102,24 +103,4 @@ FamixTInvocation >> sender: anObject [
 
 	<generated>
 	sender := anObject
-]
-
-{ #category : #accessing }
-FamixTInvocation >> source [
-	^ self sender
-]
-
-{ #category : #accessing }
-FamixTInvocation >> source: aSender [
-	self sender: aSender
-]
-
-{ #category : #accessing }
-FamixTInvocation >> target [
-	^ self candidates
-]
-
-{ #category : #accessing }
-FamixTInvocation >> target: aCollCandidates [
-	self candidates: aCollCandidates 
 ]

--- a/src/Famix-Traits/FamixTReference.trait.st
+++ b/src/Famix-Traits/FamixTReference.trait.st
@@ -18,6 +18,7 @@ Trait {
 		'#referredType => FMOne type: #FamixTReferenceable opposite: #incomingReferences'
 	],
 	#traits : 'FamixTAssociation',
+	#classTraits : 'FamixTAssociation classTrait',
 	#category : #'Famix-Traits-Reference'
 }
 
@@ -74,24 +75,4 @@ FamixTReference >> referredType: anObject [
 
 	<generated>
 	referredType := anObject
-]
-
-{ #category : #accessing }
-FamixTReference >> source [
-	^ self referencer
-]
-
-{ #category : #accessing }
-FamixTReference >> source: aSource [
-	self referencer: aSource 
-]
-
-{ #category : #accessing }
-FamixTReference >> target [
-	^ referredType 
-]
-
-{ #category : #accessing }
-FamixTReference >> target: aTarget [
-	self referredType: aTarget 
 ]

--- a/src/Famix-Traits/FamixTTraitUsage.trait.st
+++ b/src/Famix-Traits/FamixTTraitUsage.trait.st
@@ -5,6 +5,7 @@ Trait {
 		'#user => FMOne type: #FamixTTraitUser opposite: #outgoingTraitUsages'
 	],
 	#traits : 'FamixTAssociation',
+	#classTraits : 'FamixTAssociation classTrait',
 	#category : #'Famix-Traits-Trait'
 }
 
@@ -15,26 +16,6 @@ FamixTTraitUsage classSide >> annotation [
 	<package: #'Famix-Traits'>
 	<generated>
 	^self
-]
-
-{ #category : #accessing }
-FamixTTraitUsage >> source [
-	^ self user
-]
-
-{ #category : #accessing }
-FamixTTraitUsage >> source: anObject [
-	self user: anObject
-]
-
-{ #category : #accessing }
-FamixTTraitUsage >> target [
-	^ self trait
-]
-
-{ #category : #accessing }
-FamixTTraitUsage >> target: anObject [
-	self trait: anObject
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
fix #137 

~ implements a generic way to retrieve source and target of an association using the entity's metamodel