### PR TITLE
Allow people to change species of inner collection of MooseGroup

### DIFF
--- a/src/Moose-Core/MooseGroupRuntimeStorage.class.st
+++ b/src/Moose-Core/MooseGroupRuntimeStorage.class.st
@@ -66,9 +66,11 @@ MooseGroupRuntimeStorage >> elements [
 
 { #category : #initialization }
 MooseGroupRuntimeStorage >> initialize: capacity [
+
+	super initialize: capacity.
 	byType := IdentityDictionary new: 24.
 	byName := IdentityHashTable new: capacity.
-	elements := OrderedCollection new: capacity
+	elements := self species new: capacity
 ]
 
 { #category : #copying }
@@ -122,6 +124,17 @@ MooseGroupRuntimeStorage >> selectAllWithType: aSmalltalkType [
 { #category : #accessing }
 MooseGroupRuntimeStorage >> size [ 
 	^ elements size
+]
+
+{ #category : #accessing }
+MooseGroupRuntimeStorage >> species: anObject [
+
+	"WARNING: Changing the species of the inner collection might have unattempted consequences.
+	DO NOT EXECUTE THIS METHOD EXCEPT IF YOU ARE REALLY SURE OF YOUR NEED
+	
+	For instance, `model species: Set` would make indexed access to collection element impossible"
+	super species: anObject.
+	elements := self species withAll: elements
 ]
 
 { #category : #private }

--- a/src/Moose-Core/MooseGroupSetupStorage.class.st
+++ b/src/Moose-Core/MooseGroupSetupStorage.class.st
@@ -41,9 +41,9 @@ MooseGroupSetupStorage >> do: aBlock [
 ]
 
 { #category : #accessing }
-MooseGroupSetupStorage >> elements [ 
-	 
-	^self asArray
+MooseGroupSetupStorage >> elements [
+
+	^ self asArray
 ]
 
 { #category : #'accessing-sequenceable' }
@@ -56,13 +56,14 @@ MooseGroupSetupStorage >> first [
 MooseGroupSetupStorage >> initialize [
 	super initialize.
 
-	elements := OrderedCollection new: 10000
+	elements := self species new: 10000
 ]
 
 { #category : #initialization }
-MooseGroupSetupStorage >> initialize: capacity [ 
-	 
-	elements := OrderedCollection new: capacity
+MooseGroupSetupStorage >> initialize: capacity [
+
+	super initialize: capacity.
+	elements := self species new: capacity
 ]
 
 { #category : #'accessing-sequenceable' }
@@ -101,4 +102,16 @@ MooseGroupSetupStorage >> selectAllWithType: aSmalltalkClass [
 MooseGroupSetupStorage >> size [ 
 	 
 	^elements size
+]
+
+{ #category : #accessing }
+MooseGroupSetupStorage >> species: anObject [
+
+	"WARNING: Changing the species of the inner collection might have unattempted consequences.
+	DO NOT EXECUTE THIS METHOD EXCEPT IF YOU ARE REALLY SURE OF YOUR NEED
+	
+	For instance, `model species: Set` would make indexed access to collection element impossible"
+
+	super species: anObject.
+	elements := self species withAll: elements
 ]

--- a/src/Moose-Core/MooseGroupStorage.class.st
+++ b/src/Moose-Core/MooseGroupStorage.class.st
@@ -2,6 +2,9 @@ Class {
 	#name : #MooseGroupStorage,
 	#superclass : #Collection,
 	#type : #variable,
+	#instVars : [
+		'species'
+	],
 	#category : #'Moose-Core'
 }
 
@@ -113,8 +116,16 @@ MooseGroupStorage >> includesID: mooseID [
 ]
 
 { #category : #initialization }
+MooseGroupStorage >> initialize [
+
+	super initialize.
+	self species: OrderedCollection
+]
+
+{ #category : #initialization }
 MooseGroupStorage >> initialize: aSize [
-	self subclassResponsibility
+
+	self species: OrderedCollection
 ]
 
 { #category : #iterators }
@@ -161,5 +172,15 @@ MooseGroupStorage >> size [
 { #category : #private }
 MooseGroupStorage >> species [ 
 	 
-	^OrderedCollection
+	^ species
+]
+
+{ #category : #accessing }
+MooseGroupStorage >> species: anObject [
+
+	"WARNING: Changing the species of the inner collection might have unattempted consequences.
+	DO NOT EXECUTE THIS METHOD EXCEPT IF YOU ARE REALLY SURE OF YOUR NEED
+	
+	For instance, `model species: Set` would make indexed access to collection element impossible"
+	species := anObject
 ]

--- a/src/Moose-Core/MooseGroupStorage.class.st
+++ b/src/Moose-Core/MooseGroupStorage.class.st
@@ -119,13 +119,13 @@ MooseGroupStorage >> includesID: mooseID [
 MooseGroupStorage >> initialize [
 
 	super initialize.
-	self species: OrderedCollection
+	species := OrderedCollection
 ]
 
 { #category : #initialization }
 MooseGroupStorage >> initialize: aSize [
 
-	self species: OrderedCollection
+	species := OrderedCollection
 ]
 
 { #category : #iterators }


### PR DESCRIPTION
This PR aims to improve usability of large mooseModel.

## Problem description

When having a super large moose Model (more than 1 000 000 elements), removing one element of the collection is super slow.
And removing several elements can be super slow.

If there is no requirement for accessing elements by their index in the MooseModel, it can be interesting to use a Set instead of an OrderedCollection.

## Proposed solution

We keed the current behavior.
One can change the inner collection type using the `#species:` keyword. Sending this message asks the `MooseGroupRuntimeStorage` to change its inner collection. It results in a first overload that is then, it goes faster.

## Example usage

This is an example for someone that want to load directly the model in a Set instead of a collection

```st
famixJavaModel := FamixJavaModel new.
famixJavaModel entityStorage species: Set.
'D:\myModel.json' asFileReference readStreamDo: [ :stream | famixJavaModel importFromJSONStream: stream ].
```
