### PR TITLE
Add Moose core generator

### DIFF
--- a/src/BaselineOfFamix/BaselineOfFamix.class.st
+++ b/src/BaselineOfFamix/BaselineOfFamix.class.st
@@ -75,7 +75,7 @@ BaselineOfFamix >> groups: spec [
 		  group: 'Core' with: #( 'Famix-Traits' 'Moose-Query-Extensions' );
 		  group: 'Minimal' with: #( 'Moose-Core' );
 		  group: 'Basic'
-		  with: #( 'Famix-BasicInfrastructure' 'Famix-MetamodelGeneration' );
+		  with: #( 'Famix-BasicInfrastructure' 'Famix-MetamodelGeneration' 'Moose-Core-Generator' );
 		  group: 'TestsResources'
 		  with: #( 'ReferenceTestResources' 'Moose-TestResources-LAN'
 			     'Moose-TestResources-LCOM' 'KGBTestResources'
@@ -146,6 +146,7 @@ BaselineOfFamix >> packages: spec [
 			spec requires: #( 'Fame' 'DeepTraverser' 'CollectionExtensions' ) ];
 		package: 'Moose-Core'
 		with: [ spec requires: #( 'Fame' 'Moose-Query' ) ];
+		package: 'Moose-Core-Generator';
 		package: 'Moose-Query-Extensions'
 		with: [ spec requires: #( 'Moose-Query' 'BasicTraits' ) ];
 		package: 'Famix-Traits' with: [ spec requires: #( 'Moose-Core' ) ];

--- a/src/Famix-MetamodelBuilder-Core/FmxMBClass.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxMBClass.class.st
@@ -20,7 +20,7 @@ FmxMBClass >> allClassGeneralizations [
 	result := OrderedCollection new.
 	c := self.
 	[ g := c classGeneralization.
-	g isNotNil ]
+	g isNotNil and: [ g isKindOf: FmxMBClass ] ]
 		whileTrue: [ result add: g.
 			c := g ].
 	^ result

--- a/src/Moose-Core-Generator/MooseModelGenerator.class.st
+++ b/src/Moose-Core-Generator/MooseModelGenerator.class.st
@@ -1,0 +1,56 @@
+Class {
+	#name : #MooseModelGenerator,
+	#superclass : #FamixMetamodelGenerator,
+	#instVars : [
+		'obj',
+		'abstractGroup',
+		'group',
+		'specializedGroup',
+		'model',
+		'entity'
+	],
+	#category : #'Moose-Core-Generator'
+}
+
+{ #category : #accessing }
+MooseModelGenerator class >> packageName [
+
+	<ignoreForCoverage>
+	^ #'Moose-Core'
+]
+
+{ #category : #accessing }
+MooseModelGenerator class >> prefix [
+
+	<ignoreForCoverage>
+	^ #Moose
+]
+
+{ #category : #definition }
+MooseModelGenerator >> defineClasses [
+
+	super defineClasses.
+
+	obj := builder newClassNamed: #Object.
+	obj classGeneralization: Object.
+	abstractGroup := builder newClassNamed: #AbstractGroup.
+	group := builder newClassNamed: #Group.
+	specializedGroup := builder newClassNamed: #SpecializedGroup.
+	model := builder newClassNamed: #Model.
+	entity := builder newClassNamed: #Entity
+	
+]
+
+{ #category : #definition }
+MooseModelGenerator >> defineHierarchy [
+
+	super defineHierarchy.
+
+	abstractGroup --|> obj.
+	group --|> abstractGroup.
+	specializedGroup --|> group.
+	model --|> abstractGroup.
+	entity --|> obj
+
+	
+]

--- a/src/Moose-Core-Generator/package.st
+++ b/src/Moose-Core-Generator/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'Moose-Core-Generator' }

--- a/src/Moose-Core/MooseModel.class.st
+++ b/src/Moose-Core/MooseModel.class.st
@@ -5,8 +5,8 @@ Class {
 	#name : #MooseModel,
 	#superclass : #MooseAbstractGroup,
 	#instVars : [
-		'name',
-		'metamodel'
+		'metamodel',
+		'name'
 	],
 	#classVars : [
 		'MostRecentOwner'


### PR DESCRIPTION
This PR add a MooseCoreGenerator to Famix.
Thus, we will be able to use the MooseCore Generator in other generator (to add remote relations for instance to any MooseOject or entity of any model)