### PR TITLE
move #numberOfMethodsAdded & #numberOfMethodsAdded: to FamixTClassMetrics

### DIFF
--- a/src/Famix-Traits/FamixTClass.trait.st
+++ b/src/Famix-Traits/FamixTClass.trait.st
@@ -8,6 +8,7 @@ A class is typically scoped in a namespace. To model nested or anonymous classes
 Trait {
 	#name : #FamixTClass,
 	#traits : 'FamixTInvocationsReceiver + FamixTPackageable + (FamixTType - {#queryStaticIncomingAssociations. #queryStaticOutgoingAssociations}) + FamixTWithAttributes + FamixTWithComments + FamixTWithInheritances + FamixTWithMethods + TOODependencyQueries',
+	#classTraits : 'FamixTInvocationsReceiver classTrait + FamixTPackageable classTrait + FamixTType classTrait + FamixTWithAttributes classTrait + FamixTWithComments classTrait + FamixTWithInheritances classTrait + FamixTWithMethods classTrait + TOODependencyQueries classTrait',
 	#category : #'Famix-Traits-Class'
 }
 
@@ -115,22 +116,6 @@ FamixTClass >> numberOfAttributesInherited: aNumber [
 ]
 
 { #category : #metrics }
-FamixTClass >> numberOfMethodsAdded [
-	<FMProperty: #numberOfMethodsAdded type: #Number>
-	<derived>
-	<FMComment: 'The number of methods in a class added with respect to super classes'>	
-	
-	^self
-		lookUpPropertyNamed: #numberOfMethodsAdded
-		computedAs: [self addedMethods size]
-]
-
-{ #category : #metrics }
-FamixTClass >> numberOfMethodsAdded: aNumber [
-	self cacheAt: #numberOfMethodsAdded put: aNumber
-]
-
-{ #category : #metrics }
 FamixTClass >> numberOfMethodsInHierarchy [
 	<FMProperty: #numberOfMethodsInHierarchy type: #Number>
 	<derived>
@@ -166,13 +151,15 @@ FamixTClass >> numberOfMethodsInherited: aNumber [
 
 { #category : #metrics }
 FamixTClass >> numberOfMethodsOverriden [
+
 	<FMProperty: #numberOfMethodsOverriden type: #Number>
 	<derived>
-	<FMComment: 'The number of methods in a class overriden with respect to super classes'>
-			
-	^self
-		lookUpPropertyNamed: #numberOfMethodsOverriden
-		computedAs: [self numberOfMethods - self numberOfMethodsAdded]
+	<FMComment:
+	'The number of methods in a class overriden with respect to super classes'>
+	^ self
+		  lookUpPropertyNamed: #numberOfMethodsOverriden
+		  computedAs: [ 
+		  self numberOfMethods - self numberOfLocallyDefinedMethods ]
 ]
 
 { #category : #metrics }

--- a/src/Famix-Traits/FamixTClassMetrics.trait.st
+++ b/src/Famix-Traits/FamixTClassMetrics.trait.st
@@ -11,3 +11,41 @@ FamixTClassMetrics classSide >> annotation [
 	<generated>
 	^self
 ]
+
+{ #category : #metrics }
+FamixTClassMetrics >> numberOfLocallyDefinedMethods [
+
+	<FMProperty: #numberOfLocallyDefinedMethods type: #Number>
+	<derived>
+	<FMComment:
+	'The number of methods in a class added with respect to super classes'>
+	^ self
+		  lookUpPropertyNamed: #numberOfLocallyDefinedMethods
+		  computedAs: [ self addedMethods size ]
+]
+
+{ #category : #metrics }
+FamixTClassMetrics >> numberOfLocallyDefinedMethods: aNumber [
+
+	self cacheAt: #numberOfLocallyDefinedMethods put: aNumber
+]
+
+{ #category : #metrics }
+FamixTClassMetrics >> numberOfMethodsAdded [
+
+	self
+		deprecated: 'Use #numberOfLocallyDefinedMethods instead.'
+		transformWith: '`@receiver numberOfMethodsAdded'
+			-> '`@receiver numberOfLocallyDefinedMethods'.
+	^ self numberOfLocallyDefinedMethods
+]
+
+{ #category : #metrics }
+FamixTClassMetrics >> numberOfMethodsAdded: aNumber [
+
+	self
+		deprecated: 'Use #numberOfLocallyDefinedMethods: instead.'
+		transformWith: '`@receiver numberOfMethodsAdded: `@arg'
+			-> '`@receiver numberOfLocallyDefinedMethods: `@arg'.
+	^ self numberOfLocallyDefinedMethods: aNumber
+]

--- a/src/Moose-SmalltalkImporter-LAN-Tests/FamixPropertiesTest.class.st
+++ b/src/Moose-SmalltalkImporter-LAN-Tests/FamixPropertiesTest.class.st
@@ -122,16 +122,16 @@ FamixPropertiesTest >> testClassMethods [
 	self assert: (self nodeClass propertyNamed: #numberOfMethodsInherited) equals: 0.
 	self assert: (self nodeClass propertyNamed: #numberOfMethodsOverriden) equals: 0.
 	self
-		assert: (self nodeClass propertyNamed: #numberOfMethodsAdded)
+		assert: (self nodeClass propertyNamed: #numberOfLocallyDefinedMethods)
 		equals: (self nodeClass propertyNamed: #numberOfMethods).
 	self
 		assert: (self workstationClass propertyNamed: #numberOfMethodsInherited)
 		equals: (self nodeClass propertyNamed: #numberOfMethods) + (self nodeClass propertyNamed: #numberOfMethodsInherited).
-	self assert: (self workstationClass propertyNamed: #numberOfMethodsAdded) equals: 1.
+	self assert: (self workstationClass propertyNamed: #numberOfLocallyDefinedMethods) equals: 1.
 	self assert: (self workstationClass propertyNamed: #numberOfMethodsOverriden) equals: 3.
 	self
 		assert:
-			(self workstationClass propertyNamed: #numberOfMethodsAdded)
+			(self workstationClass propertyNamed: #numberOfLocallyDefinedMethods)
 				+ (self workstationClass propertyNamed: #numberOfMethodsOverriden)
 		equals: (self workstationClass propertyNamed: #numberOfMethods)
 ]


### PR DESCRIPTION
add deprecation rule in order to rename it to #numberOfLocallyDefinedMethods & #numberOfLocallyDefinedMethods:

modify test , use new name.

fix #248