### PR TITLE
[Do Not Merge] MooseObject superclass is itself and not the FM3Object

### DIFF
--- a/src/Moose-Core/MooseObject.class.st
+++ b/src/Moose-Core/MooseObject.class.st
@@ -86,7 +86,7 @@ MooseObject class >> allPropertySelectors [
 
 { #category : #meta }
 MooseObject class >> annotation [
-	<FMClass: #Object super: #Object>
+	<FMClass: #Object super: #MooseObject>
 	<package: #Moose>
 	<abstract>
 ]


### PR DESCRIPTION
The annotation method of `MooseObject` is incorrect.

At the meta-model level, the superclass of MooseObject is itself and not something coming from Fame.
Actually, when exporting with FMJsonPrinter and FMMsePrinter, the superclass is considered as the fame constant `FM3Object`

Example of export without this fix:

![image](https://user-images.githubusercontent.com/6225039/126795594-1aae0d18-daad-4a61-8c5e-5b33c859ece6.png)

Example with this fix:

![image](https://user-images.githubusercontent.com/6225039/126795658-f3592bb9-f61a-446a-b690-a3610306df49.png)


