### PR TITLE
After verification, only Methods in phrao can have AnnotationInstances.

### DIFF
--- a/src/Famix-Java-Generator/FamixJavaTraitsChecker.class.st
+++ b/src/Famix-Java-Generator/FamixJavaTraitsChecker.class.st
@@ -1,0 +1,21 @@
+Class {
+	#name : #FamixJavaTraitsChecker,
+	#superclass : #Object,
+	#category : #'Famix-Java-Generator'
+}
+
+{ #category : #'as yet unclassified' }
+FamixJavaTraitsChecker >> checkTraitsFor: aClass [
+
+	^ aClass allTraits size = aClass allTraits asSet size
+]
+
+{ #category : #'as yet unclassified' }
+FamixJavaTraitsChecker >> detectDoubleFor: aClassOrTrait [ 
+	^self detectDoubleFor: aClassOrTrait  in: aClassOrTrait allTraits 
+]
+
+{ #category : #'as yet unclassified' }
+FamixJavaTraitsChecker >> detectDoubleFor: aClassOrTrait in: aCollection [
+	^aCollection select: [ :c | (aCollection occurrencesOf: c) >1 ]
+]

--- a/src/Famix-PharoSmalltalk-Entities/FamixStMethod.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStMethod.class.st
@@ -1,8 +1,8 @@
 Class {
 	#name : #FamixStMethod,
 	#superclass : #FamixStNamedEntity,
-	#traits : 'FamixTCanBeAbstract + FamixTCanBeClassSide + FamixTHasKind + FamixTMethod + FamixTWithAnnotationTypes + FamixTWithComments',
-	#classTraits : 'FamixTCanBeAbstract classTrait + FamixTCanBeClassSide classTrait + FamixTHasKind classTrait + FamixTMethod classTrait + FamixTWithAnnotationTypes classTrait + FamixTWithComments classTrait',
+	#traits : 'FamixTCanBeAbstract + FamixTCanBeClassSide + FamixTHasKind + FamixTMethod + FamixTWithAnnotationInstances + FamixTWithAnnotationTypes + FamixTWithComments',
+	#classTraits : 'FamixTCanBeAbstract classTrait + FamixTCanBeClassSide classTrait + FamixTHasKind classTrait + FamixTMethod classTrait + FamixTWithAnnotationInstances classTrait + FamixTWithAnnotationTypes classTrait + FamixTWithComments classTrait',
 	#instVars : [
 		'#protocol => FMProperty'
 	],

--- a/src/Famix-PharoSmalltalk-Entities/FamixStNamedEntity.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStNamedEntity.class.st
@@ -1,8 +1,8 @@
 Class {
 	#name : #FamixStNamedEntity,
 	#superclass : #FamixStSourcedEntity,
-	#traits : 'FamixTInvocationsReceiver + FamixTNamedEntity + FamixTPackageable + FamixTWithAnnotationInstances + TEntityMetaLevelDependency',
-	#classTraits : 'FamixTInvocationsReceiver classTrait + FamixTNamedEntity classTrait + FamixTPackageable classTrait + FamixTWithAnnotationInstances classTrait + TEntityMetaLevelDependency classTrait',
+	#traits : 'FamixTInvocationsReceiver + FamixTNamedEntity + FamixTPackageable + TEntityMetaLevelDependency',
+	#classTraits : 'FamixTInvocationsReceiver classTrait + FamixTNamedEntity classTrait + FamixTPackageable classTrait + TEntityMetaLevelDependency classTrait',
 	#category : #'Famix-PharoSmalltalk-Entities-Entities'
 }
 

--- a/src/Famix-PharoSmalltalk-Generator/FamixPharoSmalltalkGenerator.class.st
+++ b/src/Famix-PharoSmalltalk-Generator/FamixPharoSmalltalkGenerator.class.st
@@ -103,6 +103,7 @@ FamixPharoSmalltalkGenerator >> defineHierarchy [
 	class --|> #TClass.
 	class --|> #TCanBeAbstract.
 	class --|> #TClassMetrics.
+	class --|> #TWithComments.
 
 	globalVariable --|> namedEntity.
 	globalVariable --|> #TGlobalVariable.
@@ -127,11 +128,11 @@ FamixPharoSmalltalkGenerator >> defineHierarchy [
 	method --|> #TCanBeAbstract.
 	method --|> #THasKind.
 	method --|> #TWithComments.
+	method --|> #TWithAnnotationInstances.
 	method --|> #TCanBeClassSide.
 
 	namedEntity --|> #TPackageable.
 	namedEntity --|> #TInvocationsReceiver.
-	namedEntity --|> #TWithAnnotationInstances.
 	namedEntity --|> #TEntityMetaLevelDependency.
 	namedEntity --|> sourcedEntity.
 

--- a/src/Famix-PharoSmalltalk-Generator/FamixPharoSmalltalkGenerator.class.st
+++ b/src/Famix-PharoSmalltalk-Generator/FamixPharoSmalltalkGenerator.class.st
@@ -103,7 +103,6 @@ FamixPharoSmalltalkGenerator >> defineHierarchy [
 	class --|> #TClass.
 	class --|> #TCanBeAbstract.
 	class --|> #TClassMetrics.
-	class --|> #TWithComments.
 
 	globalVariable --|> namedEntity.
 	globalVariable --|> #TGlobalVariable.

--- a/src/Famix-Traits/FamixTWithAnnotationInstances.trait.st
+++ b/src/Famix-Traits/FamixTWithAnnotationInstances.trait.st
@@ -85,7 +85,7 @@ FamixTWithAnnotationInstances >> numberOfAnnotationInstances [
 	^self
 		lookUpPropertyNamed: #numberOfAnnotationInstances
 		computedAs: [
-			self annotationInstances size + (self methods inject: 0 into: [:sum :each | sum + each numberOfAnnotationInstances])]
+			self annotationInstances size + (self children inject: 0 into: [:sum :each | sum + each numberOfAnnotationInstances])]
 ]
 
 { #category : #metrics }


### PR DESCRIPTION
TWithAnnotationInstances has been modified to call `self children` et non plus `self methods`
Fix #218