### PR TITLE
Java Visitor: do not visit MooseQueryMockSpecializedInvocation

### DIFF
--- a/src/BaselineOfFamix/BaselineOfFamix.class.st
+++ b/src/BaselineOfFamix/BaselineOfFamix.class.st
@@ -60,7 +60,7 @@ BaselineOfFamix >> baseline: spec [
 
 				package: 'Famix-Java-Generator' with: [ spec requires: #('Basic') ];
 				package: 'Famix-Java-Entities' with: [ spec requires: #('BasicTraits') ];
-				package: 'Famix-Java-Visitor' with: [ spec requires: #('Famix-Java-Entities' 'Moose-Query-Test') ];
+				package: 'Famix-Java-Visitor' with: [ spec requires: #('Famix-Java-Entities') ];
 				package: 'Famix-Java-Tests' with: [ spec requires: #('Famix-Java-Entities' 'Famix-Java-Generator') ];
 
 				package: 'Moose-TestResources-LAN';

--- a/src/Famix-Java-Visitor/MooseQueryMockSpecializedInvocation.extension.st
+++ b/src/Famix-Java-Visitor/MooseQueryMockSpecializedInvocation.extension.st
@@ -1,6 +1,0 @@
-Extension { #name : #MooseQueryMockSpecializedInvocation }
-
-{ #category : #'*Famix-Java-Visitor-generated' }
-MooseQueryMockSpecializedInvocation >> accept: aFamixJavaVisitor [
-	^ aFamixJavaVisitor visitMooseQueryMockSpecializedInvocation: self
-]


### PR DESCRIPTION
and remove dependency in baseline