### PR TITLE
Add default value support for generators

### DIFF
--- a/src/BaselineOfFamix/BaselineOfFamix.class.st
+++ b/src/BaselineOfFamix/BaselineOfFamix.class.st
@@ -90,6 +90,8 @@ BaselineOfFamix >> baseline: spec [
 				package: 'Famix-Test4-Tests' with: [ spec requires: #('Famix-Test4-Entities') ];
 				package: 'Famix-Test5-Entities' with: [ spec requires: #('BasicTraits') ];
 				package: 'Famix-Test5-Tests' with: [ spec requires: #('Famix-Test5-Entities') ];
+				package: 'Famix-Test6-Entities' with: [ spec requires: #('BasicTraits') ];
+				package: 'Famix-Test6-Tests' with: [ spec requires: #('Famix-Test6-Entities') ];
 				package: 'Famix-TestComposedSubmetamodel1-Entities' with: [ spec requires: #('BasicTraits') ];
 				package: 'Famix-TestComposedSubmetamodel2-Entities' with: [ spec requires: #('BasicTraits') ];
 				package: 'Famix-TestComposedMetamodel-Entities' with: [ spec requires: #('Famix-Test2-Entities' 'Famix-TestComposedSubmetamodel1-Entities' 'Famix-TestComposedSubmetamodel2-Entities') ];

--- a/src/Famix-MetamodelBuilder-Core/FmxMBBehavior.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxMBBehavior.class.st
@@ -193,7 +193,8 @@ FmxMBBehavior >> generateInitializeFor: aClass [
 	defaultValuedProperties := self properties select: #hasDefaultValue.
 	defaultValuedProperties ifEmpty: [ ^ self ].
 	methodSource := String streamContents: [ :s |
-		s nextPutAll: 'initialize'; cr; cr.
+		s nextPutAll: 'initialize'; cr.
+		s nextPutAll: '<generated>'; cr; cr.
 		s nextPutAll: 'super initialize.'; cr; cr.
 		s nextPutAll: '"Default value initialization"'; cr.
 			defaultValuedProperties do: [ :prop | 

--- a/src/Famix-MetamodelBuilder-Core/FmxMBBehavior.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxMBBehavior.class.st
@@ -182,6 +182,29 @@ FmxMBBehavior >> generateAnnotationIn: aRealClass as: aName superclass: aSupercl
 ]
 
 { #category : #generating }
+FmxMBBehavior >> generateInitialize [
+	self generateInitializeFor: self realClass
+]
+
+{ #category : #generating }
+FmxMBBehavior >> generateInitializeFor: aClass [
+	| methodSource defaultValuedProperties |
+	
+	defaultValuedProperties := self properties select: #hasDefaultValue.
+	methodSource := String streamContents: [ :s |
+		s nextPutAll: 'initialize'; cr; cr.
+		s nextPutAll: 'super initialize.'; cr; cr.
+		s nextPutAll: '"Default value initialization"'; cr.
+			defaultValuedProperties do: [ :prop | 
+				s nextPutAll: ('{1} := {2}.' format: {prop name. prop defaultValue}); cr.	
+			].
+		 ].
+	self builder environment compile: methodSource 
+								   in: aClass instanceSide
+									classified: #initialization
+]
+
+{ #category : #generating }
 FmxMBBehavior >> generateMethodsToRemoveFromTraitCompositionFor: aBehavioral [
 	"In case of method conflict the user can select methods to remove from a trait. In that case we give the information to ring here."
 

--- a/src/Famix-MetamodelBuilder-Core/FmxMBBehavior.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxMBBehavior.class.st
@@ -376,6 +376,21 @@ FmxMBBehavior >> property: propertyName type: aTypeName [
 	^ aSide
 ]
 
+{ #category : #accessing }
+FmxMBBehavior >> property: propertyName type: aTypeName defaultValue: aValue [ 
+	| aSide |
+	aSide := FmxMBTypedProperty new
+		builder: self builder;
+		name: propertyName;
+		propertyType: aTypeName asSymbol;
+		defaultValue: aValue;
+		yourself.
+
+	self properties add: aSide.
+
+	^ aSide
+]
+
 { #category : #private }
 FmxMBBehavior >> propertyName [
 	^ self name uncapitalized

--- a/src/Famix-MetamodelBuilder-Core/FmxMBBehavior.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxMBBehavior.class.st
@@ -193,12 +193,12 @@ FmxMBBehavior >> generateInitializeFor: aClass [
 	defaultValuedProperties := self properties select: #hasDefaultValue.
 	defaultValuedProperties ifEmpty: [ ^ self ].
 	methodSource := String streamContents: [ :s |
-		s nextPutAll: 'initialize'; cr.
-		s nextPutAll: '<generated>'; cr; cr.
-		s nextPutAll: 'super initialize.'; cr; cr.
-		s nextPutAll: '"Default value initialization"'; cr.
+		s nextPutAll: 'initialize'; cr; cr.
+		s tab; nextPutAll: '<generated>'; cr.
+		s tab; nextPutAll: 'super initialize.'; cr; cr.
+		s tab; nextPutAll: '"Default value initialization"'; cr.
 			defaultValuedProperties do: [ :prop | 
-				s nextPutAll: ('{1} := {2}.' format: {prop name. prop defaultValue}); cr.	
+				s tab; nextPutAll: ('{1} := {2}.' format: {prop name. prop defaultValue}); cr.	
 			].
 		 ].
 	self builder environment compile: methodSource 

--- a/src/Famix-MetamodelBuilder-Core/FmxMBBehavior.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxMBBehavior.class.st
@@ -191,6 +191,7 @@ FmxMBBehavior >> generateInitializeFor: aClass [
 	| methodSource defaultValuedProperties |
 	
 	defaultValuedProperties := self properties select: #hasDefaultValue.
+	defaultValuedProperties ifEmpty: [ ^ self ].
 	methodSource := String streamContents: [ :s |
 		s nextPutAll: 'initialize'; cr; cr.
 		s nextPutAll: 'super initialize.'; cr; cr.

--- a/src/Famix-MetamodelBuilder-Core/FmxMBClass.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxMBClass.class.st
@@ -63,6 +63,8 @@ FmxMBClass >> generate [
 			
 	self realClass: aClass.
 	
+	self generateInitialize.
+	
 	self generateAccessors.
 	self generateAnnotationIn: aClass as: self name superclass: nil.
 	

--- a/src/Famix-MetamodelBuilder-Core/FmxMBProperty.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxMBProperty.class.st
@@ -34,6 +34,11 @@ FmxMBProperty >> generateSetterIn: aClassOrTrait [
 	self subclassResponsibility
 ]
 
+{ #category : #printing }
+FmxMBProperty >> hasDefaultValue [
+	^ false
+]
+
 { #category : #initialization }
 FmxMBProperty >> initialize [
 	super initialize.

--- a/src/Famix-MetamodelBuilder-Core/FmxMBRingEnvironment.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxMBRingEnvironment.class.st
@@ -217,3 +217,9 @@ FmxMBRingEnvironment >> slotNamed: slotName cardinality: cardinality type: type 
 		 expression: ('{1} type: #{2} opposite: #{3}' 
 			format: { cardinalityClassName. type. oppositeName}) 
 ]
+
+{ #category : #initialization }
+FmxMBRingEnvironment >> slotNamed: slotName defaultValue: aValue [
+	aValue ifNil: [ ^ self slotNamed: slotName ].
+	^ (RGUnknownSlot named: slotName asSymbol) expression: ('FMProperty defaultValue: {1}' format: { aValue })
+]

--- a/src/Famix-MetamodelBuilder-Core/FmxMBTrait.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxMBTrait.class.st
@@ -62,6 +62,8 @@ FmxMBTrait >> generate [
 			
 	self realClass: aTrait.
 	
+	self generateInitialize.
+	
 	self generateAccessors.
 	self generateAnnotationIn: aTrait as: self name superclass: nil.
 	

--- a/src/Famix-MetamodelBuilder-Core/FmxMBTypedProperty.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxMBTypedProperty.class.st
@@ -38,10 +38,12 @@ FmxMBTypedProperty >> defaultValue: aValue [
 { #category : #generating }
 FmxMBTypedProperty >> generateGetterIn: aClassOrTrait [
 
-	| methodSource propertyDefinition commentDefinition |
+	| methodSource propertyDefinition commentDefinition pragmaFormat |
 
-	propertyDefinition := '<FMProperty: #{1} type: #{2}>' 
-		format: { self name. self propertyType }.
+	pragmaFormat := self defaultValue ifNil: [ '<FMProperty: #{1} type: #{2}>' ] 
+											   ifNotNil: [ '<FMProperty: #{1} type: #{2} defaultValue: {3}>' ]. 
+	propertyDefinition := pragmaFormat
+		format: { self name. self propertyType. self defaultValue }.
 
 	commentDefinition := self comment
 		ifNotEmpty: [ '<FMComment: {1}>' format: { self comment printString } ].

--- a/src/Famix-MetamodelBuilder-Core/FmxMBTypedProperty.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxMBTypedProperty.class.st
@@ -6,7 +6,8 @@ Class {
 	#superclass : #FmxMBProperty,
 	#instVars : [
 		'propertyType',
-		'multivalued'
+		'multivalued',
+		'defaultValue'
 	],
 	#category : #'Famix-MetamodelBuilder-Core-Implementation'
 }
@@ -22,6 +23,16 @@ FmxMBTypedProperty >> asSlot [
 	self propertyType ifNil: [ FmxMBIncompletePropertyDefiniton signal ].
 
 	^ self builder environment slotNamed: self name asSymbol
+]
+
+{ #category : #accessing }
+FmxMBTypedProperty >> defaultValue [
+	^ defaultValue
+]
+
+{ #category : #accessing }
+FmxMBTypedProperty >> defaultValue: aValue [
+	defaultValue := aValue
 ]
 
 { #category : #generating }

--- a/src/Famix-MetamodelBuilder-Core/FmxMBTypedProperty.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxMBTypedProperty.class.st
@@ -22,7 +22,7 @@ FmxMBTypedProperty >> acceptVisitor: aVisitor [
 FmxMBTypedProperty >> asSlot [
 	self propertyType ifNil: [ FmxMBIncompletePropertyDefiniton signal ].
 
-	^ self builder environment slotNamed: self name asSymbol
+	^ self builder environment slotNamed: self name asSymbol defaultValue: self defaultValue 
 ]
 
 { #category : #accessing }

--- a/src/Famix-MetamodelBuilder-Core/FmxMBTypedProperty.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxMBTypedProperty.class.st
@@ -76,6 +76,11 @@ FmxMBTypedProperty >> generateSetterIn: aClassOrTrait [
 		classified: 'accessing'
 ]
 
+{ #category : #generating }
+FmxMBTypedProperty >> hasDefaultValue [
+	^ defaultValue isNotNil
+]
+
 { #category : #initialization }
 FmxMBTypedProperty >> initialize [
 	super initialize.

--- a/src/Famix-Test6-Entities/FamixTest6Bacon.class.st
+++ b/src/Famix-Test6-Entities/FamixTest6Bacon.class.st
@@ -33,13 +33,13 @@ FamixTest6Bacon >> eggs: anObject [
 
 { #category : #initialization }
 FamixTest6Bacon >> initialize [
-<generated>
 
-super initialize.
+	<generated>
+	super initialize.
 
-"Default value initialization"
-isFood := true.
-eggs := 12.
+	"Default value initialization"
+	isFood := true.
+	eggs := 12.
 
 ]
 

--- a/src/Famix-Test6-Entities/FamixTest6Bacon.class.st
+++ b/src/Famix-Test6-Entities/FamixTest6Bacon.class.st
@@ -1,0 +1,57 @@
+Class {
+	#name : #FamixTest6Bacon,
+	#superclass : #FamixTest6Entity,
+	#instVars : [
+		'#isFood => FMProperty defaultValue: true',
+		'#eggs => FMProperty defaultValue: 12'
+	],
+	#category : #'Famix-Test6-Entities-Entities'
+}
+
+{ #category : #meta }
+FamixTest6Bacon class >> annotation [
+
+	<FMClass: #Bacon super: #FamixTest6Entity>
+	<package: #'Famix-Test6-Entities'>
+	<generated>
+	^self
+]
+
+{ #category : #accessing }
+FamixTest6Bacon >> eggs [
+
+	<FMProperty: #eggs type: #Number defaultValue: 12>
+	<generated>
+	^ eggs
+]
+
+{ #category : #accessing }
+FamixTest6Bacon >> eggs: anObject [
+	<generated>
+	eggs := anObject
+]
+
+{ #category : #initialization }
+FamixTest6Bacon >> initialize [
+
+super initialize.
+
+"Default value initialization"
+isFood := true.
+eggs := 12.
+
+]
+
+{ #category : #accessing }
+FamixTest6Bacon >> isFood [
+
+	<FMProperty: #isFood type: #Boolean defaultValue: true>
+	<generated>
+	^ isFood
+]
+
+{ #category : #accessing }
+FamixTest6Bacon >> isFood: anObject [
+	<generated>
+	isFood := anObject
+]

--- a/src/Famix-Test6-Entities/FamixTest6Bacon.class.st
+++ b/src/Famix-Test6-Entities/FamixTest6Bacon.class.st
@@ -33,6 +33,7 @@ FamixTest6Bacon >> eggs: anObject [
 
 { #category : #initialization }
 FamixTest6Bacon >> initialize [
+<generated>
 
 super initialize.
 

--- a/src/Famix-Test6-Entities/FamixTest6Comment.class.st
+++ b/src/Famix-Test6-Entities/FamixTest6Comment.class.st
@@ -14,12 +14,3 @@ FamixTest6Comment class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #initialization }
-FamixTest6Comment >> initialize [
-
-super initialize.
-
-"Default value initialization"
-
-]

--- a/src/Famix-Test6-Entities/FamixTest6Comment.class.st
+++ b/src/Famix-Test6-Entities/FamixTest6Comment.class.st
@@ -1,0 +1,25 @@
+Class {
+	#name : #FamixTest6Comment,
+	#superclass : #FamixTest6SourcedEntity,
+	#traits : 'FamixTComment',
+	#classTraits : 'FamixTComment classTrait',
+	#category : #'Famix-Test6-Entities-Entities'
+}
+
+{ #category : #meta }
+FamixTest6Comment class >> annotation [
+
+	<FMClass: #Comment super: #FamixTest6SourcedEntity>
+	<package: #'Famix-Test6-Entities'>
+	<generated>
+	^self
+]
+
+{ #category : #initialization }
+FamixTest6Comment >> initialize [
+
+super initialize.
+
+"Default value initialization"
+
+]

--- a/src/Famix-Test6-Entities/FamixTest6Entity.class.st
+++ b/src/Famix-Test6-Entities/FamixTest6Entity.class.st
@@ -1,0 +1,30 @@
+Class {
+	#name : #FamixTest6Entity,
+	#superclass : #MooseEntity,
+	#category : #'Famix-Test6-Entities-Entities'
+}
+
+{ #category : #meta }
+FamixTest6Entity class >> annotation [
+
+	<FMClass: #Entity super: #MooseEntity>
+	<package: #'Famix-Test6-Entities'>
+	<generated>
+	^self
+]
+
+{ #category : #meta }
+FamixTest6Entity class >> metamodel [
+
+	<generated>
+	^ FamixTest6Model metamodel
+]
+
+{ #category : #initialization }
+FamixTest6Entity >> initialize [
+
+super initialize.
+
+"Default value initialization"
+
+]

--- a/src/Famix-Test6-Entities/FamixTest6Entity.class.st
+++ b/src/Famix-Test6-Entities/FamixTest6Entity.class.st
@@ -19,12 +19,3 @@ FamixTest6Entity class >> metamodel [
 	<generated>
 	^ FamixTest6Model metamodel
 ]
-
-{ #category : #initialization }
-FamixTest6Entity >> initialize [
-
-super initialize.
-
-"Default value initialization"
-
-]

--- a/src/Famix-Test6-Entities/FamixTest6Model.class.st
+++ b/src/Famix-Test6-Entities/FamixTest6Model.class.st
@@ -16,12 +16,3 @@ FamixTest6Model class >> annotation [
 	<package: #'Famix-Test6-Entities'>
 	<generated>
 ]
-
-{ #category : #initialization }
-FamixTest6Model >> initialize [
-
-super initialize.
-
-"Default value initialization"
-
-]

--- a/src/Famix-Test6-Entities/FamixTest6Model.class.st
+++ b/src/Famix-Test6-Entities/FamixTest6Model.class.st
@@ -1,0 +1,27 @@
+Class {
+	#name : #FamixTest6Model,
+	#superclass : #MooseModel,
+	#category : #'Famix-Test6-Entities-Model'
+}
+
+{ #category : #accessing }
+FamixTest6Model class >> allSubmetamodelsPackagesNames [
+	<generated>
+	^ #(#'Moose-Query' #'Famix-Traits')
+]
+
+{ #category : #meta }
+FamixTest6Model class >> annotation [
+	<FMClass: #FamixTest6Model super: #MooseModel>
+	<package: #'Famix-Test6-Entities'>
+	<generated>
+]
+
+{ #category : #initialization }
+FamixTest6Model >> initialize [
+
+super initialize.
+
+"Default value initialization"
+
+]

--- a/src/Famix-Test6-Entities/FamixTest6NamedEntity.class.st
+++ b/src/Famix-Test6-Entities/FamixTest6NamedEntity.class.st
@@ -1,0 +1,25 @@
+Class {
+	#name : #FamixTest6NamedEntity,
+	#superclass : #FamixTest6SourcedEntity,
+	#traits : 'FamixTNamedEntity',
+	#classTraits : 'FamixTNamedEntity classTrait',
+	#category : #'Famix-Test6-Entities-Entities'
+}
+
+{ #category : #meta }
+FamixTest6NamedEntity class >> annotation [
+
+	<FMClass: #NamedEntity super: #FamixTest6SourcedEntity>
+	<package: #'Famix-Test6-Entities'>
+	<generated>
+	^self
+]
+
+{ #category : #initialization }
+FamixTest6NamedEntity >> initialize [
+
+super initialize.
+
+"Default value initialization"
+
+]

--- a/src/Famix-Test6-Entities/FamixTest6NamedEntity.class.st
+++ b/src/Famix-Test6-Entities/FamixTest6NamedEntity.class.st
@@ -14,12 +14,3 @@ FamixTest6NamedEntity class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #initialization }
-FamixTest6NamedEntity >> initialize [
-
-super initialize.
-
-"Default value initialization"
-
-]

--- a/src/Famix-Test6-Entities/FamixTest6SourceAnchor.class.st
+++ b/src/Famix-Test6-Entities/FamixTest6SourceAnchor.class.st
@@ -1,0 +1,25 @@
+Class {
+	#name : #FamixTest6SourceAnchor,
+	#superclass : #FamixTest6Entity,
+	#traits : 'FamixTSourceAnchor',
+	#classTraits : 'FamixTSourceAnchor classTrait',
+	#category : #'Famix-Test6-Entities-Entities'
+}
+
+{ #category : #meta }
+FamixTest6SourceAnchor class >> annotation [
+
+	<FMClass: #SourceAnchor super: #FamixTest6Entity>
+	<package: #'Famix-Test6-Entities'>
+	<generated>
+	^self
+]
+
+{ #category : #initialization }
+FamixTest6SourceAnchor >> initialize [
+
+super initialize.
+
+"Default value initialization"
+
+]

--- a/src/Famix-Test6-Entities/FamixTest6SourceAnchor.class.st
+++ b/src/Famix-Test6-Entities/FamixTest6SourceAnchor.class.st
@@ -14,12 +14,3 @@ FamixTest6SourceAnchor class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #initialization }
-FamixTest6SourceAnchor >> initialize [
-
-super initialize.
-
-"Default value initialization"
-
-]

--- a/src/Famix-Test6-Entities/FamixTest6SourceLanguage.class.st
+++ b/src/Famix-Test6-Entities/FamixTest6SourceLanguage.class.st
@@ -1,0 +1,25 @@
+Class {
+	#name : #FamixTest6SourceLanguage,
+	#superclass : #FamixTest6Entity,
+	#traits : 'FamixTSourceLanguage',
+	#classTraits : 'FamixTSourceLanguage classTrait',
+	#category : #'Famix-Test6-Entities-Entities'
+}
+
+{ #category : #meta }
+FamixTest6SourceLanguage class >> annotation [
+
+	<FMClass: #SourceLanguage super: #FamixTest6Entity>
+	<package: #'Famix-Test6-Entities'>
+	<generated>
+	^self
+]
+
+{ #category : #initialization }
+FamixTest6SourceLanguage >> initialize [
+
+super initialize.
+
+"Default value initialization"
+
+]

--- a/src/Famix-Test6-Entities/FamixTest6SourceLanguage.class.st
+++ b/src/Famix-Test6-Entities/FamixTest6SourceLanguage.class.st
@@ -14,12 +14,3 @@ FamixTest6SourceLanguage class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #initialization }
-FamixTest6SourceLanguage >> initialize [
-
-super initialize.
-
-"Default value initialization"
-
-]

--- a/src/Famix-Test6-Entities/FamixTest6SourceTextAnchor.class.st
+++ b/src/Famix-Test6-Entities/FamixTest6SourceTextAnchor.class.st
@@ -1,0 +1,25 @@
+Class {
+	#name : #FamixTest6SourceTextAnchor,
+	#superclass : #FamixTest6SourceAnchor,
+	#traits : 'FamixTHasImmediateSource',
+	#classTraits : 'FamixTHasImmediateSource classTrait',
+	#category : #'Famix-Test6-Entities-Entities'
+}
+
+{ #category : #meta }
+FamixTest6SourceTextAnchor class >> annotation [
+
+	<FMClass: #SourceTextAnchor super: #FamixTest6SourceAnchor>
+	<package: #'Famix-Test6-Entities'>
+	<generated>
+	^self
+]
+
+{ #category : #initialization }
+FamixTest6SourceTextAnchor >> initialize [
+
+super initialize.
+
+"Default value initialization"
+
+]

--- a/src/Famix-Test6-Entities/FamixTest6SourceTextAnchor.class.st
+++ b/src/Famix-Test6-Entities/FamixTest6SourceTextAnchor.class.st
@@ -14,12 +14,3 @@ FamixTest6SourceTextAnchor class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #initialization }
-FamixTest6SourceTextAnchor >> initialize [
-
-super initialize.
-
-"Default value initialization"
-
-]

--- a/src/Famix-Test6-Entities/FamixTest6SourcedEntity.class.st
+++ b/src/Famix-Test6-Entities/FamixTest6SourcedEntity.class.st
@@ -1,0 +1,25 @@
+Class {
+	#name : #FamixTest6SourcedEntity,
+	#superclass : #FamixTest6Entity,
+	#traits : 'FamixTSourceEntity + FamixTWithComments',
+	#classTraits : 'FamixTSourceEntity classTrait + FamixTWithComments classTrait',
+	#category : #'Famix-Test6-Entities-Entities'
+}
+
+{ #category : #meta }
+FamixTest6SourcedEntity class >> annotation [
+
+	<FMClass: #SourcedEntity super: #FamixTest6Entity>
+	<package: #'Famix-Test6-Entities'>
+	<generated>
+	^self
+]
+
+{ #category : #initialization }
+FamixTest6SourcedEntity >> initialize [
+
+super initialize.
+
+"Default value initialization"
+
+]

--- a/src/Famix-Test6-Entities/FamixTest6SourcedEntity.class.st
+++ b/src/Famix-Test6-Entities/FamixTest6SourcedEntity.class.st
@@ -14,12 +14,3 @@ FamixTest6SourcedEntity class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #initialization }
-FamixTest6SourcedEntity >> initialize [
-
-super initialize.
-
-"Default value initialization"
-
-]

--- a/src/Famix-Test6-Entities/FamixTest6Spam.class.st
+++ b/src/Famix-Test6-Entities/FamixTest6Spam.class.st
@@ -18,12 +18,12 @@ FamixTest6Spam class >> annotation [
 
 { #category : #initialization }
 FamixTest6Spam >> initialize [
-<generated>
 
-super initialize.
+	<generated>
+	super initialize.
 
-"Default value initialization"
-isSomething := false.
+	"Default value initialization"
+	isSomething := false.
 
 ]
 

--- a/src/Famix-Test6-Entities/FamixTest6Spam.class.st
+++ b/src/Famix-Test6-Entities/FamixTest6Spam.class.st
@@ -1,0 +1,41 @@
+Class {
+	#name : #FamixTest6Spam,
+	#superclass : #FamixTest6Bacon,
+	#instVars : [
+		'#isSomething => FMProperty defaultValue: false'
+	],
+	#category : #'Famix-Test6-Entities-Entities'
+}
+
+{ #category : #meta }
+FamixTest6Spam class >> annotation [
+
+	<FMClass: #Spam super: #FamixTest6Bacon>
+	<package: #'Famix-Test6-Entities'>
+	<generated>
+	^self
+]
+
+{ #category : #initialization }
+FamixTest6Spam >> initialize [
+
+super initialize.
+
+"Default value initialization"
+isSomething := false.
+
+]
+
+{ #category : #accessing }
+FamixTest6Spam >> isSomething [
+
+	<FMProperty: #isSomething type: #Boolean defaultValue: false>
+	<generated>
+	^ isSomething
+]
+
+{ #category : #accessing }
+FamixTest6Spam >> isSomething: anObject [
+	<generated>
+	isSomething := anObject
+]

--- a/src/Famix-Test6-Entities/FamixTest6Spam.class.st
+++ b/src/Famix-Test6-Entities/FamixTest6Spam.class.st
@@ -18,6 +18,7 @@ FamixTest6Spam class >> annotation [
 
 { #category : #initialization }
 FamixTest6Spam >> initialize [
+<generated>
 
 super initialize.
 

--- a/src/Famix-Test6-Entities/FamixTest6UnknownSourceLanguage.class.st
+++ b/src/Famix-Test6-Entities/FamixTest6UnknownSourceLanguage.class.st
@@ -14,12 +14,3 @@ FamixTest6UnknownSourceLanguage class >> annotation [
 	<generated>
 	^self
 ]
-
-{ #category : #initialization }
-FamixTest6UnknownSourceLanguage >> initialize [
-
-super initialize.
-
-"Default value initialization"
-
-]

--- a/src/Famix-Test6-Entities/FamixTest6UnknownSourceLanguage.class.st
+++ b/src/Famix-Test6-Entities/FamixTest6UnknownSourceLanguage.class.st
@@ -1,0 +1,25 @@
+Class {
+	#name : #FamixTest6UnknownSourceLanguage,
+	#superclass : #FamixTest6SourceLanguage,
+	#traits : 'FamixTUnknownSourceLanguage',
+	#classTraits : 'FamixTUnknownSourceLanguage classTrait',
+	#category : #'Famix-Test6-Entities-Entities'
+}
+
+{ #category : #meta }
+FamixTest6UnknownSourceLanguage class >> annotation [
+
+	<FMClass: #UnknownSourceLanguage super: #FamixTest6SourceLanguage>
+	<package: #'Famix-Test6-Entities'>
+	<generated>
+	^self
+]
+
+{ #category : #initialization }
+FamixTest6UnknownSourceLanguage >> initialize [
+
+super initialize.
+
+"Default value initialization"
+
+]

--- a/src/Famix-Test6-Entities/package.st
+++ b/src/Famix-Test6-Entities/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'Famix-Test6-Entities' }

--- a/src/Famix-Test6-Tests/FamixTest6Test.class.st
+++ b/src/Famix-Test6-Tests/FamixTest6Test.class.st
@@ -3,3 +3,58 @@ Class {
 	#superclass : #TestCase,
 	#category : #'Famix-Test6-Tests'
 }
+
+{ #category : #running }
+FamixTest6Test >> testDefaultValueOnCreation [
+
+	| bacon foodProperty |
+	
+	bacon := FamixTest6Bacon new.
+	foodProperty := (bacon mooseDescription properties select: [ :each | each name = #isFood ]) at: 1.
+	
+	self assert: bacon isFood equals: true.
+	self assert: foodProperty defaultValue equals: true.
+	
+	bacon isFood: false.
+	self assert: bacon isFood equals: false.
+	self assert: foodProperty defaultValue equals: true.
+]
+
+{ #category : #running }
+FamixTest6Test >> testDefaultValueOnCreation2 [
+
+	| bacon eggProperty |
+	bacon := FamixTest6Bacon new.
+	eggProperty := (bacon mooseDescription properties select: [ :each | 
+		                each name = #eggs ]) at: 1.
+
+	self assert: bacon eggs equals: 12.
+	self assert: eggProperty defaultValue equals: 12.
+
+	bacon eggs: 0.
+	self assert: bacon eggs equals: 0.
+	self assert: eggProperty defaultValue equals: 12.
+
+	bacon eggs: nil.
+	self assert: bacon eggs equals: nil.
+	self assert: eggProperty defaultValue equals: 12
+]
+
+{ #category : #running }
+FamixTest6Test >> testDefaultValueOnCreationInheritance [
+
+	| spam eggProperty bacon |
+	spam := FamixTest6Spam new.
+
+	self assert: spam isSomething equals: false.
+	self assert: spam isFood equals: true.
+	self assert: spam eggs equals: 12.
+
+	spam isSomething: true.
+	spam isFood: false.
+	spam eggs: 1.
+
+	self assert: spam isSomething equals: true.
+	self assert: spam isFood equals: false.
+	self assert: spam eggs equals: 1
+]

--- a/src/Famix-Test6-Tests/FamixTest6Test.class.st
+++ b/src/Famix-Test6-Tests/FamixTest6Test.class.st
@@ -1,8 +1,5 @@
 Class {
 	#name : #FamixTest6Test,
 	#superclass : #TestCase,
-	#instVars : [
-		'bacon'
-	],
 	#category : #'Famix-Test6-Tests'
 }

--- a/src/Famix-Test6-Tests/FamixTest6Test.class.st
+++ b/src/Famix-Test6-Tests/FamixTest6Test.class.st
@@ -1,0 +1,8 @@
+Class {
+	#name : #FamixTest6Test,
+	#superclass : #TestCase,
+	#instVars : [
+		'bacon'
+	],
+	#category : #'Famix-Test6-Tests'
+}

--- a/src/Famix-Test6-Tests/package.st
+++ b/src/Famix-Test6-Tests/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'Famix-Test6-Tests' }

--- a/src/Famix-TestGenerators/FamixTest6Generator.class.st
+++ b/src/Famix-TestGenerators/FamixTest6Generator.class.st
@@ -1,0 +1,46 @@
+Class {
+	#name : #FamixTest6Generator,
+	#superclass : #FamixBasicInfrastructureGenerator,
+	#instVars : [
+		'spam',
+		'bacon'
+	],
+	#category : #'Famix-TestGenerators'
+}
+
+{ #category : #accessing }
+FamixTest6Generator class >> packageName [
+
+	^ #'Famix-Test6-Entities'
+]
+
+{ #category : #accessing }
+FamixTest6Generator class >> prefix [
+
+	^ #'FamixTest6'
+]
+
+{ #category : #definition }
+FamixTest6Generator >> defineClasses [
+
+	super defineClasses.
+	spam := builder newClassNamed: #Spam.
+	bacon := builder newClassNamed: #Bacon
+]
+
+{ #category : #definition }
+FamixTest6Generator >> defineHierarchy [
+	super defineHierarchy.
+
+	spam --|> bacon.
+
+]
+
+{ #category : #definition }
+FamixTest6Generator >> defineProperties [
+
+	super defineProperties.
+	bacon property: #isFood type: #Boolean defaultValue: true.
+	bacon property: #eggs type: #Number defaultValue: 12.
+	spam property: #isSomething type: #Boolean defaultValue: false
+]


### PR DESCRIPTION
This PR provides default value generation for Fame/Famix generator.

The PR requires first the use/inclusion of https://github.com/moosetechnology/Fame/pull/29 to work.