### PR TITLE
remove tPackageable from JavaNameEntity

### DIFF
--- a/src/Famix-Java-Entities/FamixJavaAnnotationType.class.st
+++ b/src/Famix-Java-Entities/FamixJavaAnnotationType.class.st
@@ -1,8 +1,8 @@
 Class {
 	#name : #FamixJavaAnnotationType,
 	#superclass : #FamixJavaType,
-	#traits : 'FamixTAnnotationType + FamixTWithAttributes + FamixTWithInheritances',
-	#classTraits : 'FamixTAnnotationType classTrait + FamixTWithAttributes classTrait + FamixTWithInheritances classTrait',
+	#traits : 'FamixTAnnotationType + FamixTPackageable + FamixTWithAttributes + FamixTWithInheritances',
+	#classTraits : 'FamixTAnnotationType classTrait + FamixTPackageable classTrait + FamixTWithAttributes classTrait + FamixTWithInheritances classTrait',
 	#category : #'Famix-Java-Entities-Entities'
 }
 

--- a/src/Famix-Java-Entities/FamixJavaClass.class.st
+++ b/src/Famix-Java-Entities/FamixJavaClass.class.st
@@ -1,8 +1,8 @@
 Class {
 	#name : #FamixJavaClass,
 	#superclass : #FamixJavaType,
-	#traits : 'FamixJavaTClassMetrics + FamixTCanBeAbstract + FamixTCanBeClassSide + FamixTCanBeFinal + FamixTClass + FamixTClassMetrics + FamixTHasVisibility + FamixTLCOMMetrics + FamixTWithExceptions',
-	#classTraits : 'FamixJavaTClassMetrics classTrait + FamixTCanBeAbstract classTrait + FamixTCanBeClassSide classTrait + FamixTCanBeFinal classTrait + FamixTClass classTrait + FamixTClassMetrics classTrait + FamixTHasVisibility classTrait + FamixTLCOMMetrics classTrait + FamixTWithExceptions classTrait',
+	#traits : 'FamixJavaTClassMetrics + FamixTCanBeAbstract + FamixTCanBeClassSide + FamixTCanBeFinal + FamixTClass + FamixTClassMetrics + FamixTHasVisibility + FamixTLCOMMetrics + FamixTPackageable + FamixTWithExceptions',
+	#classTraits : 'FamixJavaTClassMetrics classTrait + FamixTCanBeAbstract classTrait + FamixTCanBeClassSide classTrait + FamixTCanBeFinal classTrait + FamixTClass classTrait + FamixTClassMetrics classTrait + FamixTHasVisibility classTrait + FamixTLCOMMetrics classTrait + FamixTPackageable classTrait + FamixTWithExceptions classTrait',
 	#category : #'Famix-Java-Entities-Entities'
 }
 

--- a/src/Famix-Java-Entities/FamixJavaNamedEntity.class.st
+++ b/src/Famix-Java-Entities/FamixJavaNamedEntity.class.st
@@ -1,8 +1,8 @@
 Class {
 	#name : #FamixJavaNamedEntity,
 	#superclass : #FamixJavaSourcedEntity,
-	#traits : 'FamixTInvocationsReceiver + FamixTNamedEntity + FamixTPackageable + FamixTWithAnnotationInstances',
-	#classTraits : 'FamixTInvocationsReceiver classTrait + FamixTNamedEntity classTrait + FamixTPackageable classTrait + FamixTWithAnnotationInstances classTrait',
+	#traits : 'FamixTInvocationsReceiver + FamixTNamedEntity + FamixTWithAnnotationInstances',
+	#classTraits : 'FamixTInvocationsReceiver classTrait + FamixTNamedEntity classTrait + FamixTWithAnnotationInstances classTrait',
 	#category : #'Famix-Java-Entities-Entities'
 }
 

--- a/src/Famix-Java-Entities/FamixJavaPackage.class.st
+++ b/src/Famix-Java-Entities/FamixJavaPackage.class.st
@@ -1,8 +1,8 @@
 Class {
 	#name : #FamixJavaPackage,
 	#superclass : #FamixJavaContainerEntity,
-	#traits : 'FamixTPackage + FamixTWithGlobalVariables',
-	#classTraits : 'FamixTPackage classTrait + FamixTWithGlobalVariables classTrait',
+	#traits : 'FamixTPackage + FamixTPackageable + FamixTWithGlobalVariables',
+	#classTraits : 'FamixTPackage classTrait + FamixTPackageable classTrait + FamixTWithGlobalVariables classTrait',
 	#category : #'Famix-Java-Entities-Entities'
 }
 

