### PR TITLE
Adaptation of the FamixMMUMLDocumentor for classes

### DIFF
--- a/src/FamixTestGenerator/FamixClassTestAndTraitGenerator.class.st
+++ b/src/FamixTestGenerator/FamixClassTestAndTraitGenerator.class.st
@@ -1,0 +1,100 @@
+Class {
+	#name : #FamixClassTestAndTraitGenerator,
+	#superclass : #FamixTestAndTraitGenerator,
+	#category : #FamixTestGenerator
+}
+
+{ #category : #'generate for FMMany slot' }
+FamixClassTestAndTraitGenerator >> generateCodeForFMManySlotInitialization: aSlot [
+	| traitSlotName1 traitSlotName2 | 
+	"Example of what we want to generate
+	method1 := MooseEntity new copyWithTalent: FamixTMethod.
+	method1 class initializeSlots: method1.
+	model add: method1.
+	method2 := MooseEntity new copyWithTalent: FamixTMethod.
+	method2 class initializeSlots: method2.
+	model add: method2.
+	self entity addMethod: method1.
+	self entity addMethod: method2."
+	traitSlotName1 := (self generateSlotNameOfTestTraitFrom: aSlot) asString , '1'.
+	traitSlotName2 := (self generateSlotNameOfTestTraitFrom: aSlot) asString , '2'.
+	^ String streamContents: [ :aStream | aStream nextPutAll:  traitSlotName1 ;
+		nextPutAll: ' := MooseEntity new copyWithTalent: ';
+		nextPutAll: aSlot targetClass name  ;
+		nextPutAll: '.';
+		cr;
+		nextPutAll: traitSlotName1 ;
+		nextPutAll: ' class initializeSlots: ';
+		nextPutAll: traitSlotName1 ;
+		nextPutAll: '.';
+		cr;
+		nextPutAll: 'model add: ';
+		nextPutAll: traitSlotName1 ;
+		nextPutAll: '.';
+		cr;
+		nextPutAll:  traitSlotName2 ;
+		nextPutAll: ' := ';
+		nextPutAll: aSlot targetClass name  ;
+		nextPutAll: ' new.';
+		cr;
+		nextPutAll: traitSlotName2 ;
+		nextPutAll: ' class initializeSlots: ';
+		nextPutAll: traitSlotName2 ;
+		nextPutAll: '.';
+		cr;
+		nextPutAll: 'model add: ';
+		nextPutAll: traitSlotName2 ;
+		nextPutAll: '.';
+		cr;
+		nextPutAll: (self generateCodeForAddingSlotInCollection: traitSlotName1 for: aSlot);
+		cr;
+		nextPutAll: (self generateCodeForAddingSlotInCollection: traitSlotName2 for: aSlot) ]
+]
+
+{ #category : #'generate for FMOne slot' }
+FamixClassTestAndTraitGenerator >> generateCodeForFMOneSlotInitialization: aSlot [
+	| traitSlotName | 
+	"Example of what we want to generate
+	access := MooseEntity new copyWithTalent: FamixTWithAccesses.
+	access class initializeSlots: access.
+	model add: access.
+	self entity accessor: access."
+	traitSlotName := aSlot name asString.
+	^ String streamContents: [ :aStream | aStream nextPutAll:  traitSlotName ;
+		nextPutAll: ' := ';
+		nextPutAll: aSlot targetClass name  ;
+		nextPutAll: ' new. ';
+		cr;
+		nextPutAll: traitSlotName ;
+		nextPutAll: ' class initializeSlots: ';
+		nextPutAll: traitSlotName ;
+		nextPutAll: '.';
+		cr;
+		nextPutAll: 'model add: ';
+		nextPutAll: traitSlotName ;
+		nextPutAll: '.';
+		cr;
+		nextPutAll: 'self entity ';
+		nextPutAll: aSlot name;
+		nextPutAll: ': ';
+		nextPutAll: traitSlotName ;
+		nextPutAll: '. ']
+]
+
+{ #category : #run }
+FamixClassTestAndTraitGenerator >> generateSetUpInTraitFor: aClass [
+	^ String streamContents: [ :aStream | aStream nextPutAll: 'setUp';
+		cr;
+		nextPutAll: 'super setUp.';
+		cr;
+		nextPutAll: '	model := MooseModel new metamodel: FamixGenerator metamodel.';
+		cr;
+		nextPutAll: 'self entity: ('; 
+		nextPutAll: aClass name;
+		nextPutAll: ' new).';
+		cr;
+		nextPutAll: 'self entity class initializeSlots: self entity.';
+		cr;
+		nextPutAll: 'model add: entity. '
+		 ]
+]

--- a/src/FamixTestGenerator/FamixClassTestAndTraitGenerator.class.st
+++ b/src/FamixTestGenerator/FamixClassTestAndTraitGenerator.class.st
@@ -19,9 +19,9 @@ FamixClassTestAndTraitGenerator >> generateCodeForFMManySlotInitialization: aSlo
 	traitSlotName1 := (self generateSlotNameOfTestTraitFrom: aSlot) asString , '1'.
 	traitSlotName2 := (self generateSlotNameOfTestTraitFrom: aSlot) asString , '2'.
 	^ String streamContents: [ :aStream | aStream nextPutAll:  traitSlotName1 ;
-		nextPutAll: ' := MooseEntity new copyWithTalent: ';
+		nextPutAll: ' := ';
 		nextPutAll: aSlot targetClass name  ;
-		nextPutAll: '.';
+		nextPutAll: ' new .';
 		cr;
 		nextPutAll: traitSlotName1 ;
 		nextPutAll: ' class initializeSlots: ';

--- a/src/FamixTestGenerator/FamixClassTestAndTraitGenerator.class.st
+++ b/src/FamixTestGenerator/FamixClassTestAndTraitGenerator.class.st
@@ -18,7 +18,9 @@ FamixClassTestAndTraitGenerator >> generateCodeForFMManySlotInitialization: aSlo
 	self entity addMethod: method2."
 	traitSlotName1 := (self generateSlotNameOfTestTraitFrom: aSlot) asString , '1'.
 	traitSlotName2 := (self generateSlotNameOfTestTraitFrom: aSlot) asString , '2'.
-	^ String streamContents: [ :aStream | aStream nextPutAll:  traitSlotName1 ;
+	^ String streamContents: [ :aStream | aStream nextPutAll: '<generated>';
+		cr;
+		nextPutAll:  traitSlotName1 ;
 		nextPutAll: ' := ';
 		nextPutAll: aSlot targetClass name  ;
 		nextPutAll: ' new .';
@@ -60,7 +62,9 @@ FamixClassTestAndTraitGenerator >> generateCodeForFMOneSlotInitialization: aSlot
 	model add: access.
 	self entity accessor: access."
 	traitSlotName := aSlot name asString.
-	^ String streamContents: [ :aStream | aStream nextPutAll:  traitSlotName ;
+	^ String streamContents: [ :aStream | aStream nextPutAll: '<generated>';
+		cr;
+		nextPutAll:  traitSlotName ;
 		nextPutAll: ' := ';
 		nextPutAll: aSlot targetClass name  ;
 		nextPutAll: ' new. ';
@@ -83,7 +87,10 @@ FamixClassTestAndTraitGenerator >> generateCodeForFMOneSlotInitialization: aSlot
 
 { #category : #run }
 FamixClassTestAndTraitGenerator >> generateSetUpInTraitFor: aClass [
-	^ String streamContents: [ :aStream | aStream nextPutAll: 'setUp';
+	^ String streamContents: [ :aStream | aStream
+		nextPutAll: 'setUp';
+		cr;
+		nextPutAll: '<generated>';
 		cr;
 		nextPutAll: 'super setUp.';
 		cr;

--- a/src/FamixTestGenerator/FamixTestAndTraitGenerator.class.st
+++ b/src/FamixTestGenerator/FamixTestAndTraitGenerator.class.st
@@ -88,49 +88,7 @@ FamixTestAndTraitGenerator >> generateCodeForFMManySlotAssertions: aSlot [
 
 { #category : #'generate for FMMany slot' }
 FamixTestAndTraitGenerator >> generateCodeForFMManySlotInitialization: aSlot [
-	| traitSlotName1 traitSlotName2 | 
-	"Example of what we want to generate
-	method1 := MooseEntity new copyWithTalent: FamixTMethod.
-	method1 class initializeSlots: method1.
-	model add: method1.
-	method2 := MooseEntity new copyWithTalent: FamixTMethod.
-	method2 class initializeSlots: method2.
-	model add: method2.
-	self entity addMethod: method1.
-	self entity addMethod: method2."
-	traitSlotName1 := (self generateSlotNameOfTestTraitFrom: aSlot) asString , '1'.
-	traitSlotName2 := (self generateSlotNameOfTestTraitFrom: aSlot) asString , '2'.
-	^ String streamContents: [ :aStream | aStream nextPutAll:  traitSlotName1 ;
-		nextPutAll: ' := MooseEntity new copyWithTalent: ';
-		nextPutAll: aSlot targetClass name  ;
-		nextPutAll: '.';
-		cr;
-		nextPutAll: traitSlotName1 ;
-		nextPutAll: ' class initializeSlots: ';
-		nextPutAll: traitSlotName1 ;
-		nextPutAll: '.';
-		cr;
-		nextPutAll: 'model add: ';
-		nextPutAll: traitSlotName1 ;
-		nextPutAll: '.';
-		cr;
-		nextPutAll:  traitSlotName2 ;
-		nextPutAll: ' := MooseEntity new copyWithTalent: ';
-		nextPutAll: aSlot targetClass name  ;
-		nextPutAll: '.';
-		cr;
-		nextPutAll: traitSlotName2 ;
-		nextPutAll: ' class initializeSlots: ';
-		nextPutAll: traitSlotName2 ;
-		nextPutAll: '.';
-		cr;
-		nextPutAll: 'model add: ';
-		nextPutAll: traitSlotName2 ;
-		nextPutAll: '.';
-		cr;
-		nextPutAll: (self generateCodeForAddingSlotInCollection: traitSlotName1 for: aSlot);
-		cr;
-		nextPutAll: (self generateCodeForAddingSlotInCollection: traitSlotName2 for: aSlot) ]
+	self subclassResponsibility.
 ]
 
 { #category : #'generate for FMMany slot' }
@@ -178,32 +136,7 @@ FamixTestAndTraitGenerator >> generateCodeForFMOneSlotAssertions: aSlot [
 
 { #category : #'generate for FMOne slot' }
 FamixTestAndTraitGenerator >> generateCodeForFMOneSlotInitialization: aSlot [
-	| traitSlotName | 
-	"Example of what we want to generate
-	access := MooseEntity new copyWithTalent: FamixTWithAccesses.
-	access class initializeSlots: access.
-	model add: access.
-	self entity accessor: access."
-	traitSlotName := aSlot name asString.
-	^ String streamContents: [ :aStream | aStream nextPutAll:  traitSlotName ;
-		nextPutAll: ' := MooseEntity new copyWithTalent: ';
-		nextPutAll: aSlot targetClass name  ;
-		nextPutAll: '. ';
-		cr;
-		nextPutAll: traitSlotName ;
-		nextPutAll: ' class initializeSlots: ';
-		nextPutAll: traitSlotName ;
-		nextPutAll: '.';
-		cr;
-		nextPutAll: 'model add: ';
-		nextPutAll: traitSlotName ;
-		nextPutAll: '.';
-		cr;
-		nextPutAll: 'self entity ';
-		nextPutAll: aSlot name;
-		nextPutAll: ': ';
-		nextPutAll: traitSlotName ;
-		nextPutAll: '. ']
+	self subclassResponsibility .
 ]
 
 { #category : #'generate for FMOne slot' }
@@ -258,20 +191,7 @@ FamixTestAndTraitGenerator >> generateCodeForPrimitiveSlotInitialization: aSlot 
 
 { #category : #run }
 FamixTestAndTraitGenerator >> generateSetUpInTraitFor: aClass [
-	^ String streamContents: [ :aStream | aStream nextPutAll: 'setUp';
-		cr;
-		nextPutAll: 'super setUp.';
-		cr;
-		nextPutAll: '	model := MooseModel new metamodel: FamixGenerator metamodel.';
-		cr;
-		nextPutAll: 'self entity: (MooseEntity new copyWithTalent:'; 
-		nextPutAll: aClass name;
-		nextPutAll: ').';
-		cr;
-		nextPutAll: 'self entity class initializeSlots: self entity.';
-		cr;
-		nextPutAll: 'model add: entity. '
-		 ]
+	self subclassResponsibility .
 ]
 
 { #category : #'generate for FMOne slot' }

--- a/src/FamixTestGenerator/FamixTestAndTraitGenerator.class.st
+++ b/src/FamixTestGenerator/FamixTestAndTraitGenerator.class.st
@@ -294,8 +294,8 @@ FamixTestAndTraitGenerator >> generateSlotsOfTraitOfTestFor: aClass [
 FamixTestAndTraitGenerator >> generateSlotsOfTraitOfTestFrom: aSlot [
 	^((aSlot class == FMOne) or: [ aSlot class == FMProperty ])
 		ifTrue: [ {aSlot name} ]
-		ifFalse: [  {(self generateSlotNameOfTestTraitFrom: aSlot) asString , '1'.
-						(self generateSlotNameOfTestTraitFrom: aSlot) asString , '2' } ]
+		ifFalse: [  {(self generateSlotNameOfTestTraitFrom: aSlot) asSymbol , '1'.
+						(self generateSlotNameOfTestTraitFrom: aSlot) asSymbol , '2' } ]
 ]
 
 { #category : #'generate for FMMany slot' }

--- a/src/FamixTestGenerator/FamixTestGenerator.class.st
+++ b/src/FamixTestGenerator/FamixTestGenerator.class.st
@@ -75,10 +75,18 @@ FamixTestGenerator >> runFor: aClass [.
 
 { #category : #'as yet unclassified' }
 FamixTestGenerator >> runForASpecificClass: aClass with: aGenerator [
+
 	self generator: aGenerator.
 	self initPackage.
-	self runFor: aClass.
-	
+	aClass isTrait
+		ifTrue: [ 
+			FamixTraitTestAndTraitGenerator new
+				generator: self generator;
+				runFor: aClass ]
+		ifFalse: [ 
+			FamixClassTestAndTraitGenerator new
+				generator: self generator;
+				runFor: aClass ]
 ]
 
 { #category : #'as yet unclassified' }

--- a/src/FamixTestGenerator/FamixTestGenerator.class.st
+++ b/src/FamixTestGenerator/FamixTestGenerator.class.st
@@ -86,7 +86,8 @@ FamixTestGenerator >> runForAllClassesWith: aGenerator [
 	self generator: aGenerator.
 	self initPackage.
 	self initClasses.
-	self classes do: [ :c | self runFor: c ].
+	(self classes select: [:c | c isTrait ]) do: [ :c | FamixTraitTestAndTraitGenerator new runFor: c ].
+	(self classes select: [:c | c isClass ]) do: [ :c | FamixClassTestAndTraitGenerator new runFor: c ].
 	
 ]
 

--- a/src/FamixTestGenerator/FamixTestGenerator.class.st
+++ b/src/FamixTestGenerator/FamixTestGenerator.class.st
@@ -83,12 +83,18 @@ FamixTestGenerator >> runForASpecificClass: aClass with: aGenerator [
 
 { #category : #'as yet unclassified' }
 FamixTestGenerator >> runForAllClassesWith: aGenerator [
+
 	self generator: aGenerator.
 	self initPackage.
 	self initClasses.
-	(self classes select: [:c | c isTrait ]) do: [ :c | FamixTraitTestAndTraitGenerator new runFor: c ].
-	(self classes select: [:c | c isClass ]) do: [ :c | FamixClassTestAndTraitGenerator new runFor: c ].
-	
+	(self classes select: [ :c | c isTrait ]) do: [ :c | 
+		FamixTraitTestAndTraitGenerator new
+			generator: self generator;
+			runFor: c ].
+	(self classes select: [ :c | c isClass ]) do: [ :c | 
+		FamixClassTestAndTraitGenerator new
+			generator: self generator;
+			runFor: c ]
 ]
 
 { #category : #accessing }

--- a/src/FamixTestGenerator/FamixTraitTestAndTraitGenerator.class.st
+++ b/src/FamixTestGenerator/FamixTraitTestAndTraitGenerator.class.st
@@ -18,7 +18,9 @@ FamixTraitTestAndTraitGenerator >> generateCodeForFMManySlotInitialization: aSlo
 	self entity addMethod: method2."
 	traitSlotName1 := (self generateSlotNameOfTestTraitFrom: aSlot) asString , '1'.
 	traitSlotName2 := (self generateSlotNameOfTestTraitFrom: aSlot) asString , '2'.
-	^ String streamContents: [ :aStream | aStream nextPutAll:  traitSlotName1 ;
+	^ String streamContents: [ :aStream | aStream nextPutAll: '<generated>';
+		cr;
+		nextPutAll:  traitSlotName1 ;
 		nextPutAll: ' := MooseEntity new copyWithTalent: ';
 		nextPutAll: aSlot targetClass name  ;
 		nextPutAll: '.';
@@ -60,7 +62,9 @@ FamixTraitTestAndTraitGenerator >> generateCodeForFMOneSlotInitialization: aSlot
 	model add: access.
 	self entity accessor: access."
 	traitSlotName := aSlot name asString.
-	^ String streamContents: [ :aStream | aStream nextPutAll:  traitSlotName ;
+	^ String streamContents: [ :aStream | aStream nextPutAll: '<generated>';
+		cr;
+		nextPutAll:  traitSlotName ;
 		nextPutAll: ' := MooseEntity new copyWithTalent: ';
 		nextPutAll: aSlot targetClass name  ;
 		nextPutAll: '. ';
@@ -83,7 +87,10 @@ FamixTraitTestAndTraitGenerator >> generateCodeForFMOneSlotInitialization: aSlot
 
 { #category : #run }
 FamixTraitTestAndTraitGenerator >> generateSetUpInTraitFor: aClass [
-	^ String streamContents: [ :aStream | aStream nextPutAll: 'setUp';
+	^ String streamContents: [ :aStream | aStream
+		nextPutAll: 'setUp';
+		cr;
+		nextPutAll: '<generated>';
 		cr;
 		nextPutAll: 'super setUp.';
 		cr;

--- a/src/FamixTestGenerator/FamixTraitTestAndTraitGenerator.class.st
+++ b/src/FamixTestGenerator/FamixTraitTestAndTraitGenerator.class.st
@@ -1,0 +1,100 @@
+Class {
+	#name : #FamixTraitTestAndTraitGenerator,
+	#superclass : #FamixTestAndTraitGenerator,
+	#category : #FamixTestGenerator
+}
+
+{ #category : #'generate for FMMany slot' }
+FamixTraitTestAndTraitGenerator >> generateCodeForFMManySlotInitialization: aSlot [
+	| traitSlotName1 traitSlotName2 | 
+	"Example of what we want to generate
+	method1 := MooseEntity new copyWithTalent: FamixTMethod.
+	method1 class initializeSlots: method1.
+	model add: method1.
+	method2 := MooseEntity new copyWithTalent: FamixTMethod.
+	method2 class initializeSlots: method2.
+	model add: method2.
+	self entity addMethod: method1.
+	self entity addMethod: method2."
+	traitSlotName1 := (self generateSlotNameOfTestTraitFrom: aSlot) asString , '1'.
+	traitSlotName2 := (self generateSlotNameOfTestTraitFrom: aSlot) asString , '2'.
+	^ String streamContents: [ :aStream | aStream nextPutAll:  traitSlotName1 ;
+		nextPutAll: ' := MooseEntity new copyWithTalent: ';
+		nextPutAll: aSlot targetClass name  ;
+		nextPutAll: '.';
+		cr;
+		nextPutAll: traitSlotName1 ;
+		nextPutAll: ' class initializeSlots: ';
+		nextPutAll: traitSlotName1 ;
+		nextPutAll: '.';
+		cr;
+		nextPutAll: 'model add: ';
+		nextPutAll: traitSlotName1 ;
+		nextPutAll: '.';
+		cr;
+		nextPutAll:  traitSlotName2 ;
+		nextPutAll: ' := MooseEntity new copyWithTalent: ';
+		nextPutAll: aSlot targetClass name  ;
+		nextPutAll: '.';
+		cr;
+		nextPutAll: traitSlotName2 ;
+		nextPutAll: ' class initializeSlots: ';
+		nextPutAll: traitSlotName2 ;
+		nextPutAll: '.';
+		cr;
+		nextPutAll: 'model add: ';
+		nextPutAll: traitSlotName2 ;
+		nextPutAll: '.';
+		cr;
+		nextPutAll: (self generateCodeForAddingSlotInCollection: traitSlotName1 for: aSlot);
+		cr;
+		nextPutAll: (self generateCodeForAddingSlotInCollection: traitSlotName2 for: aSlot) ]
+]
+
+{ #category : #'generate for FMOne slot' }
+FamixTraitTestAndTraitGenerator >> generateCodeForFMOneSlotInitialization: aSlot [
+	| traitSlotName | 
+	"Example of what we want to generate
+	access := MooseEntity new copyWithTalent: FamixTWithAccesses.
+	access class initializeSlots: access.
+	model add: access.
+	self entity accessor: access."
+	traitSlotName := aSlot name asString.
+	^ String streamContents: [ :aStream | aStream nextPutAll:  traitSlotName ;
+		nextPutAll: ' := MooseEntity new copyWithTalent: ';
+		nextPutAll: aSlot targetClass name  ;
+		nextPutAll: '. ';
+		cr;
+		nextPutAll: traitSlotName ;
+		nextPutAll: ' class initializeSlots: ';
+		nextPutAll: traitSlotName ;
+		nextPutAll: '.';
+		cr;
+		nextPutAll: 'model add: ';
+		nextPutAll: traitSlotName ;
+		nextPutAll: '.';
+		cr;
+		nextPutAll: 'self entity ';
+		nextPutAll: aSlot name;
+		nextPutAll: ': ';
+		nextPutAll: traitSlotName ;
+		nextPutAll: '. ']
+]
+
+{ #category : #run }
+FamixTraitTestAndTraitGenerator >> generateSetUpInTraitFor: aClass [
+	^ String streamContents: [ :aStream | aStream nextPutAll: 'setUp';
+		cr;
+		nextPutAll: 'super setUp.';
+		cr;
+		nextPutAll: '	model := MooseModel new metamodel: FamixGenerator metamodel.';
+		cr;
+		nextPutAll: 'self entity: (MooseEntity new copyWithTalent:'; 
+		nextPutAll: aClass name;
+		nextPutAll: ').';
+		cr;
+		nextPutAll: 'self entity class initializeSlots: self entity.';
+		cr;
+		nextPutAll: 'model add: entity. '
+		 ]
+]


### PR DESCRIPTION
New instantiation for classes (no copyWithTalent:) which allows to test classes (and traits) of Famix metamodels with the FamixTestGenerator.

For this, there are two new classes to separate the behavior dedicated to classes and traits. Moreover, the generated pragma has been added on the generation of the methods.

No added tests because no tests were present (or I didn't find them ^^). I can do some but I have to see on which meta-model to do the tests ?

@anneetien