### PR TITLE
MooseQuery: flatten the result when querying the opposites in navigation queries

### DIFF
--- a/src/Moose-Query-Test/MooseQueryTest.class.st
+++ b/src/Moose-Query-Test/MooseQueryTest.class.st
@@ -660,11 +660,18 @@ MooseQueryTest >> testSourceThroughInvocation [
 { #category : #tests }
 MooseQueryTest >> testTargetThroughInvocation [
 
-	self assertCollection: (method1 targetThrough: FamixTInvocation) storage flattened hasSameElements: {method2}.
-	self assertCollection: (method1 targetThrough: FamixTInvocation) hasSameElements: ((method1 queryOutgoing: FamixTInvocation) collect: #to).
-	self assertCollection: (class2 targetThrough: FamixTInvocation) storage flattened hasSameElements: {method2}.
-
-	
+	self
+		assertCollection:
+		(method1 targetThrough: FamixTInvocation) storage flattened
+		hasSameElements: { method2 }.
+	self
+		assertCollection: (method1 targetThrough: FamixTInvocation)
+		hasSameElements:
+		((method1 queryOutgoing: FamixTInvocation) flatCollect: #target).
+	self
+		assertCollection:
+		(class2 targetThrough: FamixTInvocation) storage flattened
+		hasSameElements: { method2 }
 ]
 
 { #category : #tests }

--- a/src/Moose-Query/MQNavigationIncomingDirectionStrategy.class.st
+++ b/src/Moose-Query/MQNavigationIncomingDirectionStrategy.class.st
@@ -21,8 +21,8 @@ MQNavigationIncomingDirectionStrategy class >> ensureAssociation: anObject with:
 ]
 
 { #category : #accessing }
-MQNavigationIncomingDirectionStrategy class >> entityFor: anEntity [
-	^ anEntity source
+MQNavigationIncomingDirectionStrategy class >> entityFor: anAssociation [
+	^ anAssociation source
 ]
 
 { #category : #accessing }

--- a/src/Moose-Query/MQNavigationOppositeKindStrategy.class.st
+++ b/src/Moose-Query/MQNavigationOppositeKindStrategy.class.st
@@ -12,7 +12,14 @@ Class {
 
 { #category : #enumerating }
 MQNavigationOppositeKindStrategy class >> collectResultFrom: aCollection query: aQuery [
-	^ aCollection collect: [ :each | aQuery directionStrategy entityFor: each ]
+
+	"We flat collect because some associations have multivalued targets (ex: TAssociation has #candidates) and some have only 1 target.
+	The mechanisms of #flatCollect: only works if all items in the collection are collections, 
+		so we use the mechanism of #flattened while collecting."
+
+	^ Array streamContents: [ :stream | 
+		  aCollection do: [ :each | 
+			  (aQuery directionStrategy entityFor: each) flattenOn: stream ] ]
 ]
 
 { #category : #running }

--- a/src/Moose-Query/MQNavigationOutgoingDirectionStrategy.class.st
+++ b/src/Moose-Query/MQNavigationOutgoingDirectionStrategy.class.st
@@ -21,8 +21,8 @@ MQNavigationOutgoingDirectionStrategy class >> ensureAssociation: anObject with:
 ]
 
 { #category : #accessing }
-MQNavigationOutgoingDirectionStrategy class >> entityFor: anEntity [
-	^ anEntity target
+MQNavigationOutgoingDirectionStrategy class >> entityFor: anAssociation [
+	^ anAssociation target
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
Corrected test accordingly