### PR TITLE
Port Namespace feature on FamixJava

### DIFF
--- a/src/Famix-Java-Entities/FamixJavaPackage.class.st
+++ b/src/Famix-Java-Entities/FamixJavaPackage.class.st
@@ -193,6 +193,18 @@ FamixJavaPackage >> methods [
 	^ self cacheAt: #methods ifAbsentPut: [ self classes flatCollect: #methods ]
 ]
 
+{ #category : #printing }
+FamixJavaPackage >> mooseNameOn: stream [
+	| parent |
+	parent := self belongsTo.
+	parent ifNotNil: 
+		[ parent mooseNameOn: stream.
+		stream
+			nextPut: $:;
+			nextPut: $: ].
+	self name ifNotNil: [stream nextPutAll: self name]
+]
+
 { #category : #accessing }
 FamixJavaPackage >> numberOfClientPackages [
 	<FMProperty: #numberOfClientPackages type: #Number>

--- a/src/Famix-Java-Entities/FamixJavaType.class.st
+++ b/src/Famix-Java-Entities/FamixJavaType.class.st
@@ -73,11 +73,14 @@ FamixJavaType >> isAnonymousClass [
 
 { #category : #testing }
 FamixJavaType >> isInnerClass [
+
 	<FMProperty: #isInnerClass type: #Boolean>
 	<derived>
 	<FMComment:
-		'True if the method is considered as an innerclass (i.e. is contained elsewhere than a java package: class, method, enum,...)'>
-	^ self container ifNotNil: [ :c | c isNamespace not ] ifNil: [ false ]
+	'True if the method is considered as an innerclass (i.e. is contained elsewhere than a java package: class, method, enum,...)'>
+	^ self typeContainer
+		  ifNotNil: [ :c | c isPackage not ]
+		  ifNil: [ false ]
 ]
 
 { #category : #testing }


### PR DESCRIPTION
I update the compute of `mooseName` and `innerClass` to mimic the behavior we had with FamixJavaNamespace