### PR TITLE
Move #numberOfConstructorMethods to FamixTJavaClassMetrics.

### DIFF
--- a/src/Famix-Java-Entities/FamixJavaTClassMetrics.trait.st
+++ b/src/Famix-Java-Entities/FamixJavaTClassMetrics.trait.st
@@ -31,3 +31,27 @@ FamixJavaTClassMetrics >> numberOfAccessorMethods [
 FamixJavaTClassMetrics >> numberOfAccessorMethods: aNumber [
 	self cacheAt: #numberOfAccessorMethods put: aNumber
 ]
+
+{ #category : #metrics }
+FamixJavaTClassMetrics >> numberOfConstructorMethods [
+	<FMProperty: #numberOfConstructorMethods type: #Number>
+	<derived>
+	<FMComment: 'The number of constructor methods in a class'>
+	^ self
+		lookUpPropertyNamed: #numberOfConstructorMethods
+		computedAs: [ 
+			| nc |
+			nc := 0.
+			self methods
+				do: [ :method | 
+					method isConstructor
+						ifNotNil: [ 
+							method isConstructor
+								ifTrue: [ nc := 1 ] ] ].
+			nc ]
+]
+
+{ #category : #metrics }
+FamixJavaTClassMetrics >> numberOfConstructorMethods: aNumber [
+	self cacheAt: #numberOfConstructorMethods put: aNumber
+]

--- a/src/Famix-Java-Tests/FamixJavaClassTest.class.st
+++ b/src/Famix-Java-Tests/FamixJavaClassTest.class.st
@@ -48,3 +48,19 @@ FamixJavaClassTest >> testNumberOfAccessorMethods [
 	c1 numberOfAccessorMethods: 100.
 	self assert: c1 numberOfAccessorMethods equals: 100
 ]
+
+{ #category : #tests }
+FamixJavaClassTest >> testNumberOfConstructorMethods [
+
+	| m1 c1 model |
+	model := FamixJavaModel new.
+	c1 := FamixJavaClass named: 'Class1' model: model.
+	m1 := FamixJavaMethod named: 'method1' model: model.
+	m1 parentType: c1.
+	
+	m1 isConstructor: true.
+	self assert: c1 numberOfConstructorMethods equals: 1.
+	c1 numberOfConstructorMethods: 100.
+	self assert: c1 numberOfConstructorMethods equals: 100.
+
+]

--- a/src/Famix-Test1-Tests/FamixWithMethodsTest.class.st
+++ b/src/Famix-Test1-Tests/FamixWithMethodsTest.class.st
@@ -49,16 +49,6 @@ FamixWithMethodsTest >> testMethodsGroup [
 ]
 
 { #category : #tests }
-FamixWithMethodsTest >> testNumberOfConstructorMethods [
-
-	m1 isConstructor: true.
-	self assert: c1 numberOfConstructorMethods equals: 1.
-	c1 numberOfConstructorMethods: 100.
-	self assert: c1 numberOfConstructorMethods equals: 100.
-
-]
-
-{ #category : #tests }
 FamixWithMethodsTest >> testNumberOfLinesOfCode [
 
 	self assert: c1 numberOfLinesOfCode equals: 2.

--- a/src/Famix-Traits/FamixTWithMethods.trait.st
+++ b/src/Famix-Traits/FamixTWithMethods.trait.st
@@ -59,30 +59,6 @@ FamixTWithMethods >> numberOfAbstractMethods: aNumber [
 ]
 
 { #category : #metrics }
-FamixTWithMethods >> numberOfConstructorMethods [
-	<FMProperty: #numberOfConstructorMethods type: #Number>
-	<derived>
-	<FMComment: 'The number of constructor methods in a class'>
-	^ self
-		lookUpPropertyNamed: #numberOfConstructorMethods
-		computedAs: [ 
-			| nc |
-			nc := 0.
-			self methods
-				do: [ :method | 
-					method isConstructor
-						ifNotNil: [ 
-							method isConstructor
-								ifTrue: [ nc := 1 ] ] ].
-			nc ]
-]
-
-{ #category : #metrics }
-FamixTWithMethods >> numberOfConstructorMethods: aNumber [
-	self cacheAt: #numberOfConstructorMethods put: aNumber
-]
-
-{ #category : #metrics }
 FamixTWithMethods >> numberOfMessageSends [
 	<FMProperty: #numberOfMessageSends type: #Number>
 	<derived>

--- a/src/Moose-SmalltalkImporter-LAN-Tests/FamixPropertiesTest.class.st
+++ b/src/Moose-SmalltalkImporter-LAN-Tests/FamixPropertiesTest.class.st
@@ -124,7 +124,6 @@ FamixPropertiesTest >> testClassMethods [
 	self
 		assert: (self nodeClass propertyNamed: #numberOfMethodsAdded)
 		equals: (self nodeClass propertyNamed: #numberOfMethods).
-	self assert: (self nodeClass propertyNamed: #numberOfConstructorMethods) equals: 0.
 	self
 		assert: (self workstationClass propertyNamed: #numberOfMethodsInherited)
 		equals: (self nodeClass propertyNamed: #numberOfMethods) + (self nodeClass propertyNamed: #numberOfMethodsInherited).


### PR DESCRIPTION
fix #247

changes: 
* remove  numberOfConstructorMethods & numberOfConstructorMethods: from TWithMethods 
* add them to JavaTClassMetrics 
* modify tests accordingly