### PR TITLE
Add ParametrizableException

### DIFF
--- a/src/Famix-Java-Entities/FamixJavaImportingContext.class.st
+++ b/src/Famix-Java-Entities/FamixJavaImportingContext.class.st
@@ -173,6 +173,12 @@ FamixJavaImportingContext >> importParameterizableClass [
 ]
 
 { #category : #testing }
+FamixJavaImportingContext >> importParameterizableException [
+	<generated>
+	^ self import: FamixJavaParameterizableException
+]
+
+{ #category : #testing }
 FamixJavaImportingContext >> importParameterizableInterface [
 	<generated>
 	^ self import: FamixJavaParameterizableInterface
@@ -404,6 +410,12 @@ FamixJavaImportingContext >> shouldImportParameterType [
 FamixJavaImportingContext >> shouldImportParameterizableClass [
 	<generated>
 	^ self shouldImport: FamixJavaParameterizableClass
+]
+
+{ #category : #testing }
+FamixJavaImportingContext >> shouldImportParameterizableException [
+	<generated>
+	^ self shouldImport: FamixJavaParameterizableException
 ]
 
 { #category : #testing }

--- a/src/Famix-Java-Entities/FamixJavaParameterizableException.class.st
+++ b/src/Famix-Java-Entities/FamixJavaParameterizableException.class.st
@@ -1,0 +1,16 @@
+Class {
+	#name : #FamixJavaParameterizableException,
+	#superclass : #FamixJavaException,
+	#traits : 'FamixTWithParameterizedTypes',
+	#classTraits : 'FamixTWithParameterizedTypes classTrait',
+	#category : #'Famix-Java-Entities-Entities'
+}
+
+{ #category : #meta }
+FamixJavaParameterizableException class >> annotation [
+
+	<FMClass: #ParameterizableException super: #FamixJavaException>
+	<package: #'Famix-Java-Entities'>
+	<generated>
+	^self
+]

--- a/src/Famix-Java-Generator/FamixJavaGenerator.class.st
+++ b/src/Famix-Java-Generator/FamixJavaGenerator.class.st
@@ -39,7 +39,8 @@ Class {
 		'tImplementable',
 		'tCanImplement',
 		'tWithInterfaces',
-		'parameterizableInterface'
+		'parameterizableInterface',
+		'parameterizableException'
 	],
 	#category : #'Famix-Java-Generator'
 }
@@ -140,6 +141,7 @@ FamixJavaGenerator >> defineClasses [
 	parameter := builder newClassNamed: #Parameter.
 	parameterType := builder newClassNamed: #ParameterType.
 	parameterizableClass := builder newClassNamed: #ParameterizableClass.
+	parameterizableException := builder newClassNamed: #ParameterizableException.
 	parameterizableInterface := builder newClassNamed: #ParameterizableInterface.
 	parameterizedType := builder newClassNamed: #ParameterizedType.
 	primitiveType := builder newClassNamed: #PrimitiveType.
@@ -313,6 +315,9 @@ FamixJavaGenerator >> defineHierarchy [
 
 	parameterizableClass --|> class.
 	parameterizableClass --|> #TWithParameterizedTypes.
+	
+	parameterizableException --|> exception.
+	parameterizableException --|> #TWithParameterizedTypes.
 	
 	parameterizableInterface --|> interface.
 	parameterizableInterface --|> #TWithParameterizedTypes.


### PR DESCRIPTION
fix #499 

As reminder

As well as Classes and Types, Exception can be parametrizable.
I propose to create a new entity named `FamixJavaParameterizableException`, subclass of `FamixJavaException`, and add to it the trait `FamixTWithParameterizedTypeUsers`

```mermaid
classDiagram
    FamixJavaException <|-- FamixJavaParameterizableException
    FamixTWithParameterizedTypeUsers <|-- FamixJavaParameterizableException
```

Note that we can find examples of this issue in VerveineJ