### PR TITLE
beautify and fix bug with submetamodel for inheriantance/utilisation

### DIFF
--- a/src/Famix-MetamodelDocumentor/FamixMMUMLAbstractDocumentor.class.st
+++ b/src/Famix-MetamodelDocumentor/FamixMMUMLAbstractDocumentor.class.st
@@ -101,7 +101,8 @@ FamixMMUMLAbstractDocumentor >> models: anObject [
 
 { #category : #private }
 FamixMMUMLAbstractDocumentor >> ofInterest: aFMClass [
-	^classesOfInterest includes: aFMClass
+
+	^ classesOfInterest anySatisfy: [ :fmClassOfInterest | fmClassOfInterest fullName = aFMClass fullName ]
 ]
 
 { #category : #accessing }

--- a/src/Famix-MetamodelDocumentor/FamixMMUMLInheritanceDocumentor.class.st
+++ b/src/Famix-MetamodelDocumentor/FamixMMUMLInheritanceDocumentor.class.st
@@ -14,6 +14,7 @@ Class {
 
 { #category : #visiting }
 FamixMMUMLInheritanceDocumentor >> visitClass: aFMClass [
+
 	| aFMSuperClass |
 	aFMSuperClass := aFMClass superclass.
 	(self relationEndOfInterest: aFMClass) ifFalse: [ ^ self ].
@@ -22,23 +23,28 @@ FamixMMUMLInheritanceDocumentor >> visitClass: aFMClass [
 	outputStream nextPutAll: ' <|-- '.
 	self generateClassName: aFMClass.
 	outputStream cr.
-   aFMClass traits do: [ :aTrait | self visitUsedTrait: aTrait byClass: aFMClass ]
+	self flag: 'Hack to access to direct traits only - https://github.com/moosetechnology/Fame/issues/23'.
+	aFMClass implementingClass traits
+		collect: [ :stClass | self findDescriptionOf: stClass ]
+		thenDo: [ :aTrait | self visitUsedTrait: aTrait byClass: aFMClass ]
 ]
 
 { #category : #visiting }
 FamixMMUMLInheritanceDocumentor >> visitTrait: aFMTrait [
+
 	self flag: 'Hack to access to direct traits only - https://github.com/moosetechnology/Fame/issues/23'.
-	(aFMTrait implementingClass traits collect: [:stClass | self findDescriptionOf: stClass ])  do: [ :aFMSuperTrait | 
-	(self relationEndOfInterest: aFMTrait) ifFalse: [ ^ self ].
-	(self relationEndOfInterest: aFMSuperTrait ) ifFalse: [ ^ self ].
-	self generateClassName: aFMSuperTrait .
-	outputStream nextPutAll: ' <|.. '.
-	self generateClassName: aFMTrait .
-	outputStream cr.]
+	(aFMTrait implementingClass traits collect: [ :stClass | self findDescriptionOf: stClass ]) do: [ :aFMSuperTrait |
+		(self relationEndOfInterest: aFMTrait) ifFalse: [ ^ self ].
+		(self relationEndOfInterest: aFMSuperTrait) ifFalse: [ ^ self ].
+		self generateClassName: aFMSuperTrait.
+		outputStream nextPutAll: ' <|.. '.
+		self generateClassName: aFMTrait.
+		outputStream cr ]
 ]
 
 { #category : #visiting }
 FamixMMUMLInheritanceDocumentor >> visitUsedTrait: aTrait byClass: aFMClass [
+
 	(self relationEndOfInterest: aTrait) ifFalse: [ ^ self ].
 	(self relationEndOfInterest: aTrait) ifFalse: [ ^ self ].
 


### PR DESCRIPTION
This is a fix to make FamixMMUMLDocumentor work with submetamodel for ineritances and usage
done w/ @enwiro 