### PR TITLE
Add support of sub meta-models and color to the FamixMMUMLDocumentor

### DIFF
--- a/src/Famix-MetamodelDocumentor/FamixMMUMLAbstractDocumentor.class.st
+++ b/src/Famix-MetamodelDocumentor/FamixMMUMLAbstractDocumentor.class.st
@@ -84,7 +84,7 @@ FamixMMUMLAbstractDocumentor >> model [
 { #category : #accessing }
 FamixMMUMLAbstractDocumentor >> model: aModel [
 
-	models add: (FamixUMLModelColorTuple model: aModel)
+	self withModel: aModel
 ]
 
 { #category : #accessing }
@@ -119,6 +119,12 @@ FamixMMUMLAbstractDocumentor >> relationEndOfInterest: aFMClass [
 	^self isWithStub
 		ifTrue: [ aFMClass class ~= FM3Object ]
 		ifFalse: [ self ofInterest: aFMClass ]
+]
+
+{ #category : #accessing }
+FamixMMUMLAbstractDocumentor >> withModel: aModel [
+
+	models add: (FamixUMLModelColorTuple model: aModel)
 ]
 
 { #category : #accessing }

--- a/src/Famix-MetamodelDocumentor/FamixMMUMLAbstractDocumentor.class.st
+++ b/src/Famix-MetamodelDocumentor/FamixMMUMLAbstractDocumentor.class.st
@@ -9,11 +9,11 @@ Class {
 	#name : #FamixMMUMLAbstractDocumentor,
 	#superclass : #Object,
 	#instVars : [
-		'model',
 		'outputStream',
 		'classesOfInterest',
 		'externalClasses',
-		'withStub'
+		'withStub',
+		'models'
 	],
 	#category : #'Famix-MetamodelDocumentor'
 }
@@ -43,6 +43,17 @@ FamixMMUMLAbstractDocumentor >> externalClasses: aCollection [
 	externalClasses  := aCollection 
 ]
 
+{ #category : #'api - generation' }
+FamixMMUMLAbstractDocumentor >> findDescriptionOf: anElement [
+
+	models
+		  detect: [ :model | 
+			  ([ model model metamodel descriptionOf: anElement ]
+				   on: NotFound
+				   do: [ nil ]) isNotNil ]
+		  ifFound: [ :model | ^ model model metamodel descriptionOf: anElement ]
+]
+
 { #category : #generating }
 FamixMMUMLAbstractDocumentor >> generateClassName: aFM3Class [
 	outputStream
@@ -56,7 +67,8 @@ FamixMMUMLAbstractDocumentor >> generateClassName: aFM3Class [
 { #category : #initialization }
 FamixMMUMLAbstractDocumentor >> initialize [
 	self beWithoutStub.
-	externalClasses := Set new
+	externalClasses := Set new.
+	models := Set new.
 ]
 
 { #category : #testing }
@@ -66,12 +78,25 @@ FamixMMUMLAbstractDocumentor >> isWithStub [
 
 { #category : #accessing }
 FamixMMUMLAbstractDocumentor >> model [
-	^ model
+	^ models anyOne
 ]
 
 { #category : #accessing }
-FamixMMUMLAbstractDocumentor >> model: anObject [
-	model := anObject
+FamixMMUMLAbstractDocumentor >> model: aModel [
+
+	models add: (FamixUMLModelColorTuple model: aModel)
+]
+
+{ #category : #accessing }
+FamixMMUMLAbstractDocumentor >> models [
+
+	^ models
+]
+
+{ #category : #accessing }
+FamixMMUMLAbstractDocumentor >> models: anObject [
+
+	models := anObject
 ]
 
 { #category : #private }
@@ -94,6 +119,12 @@ FamixMMUMLAbstractDocumentor >> relationEndOfInterest: aFMClass [
 	^self isWithStub
 		ifTrue: [ aFMClass class ~= FM3Object ]
 		ifFalse: [ self ofInterest: aFMClass ]
+]
+
+{ #category : #accessing }
+FamixMMUMLAbstractDocumentor >> withModel: aModel andColor: aColor [
+
+	models add: (FamixUMLModelColorTuple model: aModel color: aColor)
 ]
 
 { #category : #accessing }

--- a/src/Famix-MetamodelDocumentor/FamixMMUMLDocumentor.class.st
+++ b/src/Famix-MetamodelDocumentor/FamixMMUMLDocumentor.class.st
@@ -64,7 +64,7 @@ FamixMMUMLDocumentor >> generateExternalClass: aFM3Class [
 FamixMMUMLDocumentor >> generatePlantUML: aCollection onStream: aStream [
 	outputStream := aStream.
 	classesOfInterest := aCollection
-		collect: [:stClass | model metamodel descriptionOf: stClass ].
+		collect: [:stClass | self findDescriptionOf: stClass ].
 	externalClasses := Set new.
 
 	self plantUMLHeader.
@@ -113,11 +113,11 @@ FamixMMUMLDocumentor >> generatePlantUMLInheritance [
 
 	| aVisitor |
 	aVisitor := FamixMMUMLInheritanceDocumentor new
-		            outputStream: outputStream ;
-		            classesOfInterest: classesOfInterest ;
-		            externalClasses: externalClasses ;
-						withStub: withStub ;
-						model: model.
+		            outputStream: outputStream;
+		            classesOfInterest: classesOfInterest;
+		            externalClasses: externalClasses;
+		            withStub: withStub;
+		            models: self models.
 	classesOfInterest do: [ :clazz | clazz accept: aVisitor ]
 ]
 
@@ -154,8 +154,9 @@ FamixMMUMLDocumentor >> generatePlantUMLModelFile: aString without: aCollection 
 
 { #category : #'api - generation' }
 FamixMMUMLDocumentor >> generatePlantUMLModelOnStream: aStream [
+
 	outputStream := aStream.
-	classesOfInterest := (model metamodel descriptionOf: model) package classes.
+	classesOfInterest := models flatCollect: [ :model | (self findDescriptionOf: model model) package classes ] as: Set.
 	externalClasses := Set new.
 
 	self plantUMLHeader.
@@ -168,8 +169,7 @@ FamixMMUMLDocumentor >> generatePlantUMLModelOnStream: aStream [
 	outputStream cr.
 	self generatePlantUMLExternalClasses.
 	outputStream cr.
-	self plantUMLFooter.
-
+	self plantUMLFooter
 ]
 
 { #category : #'api - generation' }
@@ -190,9 +190,8 @@ FamixMMUMLDocumentor >> generatePlantUMLModelWithout: aCollection onStream: aStr
 
 	outputStream := aStream.
 	classesOfNoInterest := aCollection
-		collect: [:stClass | model metamodel descriptionOf: stClass ].
-	classesOfInterest := (model metamodel descriptionOf: model) package
-		                     classes.
+		collect: [:stClass | self findDescriptionOf: stClass ].
+	classesOfInterest := models flatCollect: [ :model | (self findDescriptionOf: model model) package classes ] as: Set..
 	externalClasses := Set new.
 
 	self plantUMLHeader.
@@ -296,6 +295,13 @@ FamixMMUMLDocumentor >> isTrait: aFMClass [
 ]
 
 { #category : #private }
+FamixMMUMLDocumentor >> plantUMLBackgroundColorFor: aFMClass [
+	^ (self isTrait: aFMClass)
+		ifTrue: [ 'lightGrey' ]
+		ifFalse: [ (self tupleForEntity: aFMClass) color asHexString ]
+]
+
+{ #category : #private }
 FamixMMUMLDocumentor >> plantUMLColorFor: aFMClass [
 	^ (self isTrait: aFMClass)
 		ifTrue: [ 'lightGrey' ]
@@ -338,6 +344,12 @@ FamixMMUMLDocumentor >> plantUMLMarkerFor: aFMClass [
 		ifFalse: [ 'C' ]
 ]
 
+{ #category : #private }
+FamixMMUMLDocumentor >> tupleForEntity: aFM3Class [
+
+	^ models detect: [ :model | (self findDescriptionOf: model model) package = aFM3Class package ]
+]
+
 { #category : #visiting }
 FamixMMUMLDocumentor >> visitClass: aFMClass [
 	outputStream
@@ -347,7 +359,10 @@ FamixMMUMLDocumentor >> visitClass: aFMClass [
 		nextPutAll: (self plantUMLMarkerFor: aFMClass) ;
 		nextPut: $, ;
 		nextPutAll: (self plantUMLColorFor: aFMClass) ;
-		nextPutAll: ') >> {' ;
+		nextPutAll: ') >>' ;
+		nextPutAll: ' #';
+		nextPutAll: (self plantUMLBackgroundColorFor: aFMClass) ;
+		nextPutAll: ' {';
 		cr.
 	aFMClass
 		primitiveProperties do: [ :prop | prop accept: self ].

--- a/src/Famix-MetamodelDocumentor/FamixMMUMLDocumentorAbstractTest.class.st
+++ b/src/Famix-MetamodelDocumentor/FamixMMUMLDocumentorAbstractTest.class.st
@@ -10,14 +10,14 @@ Class {
 
 { #category : #running }
 FamixMMUMLDocumentorAbstractTest >> famixClassFor: stClass [
-	^documentor model metamodel descriptionOf: stClass
+	^documentor findDescriptionOf: stClass
 ]
 
 { #category : #running }
 FamixMMUMLDocumentorAbstractTest >> famixProperty: aName in: stClass [
 	| famixClass |
 	famixClass := self famixClassFor: stClass.
-	^famixClass allProperties  detect: [ :p | p name = aName ]
+	^famixClass allProperties detect: [ :p | p name = aName ]
 ]
 
 { #category : #running }

--- a/src/Famix-MetamodelDocumentor/FamixMMUMLDocumentorVisitorTest.class.st
+++ b/src/Famix-MetamodelDocumentor/FamixMMUMLDocumentorVisitorTest.class.st
@@ -23,7 +23,7 @@ FamixMMUMLDocumentorVisitorTest >> testVisitClassNoAttributes [
 	self
 		assert: stream contents
 		equals:
-'class Book << (C,white) >> {
+'class Book << (C,white) >> #FFFFFF {
 }
 '
 ]
@@ -36,7 +36,7 @@ FamixMMUMLDocumentorVisitorTest >> testVisitClassWithAttributes [
 	self
 		assert: stream contents
 		equals:
-'class Entity << (C,white) >> {
+'class Entity << (C,white) >> #FFFFFF {
   String name
 }
 '

--- a/src/Famix-MetamodelDocumentor/FamixMMUMLInheritanceDocumentor.class.st
+++ b/src/Famix-MetamodelDocumentor/FamixMMUMLInheritanceDocumentor.class.st
@@ -28,7 +28,7 @@ FamixMMUMLInheritanceDocumentor >> visitClass: aFMClass [
 { #category : #visiting }
 FamixMMUMLInheritanceDocumentor >> visitTrait: aFMTrait [
 	self flag: 'Hack to access to direct traits only - https://github.com/moosetechnology/Fame/issues/23'.
-	(aFMTrait implementingClass traits collect: [:stClass | model metamodel descriptionOf: stClass ])  do: [ :aFMSuperTrait | 
+	(aFMTrait implementingClass traits collect: [:stClass | self findDescriptionOf: stClass ])  do: [ :aFMSuperTrait | 
 	(self relationEndOfInterest: aFMTrait) ifFalse: [ ^ self ].
 	(self relationEndOfInterest: aFMSuperTrait ) ifFalse: [ ^ self ].
 	self generateClassName: aFMSuperTrait .

--- a/src/Famix-MetamodelDocumentor/FamixUMLModelColorTuple.class.st
+++ b/src/Famix-MetamodelDocumentor/FamixUMLModelColorTuple.class.st
@@ -1,0 +1,64 @@
+"
+I represent a tuple between a model (meta-model) and the color that will be used to represent the entities of this meta-model
+"
+Class {
+	#name : #FamixUMLModelColorTuple,
+	#superclass : #Object,
+	#instVars : [
+		'model',
+		'color'
+	],
+	#category : #'Famix-MetamodelDocumentor'
+}
+
+{ #category : #accessing }
+FamixUMLModelColorTuple class >> model: aModel [
+
+	^ self new
+		  model: aModel;
+		  yourself
+]
+
+{ #category : #accessing }
+FamixUMLModelColorTuple class >> model: aModel color: aColor [
+
+	^ self new
+		  model: aModel;
+		  color: aColor;
+		  yourself
+]
+
+{ #category : #accessing }
+FamixUMLModelColorTuple >> color [
+
+	^ color
+]
+
+{ #category : #accessing }
+FamixUMLModelColorTuple >> color: anObject [
+
+	color := anObject
+]
+
+{ #category : #initialization }
+FamixUMLModelColorTuple >> defaultColor [
+	^ Color white
+]
+
+{ #category : #initialization }
+FamixUMLModelColorTuple >> initialize [
+	super initialize.
+	color := self defaultColor
+]
+
+{ #category : #accessing }
+FamixUMLModelColorTuple >> model [
+
+	^ model
+]
+
+{ #category : #accessing }
+FamixUMLModelColorTuple >> model: anObject [
+
+	model := anObject
+]


### PR DESCRIPTION
I propose this modification to add support of color and sub-meta-model to the FamixMMUMLDocumentor.

The previous API can still be used.
I created a new API as follow: 

```st
FamixMMUMLDocumentor
    new
         beWithStub;
         withModel: CCModel andColor: Color lightBlue;
         withModel: CCEModel andColor: Color lightGreen;
         generatePlantUMLModel
```

It allows producing schema such as:

![image](https://user-images.githubusercontent.com/6225039/126115905-bae7c9f4-cb54-48d8-bd0c-f63a0b5b59fe.png)

I believe it is a great improvement when documenting meta-models with sub-meta-models

> All previous tests passe.

## Known issues

I define the `Color white` by default to all models, thus, when generating, all classes are suffixed by default with `#FFFFFF`
Example: 

```st
FamixMMUMLDocumentor

	new
		beWithStub;
		withModel: CCModel;
		generatePlantUMLModel
```

produces: 

```
...
class CCModel << (C,white) >> #FFFFFF {
}
...
```

I believe we can improve this later (removing the `#FFFFFF` when not necessary)
