### PR TITLE
Without option of the FamixMMUMLDocumentor supports a collection with more than 2 elements

### DIFF
--- a/src/Famix-MetamodelDocumentor/FamixMMUMLDocumentor.class.st
+++ b/src/Famix-MetamodelDocumentor/FamixMMUMLDocumentor.class.st
@@ -42,7 +42,8 @@ Class {
 { #category : #generating }
 FamixMMUMLDocumentor >> generateClassesOfNoInterest: aFM3Class [
 	outputStream nextPutAll: 'hide '.
-		self generateClassName: aFM3Class
+		self generateClassName: aFM3Class.
+	outputStream cr.
 ]
 
 { #category : #generating }

--- a/src/Famix-MetamodelDocumentor/FamixMMUMLDocumentorVisitorTest.class.st
+++ b/src/Famix-MetamodelDocumentor/FamixMMUMLDocumentorVisitorTest.class.st
@@ -176,9 +176,10 @@ FamixMMUMLDocumentorVisitorTest >> testVisitWithoutClasses [
 	
 	contents := FamixMMUMLDocumentor new
  		model: FDModel ;
- 		generatePlantUMLModelWithout: { FDTrait1 }. 
-	
+ 		generatePlantUMLModelWithout: { FDTrait1 . FDTrait2 }.
+		
 	self assert: [ contents includesSubstring: 'hide Trait1' ].
+	self assert: [ (contents allButFirst: 450) includesSubstring: 'hide Trait2' ].
 ]
 
 { #category : #tests }


### PR DESCRIPTION
- Add outputStream cr in FamixMMUMLClassesDocumentor >> generateClassesOfNoInterest:
- Redesign of the without option test

FIX #307 