### PR TITLE
Remove fame annotation of `FamixJavaType>>#container`

### DIFF
--- a/src/Famix-Deprecated/FamixJavaType.extension.st
+++ b/src/Famix-Deprecated/FamixJavaType.extension.st
@@ -2,8 +2,6 @@ Extension { #name : #FamixJavaType }
 
 { #category : #'*Famix-Deprecated' }
 FamixJavaType >> container [
-	<FMProperty: #container type: #FamixJavaContainerEntity>
-	<FMComment: 'Deprected, use typeContainer'>
 	self deprecated: 'Use #typeContainer instead.' transformWith: '`@receiver container' -> '`@receiver typeContainer'.
 	^ self typeContainer
 ]


### PR DESCRIPTION
fix #378 

Once the annotation is removed, we can see the navigation browser in the MiInspector
![image](https://user-images.githubusercontent.com/6225039/141943589-b348a5f0-979d-4bf4-abb0-dc7bef2b7ac5.png)
