### PR TITLE
Fix generate relations with remote traits

### DIFF
--- a/src/BaselineOfFamix/BaselineOfFamix.class.st
+++ b/src/BaselineOfFamix/BaselineOfFamix.class.st
@@ -78,7 +78,7 @@ BaselineOfFamix >> baseline: spec [
 				package: 'Moose-SmalltalkImporter-KGB-Tests' with: [ spec requires: #('KGBTestResources' 'Moose-SmalltalkImporter-Core-Tests') ];
 
 				package: 'Famix-TestGenerators' with: [ spec requires: #('Basic') ];
-				package: 'Famix-MetamodelBuilder-Tests' with: [ spec requires: #('Famix-TestGenerators' . 'Famix-MetamodelBuilder-TestsTraitsResources-A' . 'Famix-MetamodelBuilder-TestsTraitsResources-B') ];
+				package: 'Famix-MetamodelBuilder-Tests' with: [ spec requires: #('Famix-TestGenerators' 'Famix-MetamodelBuilder-TestsTraitsResources-A' 'Famix-MetamodelBuilder-TestsTraitsResources-B') ];
 				package: 'Famix-MetamodelBuilder-TestsTraitsResources-A' with: [ spec requires: #('Basic') ];
 				package: 'Famix-MetamodelBuilder-TestsTraitsResources-B' with: [ spec requires: #('Basic') ];
 				

--- a/src/BaselineOfFamix/BaselineOfFamix.class.st
+++ b/src/BaselineOfFamix/BaselineOfFamix.class.st
@@ -78,7 +78,9 @@ BaselineOfFamix >> baseline: spec [
 				package: 'Moose-SmalltalkImporter-KGB-Tests' with: [ spec requires: #('KGBTestResources' 'Moose-SmalltalkImporter-Core-Tests') ];
 
 				package: 'Famix-TestGenerators' with: [ spec requires: #('Basic') ];
-				package: 'Famix-MetamodelBuilder-Tests' with: [ spec requires: #('Famix-TestGenerators') ];
+				package: 'Famix-MetamodelBuilder-Tests' with: [ spec requires: #('Famix-TestGenerators' . 'Famix-MetamodelBuilder-TestsTraitsResources-A' . 'Famix-MetamodelBuilder-TestsTraitsResources-B') ];
+				package: 'Famix-MetamodelBuilder-TestsTraitsResources-A' with: [ spec requires: #('Basic') ];
+				package: 'Famix-MetamodelBuilder-TestsTraitsResources-B' with: [ spec requires: #('Basic') ];
 				
 				package: 'Famix-Test1-Entities' with: [ spec requires: #('BasicTraits') ];
 				package: 'Famix-Test1-Tests' with: [ spec requires: #('Famix-Test1-Entities') ];

--- a/src/Famix-MetamodelBuilder-Core/FmxMBTrait.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxMBTrait.class.st
@@ -78,7 +78,7 @@ FmxMBTrait >> generateRemotes [
 	| aTrait traitName |
 	traitName := self fullName.
 
-	aTrait := self builder environment classNamed: traitName asSymbol.
+	aTrait := self class environment at: traitName asSymbol ifAbsent: [ builder environment classNamed: traitName asSymbol ].
 
 	self realClass: aTrait.
 

--- a/src/Famix-MetamodelBuilder-Tests/FamixMetamodelGenerateRemoteAccessorTraitTestGeneratorA.class.st
+++ b/src/Famix-MetamodelBuilder-Tests/FamixMetamodelGenerateRemoteAccessorTraitTestGeneratorA.class.st
@@ -1,0 +1,33 @@
+Class {
+	#name : #FamixMetamodelGenerateRemoteAccessorTraitTestGeneratorA,
+	#superclass : #FamixMetamodelGenerator,
+	#instVars : [
+		'fmx'
+	],
+	#category : #'Famix-MetamodelBuilder-Tests-GeneratorRessources'
+}
+
+{ #category : #testing }
+FamixMetamodelGenerateRemoteAccessorTraitTestGeneratorA class >> isRealMetamodel [
+	^ false
+]
+
+{ #category : #accessing }
+FamixMetamodelGenerateRemoteAccessorTraitTestGeneratorA class >> packageName [
+
+	<ignoreForCoverage>
+	^ 'Famix-MetamodelBuilder-TestsTraitsResources-A'
+]
+
+{ #category : #accessing }
+FamixMetamodelGenerateRemoteAccessorTraitTestGeneratorA class >> prefix [
+
+<ignoreForCoverage>
+	^ #FmxTraitsTestGenerateAccessorA
+]
+
+{ #category : #definition }
+FamixMetamodelGenerateRemoteAccessorTraitTestGeneratorA >> defineTraits [
+	super defineTraits.
+	fmx := builder newTraitNamed: #TraitA
+]

--- a/src/Famix-MetamodelBuilder-Tests/FamixMetamodelGenerateRemoteAccessorTraitTestGeneratorB.class.st
+++ b/src/Famix-MetamodelBuilder-Tests/FamixMetamodelGenerateRemoteAccessorTraitTestGeneratorB.class.st
@@ -1,0 +1,46 @@
+Class {
+	#name : #FamixMetamodelGenerateRemoteAccessorTraitTestGeneratorB,
+	#superclass : #FamixMetamodelGenerator,
+	#instVars : [
+		'traitB',
+		'traitA'
+	],
+	#category : #'Famix-MetamodelBuilder-Tests-GeneratorRessources'
+}
+
+{ #category : #testing }
+FamixMetamodelGenerateRemoteAccessorTraitTestGeneratorB class >> isRealMetamodel [
+	^ false
+]
+
+{ #category : #accessing }
+FamixMetamodelGenerateRemoteAccessorTraitTestGeneratorB class >> packageName [
+
+	<ignoreForCoverage>
+	^ 'Famix-MetamodelBuilder-TestsTraitsResources-B'
+]
+
+{ #category : #accessing }
+FamixMetamodelGenerateRemoteAccessorTraitTestGeneratorB class >> prefix [
+
+<ignoreForCoverage>
+	^ #FmxTraitsTestGenerateAccessorB
+]
+
+{ #category : #accessing }
+FamixMetamodelGenerateRemoteAccessorTraitTestGeneratorB class >> submetamodels [
+	^ { FamixMetamodelGenerateRemoteAccessorTraitTestGeneratorA }
+]
+
+{ #category : #definition }
+FamixMetamodelGenerateRemoteAccessorTraitTestGeneratorB >> defineRelations [
+	super defineRelations.
+	(traitA property: #relationToB) - (traitB property: #relationToB).
+]
+
+{ #category : #definition }
+FamixMetamodelGenerateRemoteAccessorTraitTestGeneratorB >> defineTraits [
+	super defineTraits.
+	traitB := builder newTraitNamed: #TraitB.
+	traitA := self remoteTrait: #TraitA withPrefix: #FmxTraitsTestGenerateAccessorA.
+]

--- a/src/Famix-MetamodelBuilder-Tests/FmxMBTraitTest.class.st
+++ b/src/Famix-MetamodelBuilder-Tests/FmxMBTraitTest.class.st
@@ -243,6 +243,16 @@ FmxMBTraitTest >> testDefaultPackageForUserClasses [
 ]
 
 { #category : #tests }
+FmxMBTraitTest >> testGenerateRemotes [
+	| traitA traitB |
+	traitA := FmxTraitsTestGenerateAccessorBModel metamodel elementNamed: 'Famix-MetamodelBuilder-TestsTraitsResources-A.TraitA'.
+	traitB := FmxTraitsTestGenerateAccessorBModel metamodel elementNamed: 'Famix-MetamodelBuilder-TestsTraitsResources-B.TraitB'.
+
+	self assert: (traitA complexProperties anySatisfy: [:each| each opposite mmClass = traitB]).
+	self assert: (traitB complexProperties anySatisfy: [:each| each opposite mmClass = traitA]).
+]
+
+{ #category : #tests }
 FmxMBTraitTest >> testMultipleTraits [
 
 	builder newTraitNamed: #TComment.	

--- a/src/Famix-MetamodelBuilder-TestsTraitsResources-A/FmxTraitsTestGenerateAccessorAModel.class.st
+++ b/src/Famix-MetamodelBuilder-TestsTraitsResources-A/FmxTraitsTestGenerateAccessorAModel.class.st
@@ -1,0 +1,12 @@
+Class {
+	#name : #FmxTraitsTestGenerateAccessorAModel,
+	#superclass : #MooseModel,
+	#category : #'Famix-MetamodelBuilder-TestsTraitsResources-A-Model'
+}
+
+{ #category : #meta }
+FmxTraitsTestGenerateAccessorAModel class >> annotation [
+	<FMClass: #FmxTraitsTestGenerateAccessorAModel super: #MooseModel>
+	<package: #'Famix-MetamodelBuilder-TestsTraitsResources-A'>
+	<generated>
+]

--- a/src/Famix-MetamodelBuilder-TestsTraitsResources-A/FmxTraitsTestGenerateAccessorATraitA.trait.st
+++ b/src/Famix-MetamodelBuilder-TestsTraitsResources-A/FmxTraitsTestGenerateAccessorATraitA.trait.st
@@ -1,0 +1,13 @@
+Trait {
+	#name : #FmxTraitsTestGenerateAccessorATraitA,
+	#category : #'Famix-MetamodelBuilder-TestsTraitsResources-A-Traits'
+}
+
+{ #category : #meta }
+FmxTraitsTestGenerateAccessorATraitA classSide >> annotation [
+
+	<FMClass: #TraitA super: #Object>
+	<package: #'Famix-MetamodelBuilder-TestsTraitsResources-A'>
+	<generated>
+	^self
+]

--- a/src/Famix-MetamodelBuilder-TestsTraitsResources-A/package.st
+++ b/src/Famix-MetamodelBuilder-TestsTraitsResources-A/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'Famix-MetamodelBuilder-TestsTraitsResources-A' }

--- a/src/Famix-MetamodelBuilder-TestsTraitsResources-B/FmxTraitsTestGenerateAccessorATraitA.extension.st
+++ b/src/Famix-MetamodelBuilder-TestsTraitsResources-B/FmxTraitsTestGenerateAccessorATraitA.extension.st
@@ -1,0 +1,25 @@
+Extension { #name : #FmxTraitsTestGenerateAccessorATraitA }
+
+{ #category : #'*Famix-MetamodelBuilder-TestsTraitsResources-B-accessing' }
+FmxTraitsTestGenerateAccessorATraitA >> relationToB [
+	"Relation named: #relationToB type: #FmxTraitsTestGenerateAccessorBTraitB opposite: #relationToB"
+
+	<generated>
+	<FMProperty: #relationToB type: #FmxTraitsTestGenerateAccessorBTraitB opposite: #relationToB>
+	<package: #'Famix-MetamodelBuilder-TestsTraitsResources-B'>
+	^ self attributeAt: #relationToB ifAbsent: [ nil ]
+]
+
+{ #category : #'*Famix-MetamodelBuilder-TestsTraitsResources-B-accessing' }
+FmxTraitsTestGenerateAccessorATraitA >> relationToB: anObject [
+
+	<generated>
+	(self attributeAt: #relationToB ifAbsentPut: [nil]) == anObject ifTrue: [ ^ anObject ].
+	anObject ifNil: [ | otherSide |
+		otherSide :=  self relationToB.
+		self attributeAt: #relationToB put: anObject.
+		otherSide relationToB: nil ]
+	ifNotNil: [ 
+		self attributeAt: #relationToB put: anObject.
+		anObject relationToB: self ]
+]

--- a/src/Famix-MetamodelBuilder-TestsTraitsResources-B/FmxTraitsTestGenerateAccessorBModel.class.st
+++ b/src/Famix-MetamodelBuilder-TestsTraitsResources-B/FmxTraitsTestGenerateAccessorBModel.class.st
@@ -1,0 +1,18 @@
+Class {
+	#name : #FmxTraitsTestGenerateAccessorBModel,
+	#superclass : #MooseModel,
+	#category : #'Famix-MetamodelBuilder-TestsTraitsResources-B-Model'
+}
+
+{ #category : #accessing }
+FmxTraitsTestGenerateAccessorBModel class >> allSubmetamodelsPackagesNames [
+	<generated>
+	^ #('Famix-MetamodelBuilder-TestsTraitsResources-A')
+]
+
+{ #category : #meta }
+FmxTraitsTestGenerateAccessorBModel class >> annotation [
+	<FMClass: #FmxTraitsTestGenerateAccessorBModel super: #MooseModel>
+	<package: #'Famix-MetamodelBuilder-TestsTraitsResources-B'>
+	<generated>
+]

--- a/src/Famix-MetamodelBuilder-TestsTraitsResources-B/FmxTraitsTestGenerateAccessorBTraitB.trait.st
+++ b/src/Famix-MetamodelBuilder-TestsTraitsResources-B/FmxTraitsTestGenerateAccessorBTraitB.trait.st
@@ -1,0 +1,37 @@
+Trait {
+	#name : #FmxTraitsTestGenerateAccessorBTraitB,
+	#category : #'Famix-MetamodelBuilder-TestsTraitsResources-B-Traits'
+}
+
+{ #category : #meta }
+FmxTraitsTestGenerateAccessorBTraitB classSide >> annotation [
+
+	<FMClass: #TraitB super: #Object>
+	<package: #'Famix-MetamodelBuilder-TestsTraitsResources-B'>
+	<generated>
+	^self
+]
+
+{ #category : #accessing }
+FmxTraitsTestGenerateAccessorBTraitB >> relationToB [
+	"Relation named: #relationToB type: #FmxTraitsTestGenerateAccessorATraitA opposite: #relationToB"
+
+	<generated>
+	<derived>
+	<FMProperty: #relationToB type: #FmxTraitsTestGenerateAccessorATraitA opposite: #relationToB>
+	^ self attributeAt: #relationToB ifAbsent: [ nil ]
+]
+
+{ #category : #accessing }
+FmxTraitsTestGenerateAccessorBTraitB >> relationToB: anObject [
+
+	<generated>
+	(self attributeAt: #relationToB ifAbsentPut: [nil]) == anObject ifTrue: [ ^ anObject ].
+	anObject ifNil: [ | otherSide |
+		otherSide :=  self relationToB.
+		self attributeAt: #relationToB put: anObject.
+		otherSide relationToB: nil ]
+	ifNotNil: [ 
+		self attributeAt: #relationToB put: anObject.
+		anObject relationToB: self ]
+]

--- a/src/Famix-MetamodelBuilder-TestsTraitsResources-B/package.st
+++ b/src/Famix-MetamodelBuilder-TestsTraitsResources-B/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'Famix-MetamodelBuilder-TestsTraitsResources-B' }


### PR DESCRIPTION
In generateRemotes of FmxMBTrait, fix counterpart to FmxMBClass. Change the search for the realClass.

Added two test metamodels and an associated test.

fix #311