### PR TITLE
turn deprecated numberOfAccessesToForeignData getter and setter.

### DIFF
--- a/src/Famix-Traits/FamixTType.trait.st
+++ b/src/Famix-Traits/FamixTType.trait.st
@@ -71,18 +71,18 @@ FamixTType >> mooseNameOn: aStream [
 
 { #category : #metrics }
 FamixTType >> numberOfAccessesToForeignData [
-	<FMProperty: #numberOfAccessesToForeignData type: #Number>
-	<derived>
-	<FMComment: 'Number of accesses to foreign data'>
-	
-	^self
-		lookUpPropertyNamed: #numberOfAccessesToForeignData
-		computedAs: [self notExistentMetricValue]
+
+	self
+		deprecated: 'you should not use this method anymore.'
+		transformWith: '`@receiver numberOfAccessesToForeignData'
+			-> '`@receiver notExistentMetricValue'.
+	^ self notExistentMetricValue
 ]
 
 { #category : #metrics }
 FamixTType >> numberOfAccessesToForeignData: aNumber [
-	self cacheAt: #numberOfAccessesToForeignData put: aNumber
+
+	self deprecated: 'you should not use this method anymore.'
 ]
 
 { #category : #testing }


### PR DESCRIPTION
fix #258.

we decided to use deprecation instead of removing it. 
and we transform it to notExistentMetricValue