--- a/src/Famix-Java-Generator/FamixJavaGenerator.class.st
+++ b/src/Famix-Java-Generator/FamixJavaGenerator.class.st
@@ -177,6 +177,7 @@ FamixJavaGenerator >> defineHierarchy [
 	annotationType --|> #TAnnotationType.
 	annotationType --|> #TWithAttributes.
 	annotationType --|> #TWithInheritances.
+	annotationType --|> #TPackageable.
 
 	annotationTypeAttribute --|> namedEntity.
 	annotationTypeAttribute --|> #TAnnotationTypeAttribute.
@@ -215,6 +216,7 @@ FamixJavaGenerator >> defineHierarchy [
 
 	class --|> type.
 	class --|> #TWithExceptions.
+	class --|> #TPackageable.
 	class --|> #TClass.
 	class --|> #TLCOMMetrics.
 	class --|> #TCanBeAbstract.
@@ -264,7 +266,6 @@ FamixJavaGenerator >> defineHierarchy [
 	localVariable --|> #TCanBeFinal.
 	localVariable --|> #TInvocationsReceiver.
 	
-	namedEntity --|> #TPackageable.
 	namedEntity --|> #TInvocationsReceiver.
 	namedEntity --|> #TWithAnnotationInstances.
 
@@ -275,6 +276,7 @@ FamixJavaGenerator >> defineHierarchy [
 	package --|> containerEntity.
 	package --|> #TWithGlobalVariables.
 	package --|> #TPackage.
+	package --|> #TPackageable.
 
 	parameter --|> namedEntity.
 	parameter --|> #TParameter.

--- a/src/Famix-Java-Tests/FamixJavaMethodTest.class.st
+++ b/src/Famix-Java-Tests/FamixJavaMethodTest.class.st
@@ -60,14 +60,12 @@ FamixJavaMethodTest >> testOverride [
 		signature: 'method()';
 		parentType: c1;
 		declaredType: c1;
-		parentPackage: package;
 		yourself.
 	method
 		name: 'method';
 		signature: 'method()';
 		parentType: c2;
-		declaredType: c2;
-		parentPackage: package.
+		declaredType: c2.
 	c2
 		addSuperInheritance:
 			(FamixJavaInheritance new

--- a/src/Famix-Java-Tests/FamixJavaQueryTest.class.st
+++ b/src/Famix-Java-Tests/FamixJavaQueryTest.class.st
@@ -68,7 +68,6 @@ FamixJavaQueryTest >> setUp [
 		name: 'm1';
 		signature: 'm1()';
 		parentType: c1;
-		parentPackage: p1;
 		declaredType: c2;
 		yourself.
 	m2 := FamixJavaMethod new
@@ -76,7 +75,6 @@ FamixJavaQueryTest >> setUp [
 		name: 'm2';
 		signature: 'm2()';
 		parentType: c2;
-		parentPackage: p1;
 		declaredType: c3;
 		yourself.
 	m3 := FamixJavaMethod new
@@ -84,7 +82,6 @@ FamixJavaQueryTest >> setUp [
 		name: 'm3';
 		signature: 'm3(C2,C3)';
 		parentType: c2;
-		parentPackage: p1;
 		declaredType: c1;
 		yourself.
 	m4 := FamixJavaMethod new
@@ -92,7 +89,6 @@ FamixJavaQueryTest >> setUp [
 		name: 'm4';
 		signature: 'm4()';
 		parentType: c3;
-		parentPackage: p2;
 		declaredType: c3;
 		yourself.
 
@@ -100,7 +96,6 @@ FamixJavaQueryTest >> setUp [
 		stub: true;
 		name: 'v1';
 		parentBehaviouralEntity: m2;
-		parentPackage: p1;
 		declaredType: c1;
 		yourself.
 
@@ -108,14 +103,12 @@ FamixJavaQueryTest >> setUp [
 		stub: true;
 		name: 'pr1';
 		parentBehaviouralEntity: m3;
-		parentPackage: p1;
 		declaredType: c2;
 		yourself.
 	pr2 := FamixJavaParameter new
 		stub: true;
 		name: 'pr2';
 		parentBehaviouralEntity: m3;
-		parentPackage: p1;
 		declaredType: c3;
 		yourself.
 
@@ -123,14 +116,12 @@ FamixJavaQueryTest >> setUp [
 		stub: true;
 		name: 'at1';
 		parentType: c1;
-		parentPackage: p1;
 		declaredType: c3;
 		yourself.
 	at2 := FamixJavaAttribute new
 		stub: true;
 		name: 'at2';
 		parentType: c3;
-		parentPackage: p2;
 		declaredType: c2;
 		yourself.
 

--- a/src/Moose-Query-Test/MooseQueryTest.class.st
+++ b/src/Moose-Query-Test/MooseQueryTest.class.st
@@ -72,10 +72,6 @@ MooseQueryTest >> setUp [
 	isolatedMethod := (FamixJavaMethod named: 'isolatedMethod')
 		parentType: isolatedClass;
 		mooseModel: model.
-	methodExt := (FamixJavaMethod named: 'methodExt')
-		parentType: class2;
-		parentPackage: package1;
-		mooseModel: model.
 	var1 := (FamixJavaAttribute named: 'var1')
 		parentType: class2;
 		declaredType: class1;
@@ -123,7 +119,7 @@ MooseQueryTest >> testAllAtAnyScope [
 	self assertCollection: (class1 allAtAnyScope: {FamixTPackage}) hasSameElements: {package1}.
 	self assertCollection: (class1 allAtAnyScope: {FamixTClass . FamixTPackage}) hasSameElements: {class1. package1}.
 	self assertCollection: (class1 allAtAnyScope: {FamixTMethod}) hasSameElements: {}.
-	self assertCollection: (methodExt allAtAnyScope: {FamixJavaPackage}) hasSameElements: {package1. package2}.
+
 ]
 
 { #category : #tests }
@@ -165,8 +161,8 @@ MooseQueryTest >> testAllAtScopeUntil [
 
 { #category : #tests }
 MooseQueryTest >> testAllChildren [
-	self assert: package2 allChildren size equals: 7.
-	self assert: class2 allChildren size equals: 6.
+	self assert: package2 allChildren size equals: 6.
+	self assert: class2 allChildren size equals: 5.
 	self assert: method2 allChildren size equals: 1
 ]
 
@@ -192,17 +188,17 @@ MooseQueryTest >> testAllParents [
 
 { #category : #tests }
 MooseQueryTest >> testAllToAnyScope [
-	self assertCollection: (class2 allToAnyScope: {FamixJavaMethod . FamixJavaAttribute}) hasSameElements: {method2 . method3 . methodExt . var1 . var2}.
-	self assertCollection: (class2 allToAnyScope: {FamixJavaMethod . FamixJavaLocalVariable}) hasSameElements: {method2 . method3 . methodExt . localVariable}.
-	self assertCollection: (class2 allToAnyScope: {FamixJavaMethod . FamixTStructuralEntity}) hasSameElements: {method2 . method3 . methodExt . var1 . var2 . localVariable}.
-	self assertCollection: (class2 allToAnyScope: {FamixJavaClass . FamixJavaMethod}) hasSameElements: {class2 . method2 . method3 . methodExt}.
+	self assertCollection: (class2 allToAnyScope: {FamixJavaMethod . FamixJavaAttribute}) hasSameElements: {method2 . method3  . var1 . var2}.
+	self assertCollection: (class2 allToAnyScope: {FamixJavaMethod . FamixJavaLocalVariable}) hasSameElements: {method2 . method3 . localVariable}.
+	self assertCollection: (class2 allToAnyScope: {FamixJavaMethod . FamixTStructuralEntity}) hasSameElements: {method2 . method3 . var1 . var2 . localVariable}.
+	self assertCollection: (class2 allToAnyScope: {FamixJavaClass . FamixJavaMethod}) hasSameElements: {class2 . method2 . method3 }.
 	self assertCollection: (method1 allToAnyScope: {FamixJavaClass . FamixJavaPackage}) hasSameElements: {}
 ]
 
 { #category : #tests }
 MooseQueryTest >> testAllToAnyScopeUntil [
-	self assertCollection: (class2 allToAnyScope: {FamixJavaMethod . FamixJavaLocalVariable} until: [:entity | entity isOfType: FamixJavaMethod ]) hasSameElements: {method2 . method3 . methodExt }.
-	self assertCollection: (class2 allToAnyScope: {FamixJavaMethod . FamixTStructuralEntity} until: [:entity | entity isOfType: FamixJavaMethod ]) hasSameElements: {method2 . method3 . methodExt . var1 . var2 }.
+	self assertCollection: (class2 allToAnyScope: {FamixJavaMethod . FamixJavaLocalVariable} until: [:entity | entity isOfType: FamixJavaMethod ]) hasSameElements: {method2 . method3 }.
+	self assertCollection: (class2 allToAnyScope: {FamixJavaMethod . FamixTStructuralEntity} until: [:entity | entity isOfType: FamixJavaMethod ]) hasSameElements: {method2 . method3 . var1 . var2 }.
 ]
 
 { #category : #tests }
@@ -235,10 +231,10 @@ MooseQueryTest >> testAllToScopeUntil [
 
 { #category : #tests }
 MooseQueryTest >> testAllWithAnyScope [
-	self assertCollection: (class2 allWithAnyScope: {FamixTMethod . FamixTAttribute}) hasSameElements: {method2 . method3 . var1 . var2 . methodExt}.
+	self assertCollection: (class2 allWithAnyScope: {FamixTMethod . FamixTAttribute}) hasSameElements: {method2 . method3 . var1 . var2 }.
 	self assertCollection: (class2 allWithAnyScope: {FamixTClass . FamixTPackage}) hasSameElements: {class2. package2}.
-	self assertCollection: (class2 allWithAnyScope: {FamixTMethod . FamixTAttribute . FamixTPackage}) hasSameElements: {method2 . method3 . var1 . var2 . methodExt . package2}.
-	self assertCollection: (class2 allWithAnyScope: {FamixTMethod . FamixTStructuralEntity . FamixTPackage}) hasSameElements: {method2 . method3 . var1 . var2 . methodExt . package2 . localVariable}
+	self assertCollection: (class2 allWithAnyScope: {FamixTMethod . FamixTAttribute . FamixTPackage}) hasSameElements: {method2 . method3 . var1 . var2 . package2}.
+	self assertCollection: (class2 allWithAnyScope: {FamixTMethod . FamixTStructuralEntity . FamixTPackage}) hasSameElements: {method2 . method3 . var1 . var2 . package2 . localVariable}
 ]
 
 { #category : #tests }
@@ -246,7 +242,7 @@ MooseQueryTest >> testAllWithAnyScopeUntil [
 	self assertCollection: (class2 allWithAnyScope: {FamixTMethod . FamixTAttribute} until: [:el | el isOfType: FamixTClass]) hasSameElements: {}.
 	self assertCollection: (class2 allWithAnyScope: {FamixTClass . FamixTPackage} until: [:el | el isOfType: FamixTClass]) hasSameElements: {class2}.
 	self assertCollection: (class2 allWithAnyScope: {FamixTMethod . FamixTAttribute . FamixTPackage} until: [:el | el isOfType: FamixTClass]) hasSameElements: {}.
-	self assertCollection: (class2 allWithAnyScope: {FamixTMethod . FamixTStructuralEntity . FamixTPackage} until: [:el | el isOfType: FamixTMethod]) hasSameElements: {method2 . method3 . var1 . var2 . methodExt . package2 }
+	self assertCollection: (class2 allWithAnyScope: {FamixTMethod . FamixTStructuralEntity . FamixTPackage} until: [:el | el isOfType: FamixTMethod]) hasSameElements: {method2 . method3 . var1 . var2 . package2 }
 ]
 
 { #category : #tests }
@@ -303,7 +299,6 @@ MooseQueryTest >> testAtAnyScope [
 	self assertCollection: (class1 atAnyScope: {FamixTPackage}) hasSameElements: {package1}.
 	self assertCollection: (class1 atAnyScope: {FamixTClass . FamixTPackage}) hasSameElements: {class1}.
 	self assertCollection: (class1 atAnyScope: {FamixTMethod}) hasSameElements: {}.
-	self assertCollection: (methodExt atAnyScope: {FamixJavaPackage}) hasSameElements: {package1. package2}.
 ]
 
 { #category : #tests }
@@ -315,9 +310,7 @@ MooseQueryTest >> testAtAnyScopeUntil [
 	self assertCollection: (class1 atAnyScope: {FamixTPackage}) hasSameElements: {package1}.
 	self assertCollection: (class1 atAnyScope: {FamixTPackage} until: [ :entity | entity isOfType: FamixTClass ]) hasSameElements: {}.
 	self assertCollection: (class1 atAnyScope: {FamixTClass . FamixTPackage} until: [ :entity | entity isOfType: FamixTClass ]) hasSameElements: {class1}.
-	"the lookup for the methodExt does not go through the class"
-	self assertCollection: (methodExt atAnyScope: {FamixJavaPackage} until: [ :entity | entity isOfType: FamixTMethod ]) hasSameElements: {}.
-	self assertCollection: (methodExt atAnyScope: {FamixJavaPackage} until: [ :entity | entity isOfType: FamixTPackage ]) hasSameElements: {package1 . package2}
+	
 ]
 
 { #category : #tests }
@@ -690,17 +683,17 @@ MooseQueryTest >> testThroughAllFrom [
 
 { #category : #tests }
 MooseQueryTest >> testToAnyScope [
-	self assertCollection: (class2 toAnyScope: {FamixJavaMethod . FamixJavaAttribute}) hasSameElements: {method2 . method3 . methodExt . var1 . var2}.
-	self assertCollection: (class2 toAnyScope: {FamixJavaMethod . FamixTStructuralEntity}) hasSameElements: {method2 . method3 . methodExt . var1 . var2}.
+	self assertCollection: (class2 toAnyScope: {FamixJavaMethod . FamixJavaAttribute}) hasSameElements: {method2 . method3 . var1 . var2}.
+	self assertCollection: (class2 toAnyScope: {FamixJavaMethod . FamixTStructuralEntity}) hasSameElements: {method2 . method3 . var1 . var2}.
 	self assertCollection: (class2 toAnyScope: {FamixJavaClass . FamixJavaMethod}) hasSameElements: {class2}.
 	self assertCollection: (method1 toAnyScope: {FamixJavaClass . FamixJavaPackage}) hasSameElements: {}
 ]
 
 { #category : #tests }
 MooseQueryTest >> testToAnyScopeUntil [
-	self assertCollection: (class2 toAnyScope: {FamixJavaMethod . FamixJavaAttribute} until: [ :el | el isOfType: FamixTMethod ]) hasSameElements: {method2 . method3 . methodExt . var1 . var2}.
+	self assertCollection: (class2 toAnyScope: {FamixJavaMethod . FamixJavaAttribute} until: [ :el | el isOfType: FamixTMethod ]) hasSameElements: {method2 . method3 . var1 . var2}.
 	self assertCollection: (class2 toAnyScope: {FamixJavaMethod . FamixJavaAttribute} until: [ :el | el isOfType: FamixTClass ]) hasSameElements: {}.
-	self assertCollection: (class2 toAnyScope: {FamixJavaMethod . FamixTStructuralEntity} until: [ :el | el isOfType: FamixTMethod ]) hasSameElements: {method2 . method3 . methodExt . var1 . var2}.
+	self assertCollection: (class2 toAnyScope: {FamixJavaMethod . FamixTStructuralEntity} until: [ :el | el isOfType: FamixTMethod ]) hasSameElements: {method2 . method3 . var1 . var2}.
 	self assertCollection: (class2 toAnyScope: {FamixJavaMethod . FamixTStructuralEntity} until: [ :el | el isOfType: FamixTClass ]) hasSameElements: {}.
 	self assertCollection: (class2 toAnyScope: {FamixJavaClass . FamixTLocalVariable} until: [ :el | el isOfType: FamixTClass ]) hasSameElements: {class2}.
 	self assertCollection: (class2 toAnyScope: {FamixJavaClass . FamixTLocalVariable} until: [ :el | el isOfType: FamixTMethod ]) hasSameElements: {class2}.
@@ -711,7 +704,7 @@ MooseQueryTest >> testToScope [
 	self assertCollection: (class1 toScope: FamixJavaMethod) hasSameElements: {method1}.
 	self assertCollection: (class2 toScope: FamixJavaAttribute) hasSameElements: {var1 . var2}.
 	self assertCollection: (class2 toScope: FamixTStructuralEntity) hasSameElements: {var1 . var2. localVariable}.
-	self assertCollection: (package1 toScope: FamixJavaMethod) hasSameElements: {method1 . methodExt}
+	self assertCollection: (package1 toScope: FamixJavaMethod) hasSameElements: {method1}
 ]
 
 { #category : #tests }
@@ -727,8 +720,8 @@ MooseQueryTest >> testToScopeUntil [
 
 { #category : #tests }
 MooseQueryTest >> testWithAllChildren [
-	self assert: package2 withAllChildren size equals: 8.
-	self assert: class2 withAllChildren size equals: 7.
+	self assert: package2 withAllChildren size equals: 7.
+	self assert: class2 withAllChildren size equals: 6.
 	self assert: method2 withAllChildren size equals: 2
 ]
 
@@ -742,10 +735,10 @@ MooseQueryTest >> testWithAllParents [
 
 { #category : #tests }
 MooseQueryTest >> testWithAnyScope [
-	self assertCollection: (class2 withAnyScope: {FamixTMethod . FamixTAttribute}) hasSameElements: {method2 . method3 . var1 . var2 . methodExt}.
+	self assertCollection: (class2 withAnyScope: {FamixTMethod . FamixTAttribute}) hasSameElements: {method2 . method3 . var1 . var2 }.
 	self assertCollection: (class2 withAnyScope: {FamixTClass . FamixTPackage}) hasSameElements: {class2}.
-	self assertCollection: (class2 withAnyScope: {FamixTMethod . FamixTAttribute . FamixTPackage}) hasSameElements: {method2 . method3 . var1 . var2 . methodExt . package2}.
-	self assertCollection: (class2 withAnyScope: {FamixTMethod . FamixTStructuralEntity . FamixTPackage}) hasSameElements: {method2 . method3 . var1 . var2 . methodExt . package2}
+	self assertCollection: (class2 withAnyScope: {FamixTMethod . FamixTAttribute . FamixTPackage}) hasSameElements: {method2 . method3 . var1 . var2 . package2}.
+	self assertCollection: (class2 withAnyScope: {FamixTMethod . FamixTStructuralEntity . FamixTPackage}) hasSameElements: {method2 . method3 . var1 . var2 . package2}
 ]
 
 { #category : #tests }
@@ -757,7 +750,7 @@ MooseQueryTest >> testWithAnyScopeUntil [
 MooseQueryTest >> testWithScope [
 	self assertCollection: (class1 withScope: FamixTMethod) hasSameElements: {method1}.
 	self assertCollection: (class2 toScope: FamixTAttribute) hasSameElements: {var1 . var2}.
-	self assertCollection: (package1 toScope: FamixTMethod) hasSameElements: {method1 . methodExt}.
+	self assertCollection: (package1 toScope: FamixTMethod) hasSameElements: {method1}.
 	self assertCollection: (class1 withScope: FamixTClass) hasSameElements: {class1}.
 	self assertCollection: (class1 withScope: FamixTType) hasSameElements: {class1}.
 	self assertCollection: (class1 withScope: FamixTPackage) hasSameElements: {package1}
@@ -770,8 +763,7 @@ MooseQueryTest >> testWithScopeUntil [
 	self assertCollection: (class2 toScope: FamixTAttribute until: [ :el | el isOfType: FamixTAttribute ]) hasSameElements: {var1 . var2}.
 	self assertCollection: (class2 toScope: FamixTAttribute until: [ :el | el isOfType: FamixTClass ]) hasSameElements: {}.
 	self assertCollection: (package1 toScope: FamixTMethod until: [ :el | el isOfType: FamixTPackage ]) hasSameElements: {}.
-	self assertCollection: (package1 toScope: FamixTMethod until: [ :el | el isOfType: FamixTClass ]) hasSameElements: { methodExt }.
-	self assertCollection: (package1 toScope: FamixTMethod until: [ :el | el isOfType: FamixTMethod ]) hasSameElements: {method1 . methodExt}.
+	self assertCollection: (package1 toScope: FamixTMethod until: [ :el | el isOfType: FamixTMethod ]) hasSameElements: {method1}.
 	self assertCollection: (class1 withScope: FamixTPackage until: [:el | el isOfType: FamixTPackage]) hasSameElements: {package1}.
 	self assertCollection: (class1 withScope: FamixTPackage until: [:el | el isOfType: FamixTClass]) hasSameElements: {}.
 ]


### PR DESCRIPTION
add tPackageable to JavaClass, JavaPackage and JavaAnnotationType
correct tests consequently(methods attributes parameters are no more packageable)
fix #140