### PR TITLE
Features generation of uml code with metamodel

### DIFF
--- a/src/BaselineOfFamix/BaselineOfFamix.class.st
+++ b/src/BaselineOfFamix/BaselineOfFamix.class.st
@@ -97,7 +97,8 @@ BaselineOfFamix >> baseline: spec [
 				package: 'Famix-TestComposed3Metamodel-Entities' with: [ spec requires: #('Famix-TestComposedMetamodel-Entities') ];
 				package: 'Famix-TestComposedMetamodel' with: [ spec requires: #('Famix-TestComposedMetamodel-Entities') ];
 
-				package: 'Famix-Deprecated' with: [ spec requires: #('Core' 'ModelCompatibility' 'ModelJava' 'ModelSmalltalk' 'Tests') ].
+				package: 'Famix-Deprecated' with: [ spec requires: #('Core' 'ModelCompatibility' 'ModelJava' 'ModelSmalltalk' 'Tests') ];
+				package: 'Famix-MetamodelDocumentor' with: [ spec requires: #('Core' 'TestModels') ].
 
 			"Groups"
 			spec

--- a/src/BaselineOfFamix/BaselineOfFamix.class.st
+++ b/src/BaselineOfFamix/BaselineOfFamix.class.st
@@ -98,7 +98,8 @@ BaselineOfFamix >> baseline: spec [
 				package: 'Famix-TestComposedMetamodel' with: [ spec requires: #('Famix-TestComposedMetamodel-Entities') ];
 
 				package: 'Famix-Deprecated' with: [ spec requires: #('Core' 'ModelCompatibility' 'ModelJava' 'ModelSmalltalk' 'Tests') ];
-				package: 'Famix-MetamodelDocumentor' with: [ spec requires: #('Core' 'TestModels') ].
+				package: 'Famix-MetamodelDocumentor' with: [ spec requires: #('Core' 'TestModels' 'Famix-TestModel1MetamodelDocumentor') ];
+				package: 'Famix-TestModel1MetamodelDocumentor' with: [ spec requires: #('Core') ].
 
 			"Groups"
 			spec

--- a/src/Famix-MetamodelBuilder-Core/FmxMBPlantTextVisitor.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxMBPlantTextVisitor.class.st
@@ -22,7 +22,8 @@ Class {
 		'mergeTraits',
 		'generalizationDefinitions',
 		'typedProperties',
-		'traitsWithUsers'
+		'traitsWithUsers',
+		'withAllTraits'
 	],
 	#category : #'Famix-MetamodelBuilder-Core-Visitors'
 }
@@ -35,6 +36,15 @@ FmxMBPlantTextVisitor >> behaviorNameOrNilFor: aBehavior [
 { #category : #accessing }
 FmxMBPlantTextVisitor >> behaviors [
 	^ behaviors
+]
+
+{ #category : #checking }
+FmxMBPlantTextVisitor >> checkTrait: aTrait [
+
+	^ aTrait willGenerate and: [ 
+		  (traitsWithUsers includes: aTrait) and: [ 
+			  (aTrait builder classes flatCollect: [ :each | 
+				   each traitGeneralizations ]) includes: aTrait ] ]
 ]
 
 { #category : #accessing }
@@ -71,7 +81,8 @@ FmxMBPlantTextVisitor >> initialize [
 	mergeTraits := true.
 	generalizationDefinitions := OrderedCollection new.
 	typedProperties := OrderedCollection new.
-	traitsWithUsers := Set new
+	traitsWithUsers := Set new.
+	withAllTraits := false.
 ]
 
 { #category : #private }
@@ -103,15 +114,21 @@ FmxMBPlantTextVisitor >> onlySingleUserOf: aTrait [
 ]
 
 { #category : #private }
-FmxMBPlantTextVisitor >> recordGeneralizationsForClass: aClass mergingTraits: mergesTrait [. 
+FmxMBPlantTextVisitor >> recordGeneralizationsForClass: aClass mergingTraits: mergesTrait [
 
-	aClass classGeneralization ifNotNil: [ :generalization |
-		generalizationDefinitions add: (generalization -> aClass)].
-	
+	aClass classGeneralization ifNotNil: [ :generalization | 
+		generalizationDefinitions add: generalization -> aClass ].
 	mergesTrait ifFalse: [ 
-		aClass traitGeneralizations ifNotEmpty: [ :generalizations |
-			generalizations do: [ :generalization |
-				generalizationDefinitions add: (generalization -> aClass)]]]
+		aClass traitGeneralizations ifNotEmpty: [ :generalizations | 
+			generalizations do: [ :generalization | 
+				generalizationDefinitions add: generalization -> aClass ] ] ]
+]
+
+{ #category : #visiting }
+FmxMBPlantTextVisitor >> recordGeneralizationsForTrait: aTrait [
+
+		aTrait traitGeneralizations do: [ :generalization |
+				generalizationDefinitions add: (generalization -> aTrait)]
 	
 	
 ]
@@ -136,6 +153,7 @@ FmxMBPlantTextVisitor >> selectTraitsWithUsersFrom: aBuilder [
 
 { #category : #visiting }
 FmxMBPlantTextVisitor >> visitBuilder: aBuilder [
+
 	stream
 		nextPutAll: '@startuml';
 		cr;
@@ -143,23 +161,18 @@ FmxMBPlantTextVisitor >> visitBuilder: aBuilder [
 		nextPutAll: 'hide empty members';
 		cr;
 		cr.
-
-	self gatherTraits
-		ifTrue: [ stream
-				nextPutAll: 'together {';
-				cr ].
-
+	self gatherTraits ifTrue: [ 
+		stream
+			nextPutAll: 'together {';
+			cr ].
 	self selectTraitsWithUsersFrom: aBuilder.
-
-	(aBuilder traits select: #willGenerate) do: [ :each | each acceptVisitor: self ].
-
-	self gatherTraits
-		ifTrue: [ stream
-				nextPutAll: '}';
-				cr ].
-
+	(aBuilder traits select: #willGenerate) do: [ :each | 
+		each acceptVisitor: self ].
+	self gatherTraits ifTrue: [ 
+		stream
+			nextPutAll: '}';
+			cr ].
 	aBuilder sortedClasses do: [ :each | each acceptVisitor: self ].
-
 	self writeGeneralizations.
 	self writeRelations.
 	stream
@@ -196,36 +209,19 @@ FmxMBPlantTextVisitor >> visitRelationSide: aRelationSide [
 FmxMBPlantTextVisitor >> visitTrait: aTrait [
 
 	| behaviorKey |
-	
-	aTrait willGenerate ifFalse: [ ^ self ].
-	
-	(traitsWithUsers includes: aTrait) ifFalse: [ ^self ].
-	
-	((aTrait builder classes flatCollect: [:each | each traitGeneralizations]) includes: aTrait)
-		ifFalse: [ ^ self ].
+	withAllTraits
+		ifFalse: [ (self checkTrait: aTrait) ifFalse: [^ self]]
+		ifTrue: [ self recordGeneralizationsForTrait: aTrait ].
 
 	behaviorKey := self ensureBehaviorNameFor: aTrait.
-	
-	(self onlySingleUserOf: aTrait) ifTrue: [ 
-		| savedStream |
-		savedStream := stream.
-		stream := String new writeStream.
-		aTrait properties do: [ :each | each acceptVisitor: self ].
-		typedProperties add: (aTrait -> stream contents).
-		stream := savedStream.
-		^ self ].	
 
-	stream nextPutAll: 'class ';
-		nextPutAll: behaviorKey; 
-		nextPutAll: ' as "';
-		nextPutAll: aTrait name; 
-		nextPutAll: '" << (T,orchid) >> {'; 
-		cr.
+	(self onlySingleUserOf: aTrait) ifTrue: [ self writeSingleUseOf: aTrait.].
+
+	self writeTraitBeginningOf: aTrait with: behaviorKey.
 
 	aTrait properties do: [ :each | each acceptVisitor: self ].
 
-	stream nextPutAll: '}'; cr; cr.
-
+	self writeTraitEnd.
 ]
 
 { #category : #visiting }
@@ -238,6 +234,16 @@ FmxMBPlantTextVisitor >> visitTypedProperty: aTypedProperty [
 		space; 
 		nextPutAll: aTypedProperty name; 
 		cr. 
+]
+
+{ #category : #'public - configuration' }
+FmxMBPlantTextVisitor >> withAllTraits [
+	withAllTraits := true.
+]
+
+{ #category : #'public - configuration' }
+FmxMBPlantTextVisitor >> withoutAllTraits [
+	withAllTraits := false.
 ]
 
 { #category : #private }
@@ -281,17 +287,14 @@ FmxMBPlantTextVisitor >> writeClass: aClass mergingTraits: mergesTraits [
 { #category : #relations }
 FmxMBPlantTextVisitor >> writeGeneralizations [
 
-	generalizationDefinitions do: [ :each| 
-		
-		(each key willGenerate and: [ each value willGenerate ])
-			ifTrue: [  
-				stream 
-					nextPutAll: (self ensureBehaviorNameFor: each key);
-					nextPutAll: ' <|-- ';
-					nextPutAll: (self ensureBehaviorNameFor: each value);
-					cr ]].
-	stream cr.
-	
+	generalizationDefinitions do: [ :each | 
+		(each key willGenerate and: [ each value willGenerate ]) ifTrue: [ 
+			stream
+				nextPutAll: (self ensureBehaviorNameFor: each key);
+				nextPutAll: ' <|-- ';
+				nextPutAll: (self ensureBehaviorNameFor: each value);
+				cr ] ].
+	stream cr
 ]
 
 { #category : #relations }
@@ -333,4 +336,34 @@ FmxMBPlantTextVisitor >> writeRelations [
 			nextPutAll: (self ensureBehaviorNameFor: relation to relatedEntity); 
 			cr]
 	
+]
+
+{ #category : #writing }
+FmxMBPlantTextVisitor >> writeSingleUseOf: aTrait [
+	| savedStream |
+		savedStream := stream.
+		stream := String new writeStream.
+		aTrait properties do: [ :each | each acceptVisitor: self ].
+		typedProperties add: aTrait -> stream contents.
+		stream := savedStream.
+		^ self
+]
+
+{ #category : #writing }
+FmxMBPlantTextVisitor >> writeTraitBeginningOf: aTrait with: aBehaviorKey [
+	stream
+		nextPutAll: 'class ';
+		nextPutAll: aBehaviorKey;
+		nextPutAll: ' as "';
+		nextPutAll: aTrait name;
+		nextPutAll: '" << (T,orchid) >> {';
+		cr.
+]
+
+{ #category : #writing }
+FmxMBPlantTextVisitor >> writeTraitEnd [
+	stream
+		nextPutAll: '}';
+		cr;
+		cr
 ]

--- a/src/Famix-MetamodelDocumentor/FamixMMUMLAbstractDocumentor.class.st
+++ b/src/Famix-MetamodelDocumentor/FamixMMUMLAbstractDocumentor.class.st
@@ -1,0 +1,102 @@
+"
+I am an abstract class that gathers visitors in order to generate a plantUML code of a meta model.
+
+My main visitor is FamixMMUMLDocumentor. You can call it with different options to generate a plantUML code of your model.
+
+Therefore, I group instance variables that are shared by these two visitors and methods to access them.
+"
+Class {
+	#name : #FamixMMUMLAbstractDocumentor,
+	#superclass : #Object,
+	#instVars : [
+		'model',
+		'outputStream',
+		'classesOfInterest',
+		'externalClasses',
+		'withStub'
+	],
+	#category : #'Famix-MetamodelDocumentor'
+}
+
+{ #category : #'api - generation' }
+FamixMMUMLAbstractDocumentor >> beWithStub [
+	self withStub: true
+]
+
+{ #category : #'api - generation' }
+FamixMMUMLAbstractDocumentor >> beWithoutStub [
+	self withStub: false
+]
+
+{ #category : #accessing }
+FamixMMUMLAbstractDocumentor >> classesOfInterest: aCollection [
+	classesOfInterest := aCollection 
+]
+
+{ #category : #accessing }
+FamixMMUMLAbstractDocumentor >> externalClasses [
+	^externalClasses 
+]
+
+{ #category : #accessing }
+FamixMMUMLAbstractDocumentor >> externalClasses: aCollection [
+	externalClasses  := aCollection 
+]
+
+{ #category : #generating }
+FamixMMUMLAbstractDocumentor >> generateClassName: aFM3Class [
+	outputStream
+		nextPutAll: aFM3Class name.
+	(self ofInterest: aFM3Class)
+	ifFalse: [
+		externalClasses add: aFM3Class 
+	]
+]
+
+{ #category : #initialization }
+FamixMMUMLAbstractDocumentor >> initialize [
+	self beWithoutStub.
+	externalClasses := Set new
+]
+
+{ #category : #testing }
+FamixMMUMLAbstractDocumentor >> isWithStub [
+	^withStub
+]
+
+{ #category : #accessing }
+FamixMMUMLAbstractDocumentor >> model [
+	^ model
+]
+
+{ #category : #accessing }
+FamixMMUMLAbstractDocumentor >> model: anObject [
+	model := anObject
+]
+
+{ #category : #private }
+FamixMMUMLAbstractDocumentor >> ofInterest: aFMClass [
+	^classesOfInterest includes: aFMClass
+]
+
+{ #category : #accessing }
+FamixMMUMLAbstractDocumentor >> outputStream [
+	^ outputStream
+]
+
+{ #category : #accessing }
+FamixMMUMLAbstractDocumentor >> outputStream: anObject [
+	outputStream := anObject
+]
+
+{ #category : #private }
+FamixMMUMLAbstractDocumentor >> relationEndOfInterest: aFMClass [
+	^self isWithStub
+		ifTrue: [ aFMClass class ~= FM3Object ]
+		ifFalse: [ self ofInterest: aFMClass ]
+]
+
+{ #category : #accessing }
+FamixMMUMLAbstractDocumentor >> withStub: aBoolean [
+	withStub := aBoolean
+]

--- a/src/Famix-MetamodelDocumentor/FamixMMUMLDocumentor.class.st
+++ b/src/Famix-MetamodelDocumentor/FamixMMUMLDocumentor.class.st
@@ -1,4 +1,7 @@
 "
+Class: FamixMMUMLDocumentor
+                                                                                                    
+
 A class to create plantUML graphs from a metamodel
 
 Different from FmxMBPlantTextVisitor in that it works on the metamodel itself, and not on the builder
@@ -7,75 +10,52 @@ Currently needs a model to access its metamodel and creates a plantUML class dia
 
 ```language=Pharo
 FamixMMUMLDocumentor new
-	model: FAMIXModel ;
-	generatePlantUMLWith: { FamixTAccess . FamixTAccessible . FamixTWithAccesses }. 
+ model: FAMIXModel ;
+ generatePlantUMLWith: { FamixTAccess . FamixTAccessible . FamixTWithAccesses }. 
 ```
 
 returns a string with a script to feed into PlantUML.com
 The scripts displays the 3 classes to generate with their inter-relationships and properties
 
 Can also display  ""external classes"" (kindof ""stubs""): entities related to the ones we are interested in, but not in the list of classes to generate.
-For this, use `#beWithStub`.
+For this, use #beWithStub.
 
-Other interesting method is: `#generatePlantUMLFile: aFileName with: aCollectionOfClasses` that dumps the PlantUML script into a `aFileName.puml`
+Other interesting method is: #generatePlantUMLFile: aFileName with: aCollectionOfClasses that dumps the PlantUML script into a aFileName.puml
+
+If you don't know the model you want to analyze, I can generate the associated plantUML code on all these entities via generatePlantUMLModel or generatePlantUMLModelFile:.
+
+```language=Pharo
+FamixMMUMLDocumentor new
+ model: FAMIXModel ;
+ generatePlantUMLModel.
+```
 "
 Class {
 	#name : #FamixMMUMLDocumentor,
-	#superclass : #Object,
+	#superclass : #FamixMMUMLAbstractDocumentor,
 	#instVars : [
-		'model',
-		'outputStream',
-		'classesOfInterest',
-		'withStub',
-		'externalClasses'
+		'classesOfNoInterest'
 	],
 	#category : #'Famix-MetamodelDocumentor'
 }
 
-{ #category : #'api - generation' }
-FamixMMUMLDocumentor >> beWithStub [
-	withStub := true
-]
-
-{ #category : #'api - generation' }
-FamixMMUMLDocumentor >> beWithoutStub [
-	withStub := false
-]
-
-{ #category : #accessing }
-FamixMMUMLDocumentor >> classesOfInterest: aCollection [
-	classesOfInterest := aCollection 
-]
-
-{ #category : #accessing }
-FamixMMUMLDocumentor >> externalClasses [
-	^externalClasses 
-]
-
-{ #category : #accessing }
-FamixMMUMLDocumentor >> externalClasses: aCollection [
-	externalClasses  := aCollection 
-]
-
 { #category : #generating }
-FamixMMUMLDocumentor >> generateClassName: aFM3Class [
-	outputStream
-		nextPutAll: aFM3Class name.
-	(self ofInterest: aFM3Class)
-	ifFalse: [
-		externalClasses add: aFM3Class 
-	]
+FamixMMUMLDocumentor >> generateClassesOfNoInterest: aFM3Class [
+	outputStream nextPutAll: 'hide '.
+		self generateClassName: aFM3Class
 ]
 
 { #category : #generating }
 FamixMMUMLDocumentor >> generateExternalClass: aFM3Class [
-	outputStream
-		nextPutAll: 'class '.
+
+	outputStream nextPutAll: 'class '.
 	self generateClassName: aFM3Class.
-	(self ofInterest: aFM3Class)
-		ifFalse: [
-			outputStream nextPutAll: ' <<External>>'
-		].
+	(self ofInterest: aFM3Class) ifFalse: [ 
+		outputStream nextPutAll: ' <<'.
+		aFM3Class isClass
+			ifTrue: [ outputStream nextPutAll: '(C,LightYellow)' ]
+			ifFalse: [ outputStream nextPutAll: '(T,LightYellow)' ].
+		outputStream nextPutAll: 'External>>' ].
 	outputStream cr
 ]
 
@@ -123,10 +103,110 @@ FamixMMUMLDocumentor >> generatePlantUMLFile: aString with: aCollection [
 ]
 
 { #category : #generating }
+FamixMMUMLDocumentor >> generatePlantUMLHideClassesOfNoInterest [
+	classesOfNoInterest do: [:clazz | self generateClassesOfNoInterest: clazz]
+]
+
+{ #category : #generating }
 FamixMMUMLDocumentor >> generatePlantUMLInheritance [
-	classesOfInterest do: [ :clazz | 
-			self visitClassInheritances: clazz
-	]
+
+	| aVisitor |
+	aVisitor := FamixMMUMLInheritanceDocumentor new
+		            outputStream: outputStream ;
+		            classesOfInterest: classesOfInterest ;
+		            externalClasses: externalClasses ;
+						withStub: withStub ;
+						model: model.
+	classesOfInterest do: [ :clazz | clazz accept: aVisitor ]
+]
+
+{ #category : #'api - generation' }
+FamixMMUMLDocumentor >> generatePlantUMLModel [
+
+	| aStream |
+	aStream := ReadWriteStream with: (String new).
+	self generatePlantUMLModelOnStream: aStream.
+	^ outputStream contents 
+]
+
+{ #category : #'api - generation' }
+FamixMMUMLDocumentor >> generatePlantUMLModelFile: aString [
+	| filename |
+	filename := (aString endsWith: self plantUMLExtension)
+		ifTrue: [ aString ]
+		ifFalse: [ aString , self plantUMLExtension].
+	^filename asFileReference writeStreamDo: [ :stream |
+		self generatePlantUMLModelOnStream: stream.
+	] 
+]
+
+{ #category : #'api - generation' }
+FamixMMUMLDocumentor >> generatePlantUMLModelFile: aString without: aCollection [
+	| filename |
+	filename := (aString endsWith: self plantUMLExtension)
+		ifTrue: [ aString ]
+		ifFalse: [ aString , self plantUMLExtension].
+	^filename asFileReference writeStreamDo: [ :stream |
+		self generatePlantUMLModelWithout: aCollection onStream: stream.
+	] 
+]
+
+{ #category : #'api - generation' }
+FamixMMUMLDocumentor >> generatePlantUMLModelOnStream: aStream [
+	outputStream := aStream.
+	classesOfInterest := (model metamodel descriptionOf: model) package classes.
+	externalClasses := Set new.
+
+	self plantUMLHeader.
+	outputStream cr.
+	self generatePlantUMLClasses.
+	outputStream cr.
+	self generatePlantUMLInheritance.
+	outputStream cr.
+	self generatePlantUMLRelations.
+	outputStream cr.
+	self generatePlantUMLExternalClasses.
+	outputStream cr.
+	self plantUMLFooter.
+
+]
+
+{ #category : #'api - generation' }
+FamixMMUMLDocumentor >> generatePlantUMLModelWithout: aCollection [
+
+	| aStream |
+	aStream := ReadWriteStream with: String new.
+
+	aCollection isEmpty
+		ifTrue: [ self generatePlantUMLModelOnStream: aStream ]
+		ifFalse: [ 
+		self generatePlantUMLModelWithout: aCollection onStream: aStream ].
+	^ outputStream contents
+]
+
+{ #category : #'api - generation' }
+FamixMMUMLDocumentor >> generatePlantUMLModelWithout: aCollection onStream: aStream [
+
+	outputStream := aStream.
+	classesOfNoInterest := aCollection
+		collect: [:stClass | model metamodel descriptionOf: stClass ].
+	classesOfInterest := (model metamodel descriptionOf: model) package
+		                     classes.
+	externalClasses := Set new.
+
+	self plantUMLHeader.
+	outputStream cr.
+	self generatePlantUMLClasses.
+	outputStream cr.
+	self generatePlantUMLInheritance.
+	outputStream cr.
+	self generatePlantUMLRelations.
+	outputStream cr.
+	self generatePlantUMLExternalClasses.
+	outputStream cr.
+	self generatePlantUMLHideClassesOfNoInterest.
+	outputStream cr.
+	self plantUMLFooter
 ]
 
 { #category : #generating }
@@ -190,12 +270,6 @@ FamixMMUMLDocumentor >> generateRelationTargetRole: aFM3Prop [
 		nextPut: $"
 ]
 
-{ #category : #initialization }
-FamixMMUMLDocumentor >> initialize [
-	self beWithoutStub.
-	externalClasses := Set new
-]
-
 { #category : #testing }
 FamixMMUMLDocumentor >> isRedundantRelation: aFM3Prop [
 	"whena relation has an opposite, we want to display process only one of them (the 'non redundant' one.
@@ -218,36 +292,6 @@ FamixMMUMLDocumentor >> isRedundantRelation: aFM3Prop [
 { #category : #testing }
 FamixMMUMLDocumentor >> isTrait: aFMClass [
 	^aFMClass implementingClass isTrait
-]
-
-{ #category : #accessing }
-FamixMMUMLDocumentor >> isWithStub [
-	^withStub
-]
-
-{ #category : #accessing }
-FamixMMUMLDocumentor >> model [
-	^ model
-]
-
-{ #category : #accessing }
-FamixMMUMLDocumentor >> model: anObject [
-	model := anObject
-]
-
-{ #category : #testing }
-FamixMMUMLDocumentor >> ofInterest: aFMClass [
-	^classesOfInterest includes: aFMClass
-]
-
-{ #category : #accessing }
-FamixMMUMLDocumentor >> outputStream [
-	^ outputStream
-]
-
-{ #category : #accessing }
-FamixMMUMLDocumentor >> outputStream: anObject [
-	outputStream := anObject
 ]
 
 { #category : #private }
@@ -291,13 +335,6 @@ FamixMMUMLDocumentor >> plantUMLMarkerFor: aFMClass [
 	^(self isTrait: aFMClass)
 		ifTrue: [ 'T' ]
 		ifFalse: [ 'C' ]
-]
-
-{ #category : #testing }
-FamixMMUMLDocumentor >> relationEndOfInterest: aFMClass [
-	^self isWithStub
-		ifTrue: [ aFMClass class ~= FM3Object ]
-		ifFalse: [ self ofInterest: aFMClass ]
 ]
 
 { #category : #visiting }
@@ -372,4 +409,22 @@ FamixMMUMLDocumentor >> visitRelation: aFM3Prop [
 	outputStream space.
 	self generateRelationTarget: aFM3Prop.
 	outputStream cr
+]
+
+{ #category : #visiting }
+FamixMMUMLDocumentor >> visitTrait: aFMTrait [
+	outputStream
+		nextPutAll: 'class ' ;
+		nextPutAll: aFMTrait name ;
+		nextPutAll: ' << (' ;
+		nextPutAll: (self plantUMLMarkerFor: aFMTrait) ;
+		nextPut: $, ;
+		nextPutAll: (self plantUMLColorFor: aFMTrait) ;
+		nextPutAll: ') >> {' ;
+		cr.
+	aFMTrait 
+		primitiveProperties do: [ :prop | prop accept: self ].
+	outputStream
+		nextPutAll: '}' ;
+		cr.
 ]

--- a/src/Famix-MetamodelDocumentor/FamixMMUMLDocumentorVisitorTest.class.st
+++ b/src/Famix-MetamodelDocumentor/FamixMMUMLDocumentorVisitorTest.class.st
@@ -152,3 +152,41 @@ FamixMMUMLDocumentorVisitorTest >> testVisitRelationToExternalClass [
 'Teacher " *teachers" -- " *students" Student
 '
 ]
+
+{ #category : #tests }
+FamixMMUMLDocumentorVisitorTest >> testVisitTraitUsed [
+	| contents |
+	contents := FamixMMUMLDocumentor new
+ 		model: FDModel ;
+ 		generatePlantUMLModel. 
+		
+	self assert: [ contents includesSubstring: 'Trait1 <|.. Trait2' ].
+	self assert: [ contents includesSubstring: 'Trait2 <|.. Trait3' ].
+	self assert: [ contents includesSubstring: 'Trait2 <|.. Trait4' ].
+	self assert: [ (contents includesSubstring: 'Trait1 <|.. Trait4')not ].
+	self assert: [ (contents includesSubstring: 'Trait1 <|.. Trait3')not ].
+]
+
+{ #category : #tests }
+FamixMMUMLDocumentorVisitorTest >> testVisitWithoutClasses [
+	| contents |
+	contents := FamixMMUMLDocumentor new
+ 		model: FDModel ;
+ 		generatePlantUMLModelWithout: { }. 
+	
+	contents := FamixMMUMLDocumentor new
+ 		model: FDModel ;
+ 		generatePlantUMLModelWithout: { FDTrait1 }. 
+	
+	self assert: [ contents includesSubstring: 'hide Trait1' ].
+]
+
+{ #category : #tests }
+FamixMMUMLDocumentorVisitorTest >> testVisitWithoutClassesWithEmptyCollection [
+	| contents |
+	contents := FamixMMUMLDocumentor new
+ 		model: FDModel ;
+ 		generatePlantUMLModelWithout: { }. 
+	
+	self assert: [ ((contents allButFirst: 30) includesSubstring: 'hide')not ].
+]

--- a/src/Famix-MetamodelDocumentor/FamixMMUMLInheritanceDocumentor.class.st
+++ b/src/Famix-MetamodelDocumentor/FamixMMUMLInheritanceDocumentor.class.st
@@ -1,0 +1,49 @@
+"
+I'm a micro visitor who takes care of distinguishing inheritance for classes and traits.
+That is, trait inheritance is actually a use.
+
+I print, therefore, the inheritance or use of the class or trait in the stream.
+
+I am called by the main visitor, FamixMMUMLDocumentor, in its generatePlantUMLInheritance method.
+"
+Class {
+	#name : #FamixMMUMLInheritanceDocumentor,
+	#superclass : #FamixMMUMLAbstractDocumentor,
+	#category : #'Famix-MetamodelDocumentor'
+}
+
+{ #category : #visiting }
+FamixMMUMLInheritanceDocumentor >> visitClass: aFMClass [
+	| aFMSuperClass |
+	aFMSuperClass := aFMClass superclass.
+	(self relationEndOfInterest: aFMClass) ifFalse: [ ^ self ].
+	(self relationEndOfInterest: aFMSuperClass) ifFalse: [ ^ self ].
+	self generateClassName: aFMSuperClass.
+	outputStream nextPutAll: ' <|-- '.
+	self generateClassName: aFMClass.
+	outputStream cr.
+   aFMClass traits do: [ :aTrait | self visitUsedTrait: aTrait byClass: aFMClass ]
+]
+
+{ #category : #visiting }
+FamixMMUMLInheritanceDocumentor >> visitTrait: aFMTrait [
+	self flag: 'Hack to access to direct traits only - https://github.com/moosetechnology/Fame/issues/23'.
+	(aFMTrait implementingClass traits collect: [:stClass | model metamodel descriptionOf: stClass ])  do: [ :aFMSuperTrait | 
+	(self relationEndOfInterest: aFMTrait) ifFalse: [ ^ self ].
+	(self relationEndOfInterest: aFMSuperTrait ) ifFalse: [ ^ self ].
+	self generateClassName: aFMSuperTrait .
+	outputStream nextPutAll: ' <|.. '.
+	self generateClassName: aFMTrait .
+	outputStream cr.]
+]
+
+{ #category : #visiting }
+FamixMMUMLInheritanceDocumentor >> visitUsedTrait: aTrait byClass: aFMClass [
+	(self relationEndOfInterest: aTrait) ifFalse: [ ^ self ].
+	(self relationEndOfInterest: aTrait) ifFalse: [ ^ self ].
+
+	self generateClassName: aTrait.
+	outputStream nextPutAll: ' <|.. '.
+	self generateClassName: aFMClass.
+	outputStream cr
+]

--- a/src/Famix-MetamodelDocumentor/FamixMMUMLTest1Generator.class.st
+++ b/src/Famix-MetamodelDocumentor/FamixMMUMLTest1Generator.class.st
@@ -1,0 +1,45 @@
+"
+I am a Famix meta model generator to test the use of traits.
+"
+Class {
+	#name : #FamixMMUMLTest1Generator,
+	#superclass : #FamixMetamodelGenerator,
+	#instVars : [
+		't1',
+		't2',
+		't3',
+		't4'
+	],
+	#category : #'Famix-MetamodelDocumentor'
+}
+
+{ #category : #accessing }
+FamixMMUMLTest1Generator class >> packageName [
+
+	^ #'Famix-TestModel1MetamodelDocumentor'
+]
+
+{ #category : #accessing }
+FamixMMUMLTest1Generator class >> prefix [
+
+	^ #'FD'
+]
+
+{ #category : #definition }
+FamixMMUMLTest1Generator >> defineHierarchy [
+
+	super defineHierarchy.
+	t2 --|> t1.
+	t3 --|> t2.
+	t4 --|> t2
+]
+
+{ #category : #definition }
+FamixMMUMLTest1Generator >> defineTraits [
+
+	super defineTraits.
+	t1 := builder newTraitNamed: #Trait1.
+	t2 := builder newTraitNamed: #Trait2.
+	t3 := builder newTraitNamed: #Trait3.
+	t4 := builder newTraitNamed: #Trait4
+]

--- a/src/Famix-TestModel1MetamodelDocumentor/FDModel.class.st
+++ b/src/Famix-TestModel1MetamodelDocumentor/FDModel.class.st
@@ -1,0 +1,12 @@
+Class {
+	#name : #FDModel,
+	#superclass : #MooseModel,
+	#category : #'Famix-TestModel1MetamodelDocumentor-Model'
+}
+
+{ #category : #meta }
+FDModel class >> annotation [
+	<FMClass: #FDModel super: #MooseModel>
+	<package: #'Famix-TestModel1MetamodelDocumentor'>
+	<generated>
+]

--- a/src/Famix-TestModel1MetamodelDocumentor/FDTrait1.trait.st
+++ b/src/Famix-TestModel1MetamodelDocumentor/FDTrait1.trait.st
@@ -1,0 +1,13 @@
+Trait {
+	#name : #FDTrait1,
+	#category : #'Famix-TestModel1MetamodelDocumentor-Traits'
+}
+
+{ #category : #meta }
+FDTrait1 classSide >> annotation [
+
+	<FMClass: #Trait1 super: #Object>
+	<package: #'Famix-TestModel1MetamodelDocumentor'>
+	<generated>
+	^self
+]

--- a/src/Famix-TestModel1MetamodelDocumentor/FDTrait2.trait.st
+++ b/src/Famix-TestModel1MetamodelDocumentor/FDTrait2.trait.st
@@ -1,0 +1,15 @@
+Trait {
+	#name : #FDTrait2,
+	#traits : 'FDTrait1',
+	#classTraits : 'FDTrait1 classTrait',
+	#category : #'Famix-TestModel1MetamodelDocumentor-Traits'
+}
+
+{ #category : #meta }
+FDTrait2 classSide >> annotation [
+
+	<FMClass: #Trait2 super: #Object>
+	<package: #'Famix-TestModel1MetamodelDocumentor'>
+	<generated>
+	^self
+]

--- a/src/Famix-TestModel1MetamodelDocumentor/FDTrait3.trait.st
+++ b/src/Famix-TestModel1MetamodelDocumentor/FDTrait3.trait.st
@@ -1,0 +1,15 @@
+Trait {
+	#name : #FDTrait3,
+	#traits : 'FDTrait2',
+	#classTraits : 'FDTrait2 classTrait',
+	#category : #'Famix-TestModel1MetamodelDocumentor-Traits'
+}
+
+{ #category : #meta }
+FDTrait3 classSide >> annotation [
+
+	<FMClass: #Trait3 super: #Object>
+	<package: #'Famix-TestModel1MetamodelDocumentor'>
+	<generated>
+	^self
+]

--- a/src/Famix-TestModel1MetamodelDocumentor/FDTrait4.trait.st
+++ b/src/Famix-TestModel1MetamodelDocumentor/FDTrait4.trait.st
@@ -1,0 +1,15 @@
+Trait {
+	#name : #FDTrait4,
+	#traits : 'FDTrait2',
+	#classTraits : 'FDTrait2 classTrait',
+	#category : #'Famix-TestModel1MetamodelDocumentor-Traits'
+}
+
+{ #category : #meta }
+FDTrait4 classSide >> annotation [
+
+	<FMClass: #Trait4 super: #Object>
+	<package: #'Famix-TestModel1MetamodelDocumentor'>
+	<generated>
+	^self
+]

--- a/src/Famix-TestModel1MetamodelDocumentor/package.st
+++ b/src/Famix-TestModel1MetamodelDocumentor/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'Famix-TestModel1MetamodelDocumentor' }


### PR DESCRIPTION
 - Update FamixMMUMLDocumentor with traits (refactoring FamixMMUMLDocumentor with a abstract class and a new visitor)
- Add generatePlantUMLModel in order to generate the whole model
- Add generatePlantUMLModelWithout: in order to generate the whole model without a collection of entities
- Add tests for visitTraitUsed, VisitWithoutClasses and VisitWithoutCLassesWithEmptyCollection
- Add FamixMMUMLDocumentor in the baseline of Famix