### PR TITLE
Comments

### DIFF
--- a/src/Moose-Core/MooseModel.class.st
+++ b/src/Moose-Core/MooseModel.class.st
@@ -29,6 +29,12 @@ MooseModel class >> annotation [
 
 ]
 
+{ #category : #testing }
+MooseModel class >> canBeImportedFromFile [
+
+	^ false
+]
+
 { #category : #accessing }
 MooseModel class >> defaultPackagesToProcessWith: aCollectionOfPackages [
 	"We add to the creation of a metamodel all the metamodel entities of packages declaring to be part of the metamodels by default. 

--- a/src/Moose-SmalltalkImporter-LAN-Tests/FAMIXStepwiseImporterTest.class.st
+++ b/src/Moose-SmalltalkImporter-LAN-Tests/FAMIXStepwiseImporterTest.class.st
@@ -111,18 +111,15 @@ FamixStepwiseImporterTest >> testImportAttributeAccesses [
 
 { #category : #tests }
 FamixStepwiseImporterTest >> testImportClassAndAttributeAndMergeItsMetaclass [
-	"self debug: #testImportClassAndAttributeAndMergeItsMetaclass"
 
 	| importTask importer nodeClass |
 	importTask := self newImportClassesTask.
 	importTask importerClass: SmalltalkImporter.
-	importTask
-		importingContext:
-			(MooseImportingContext new
-				importClass;
-				importAttribute;
-				mergeClassAndMetaclass;
-				yourself).
+	importTask importingContext: (MooseImportingContext new
+			 importClass;
+			 importAttribute;
+			 mergeClassAndMetaclass;
+			 yourself).
 	importTask addClass: LANNode.
 	importer := importTask run.
 	nodeClass := importer classes at: LANNode.
@@ -274,23 +271,21 @@ FamixStepwiseImporterTest >> testImportOneClassAndItsMetaclass [
 
 { #category : #tests }
 FamixStepwiseImporterTest >> testImportOneClassAndMergeItsMetaclass [
-	"self debug: #testImportOneClassAndMergeItsMetaclass"
 
 	| importTask importer importedClasses |
 	importTask := self newImportClassesTask.
 	importTask importerClass: SmalltalkImporter.
-	importTask
-		importingContext:
-			(MooseImportingContext new
-				importClass;
-				mergeClassAndMetaclass;
-				yourself).
+	importTask importingContext: (MooseImportingContext new
+			 importClass;
+			 mergeClassAndMetaclass;
+			 yourself).
 	importTask addClass: LANNode.
 	self assert: importTask classes size equals: 1.
 	importer := importTask run.
 	importedClasses := importer classes.
 	self assert: importedClasses values asSet size equals: 3.
-	self assert: ((importedClasses at: LANNode) usesFamixTrait: FamixTClass)
+	self assert:
+		((importedClasses at: LANNode) usesFamixTrait: FamixTClass)
 ]
 
 { #category : #tests }

--- a/src/Moose-SmalltalkImporter-LAN-Tests/FAMIXStepwiseImporterTest.class.st
+++ b/src/Moose-SmalltalkImporter-LAN-Tests/FAMIXStepwiseImporterTest.class.st
@@ -195,6 +195,29 @@ FamixStepwiseImporterTest >> testImportLANPackage [
 ]
 
 { #category : #tests }
+FamixStepwiseImporterTest >> testImportMergingMetaclassDoesNotDuplicateComment [
+
+	| importTask importer comments |
+	importTask := self newImportClassesTask.
+	importTask importerClass: SmalltalkImporter.
+	importTask importingContext: (MooseImportingContext new
+			 importClass;
+			 importComment;
+			 mergeClassAndMetaclass;
+			 yourself).
+	importTask addClass: LANInterface.
+	importer := importTask run.
+
+	comments := importer allElements select: [ :e | 
+		            e class = FamixStComment ].
+
+	self assert: comments size equals: 1.
+	self
+		assert: comments anyOne container
+		equals: (importer classes at: LANInterface)
+]
+
+{ #category : #tests }
 FamixStepwiseImporterTest >> testImportMethodBody [
 	"Check if when importing the arguments of the LAN example, methods body are imported as well"
 
@@ -327,4 +350,29 @@ FamixStepwiseImporterTest >> testImportOneClassAndOneAttributeAndMergeItsMetacla
 	importer := importTask run.
 	nodeClass := importer classes at: LANNode.
 	self assert: nodeClass attributes size equals: 2
+]
+
+{ #category : #tests }
+FamixStepwiseImporterTest >> testImportWithoutMergingMetaclassDoesDuplicateComment [
+
+	| importTask importer comments |
+	importTask := self newImportClassesTask.
+	importTask importerClass: SmalltalkImporter.
+	importTask importingContext: (MooseImportingContext new
+			 importClass;
+			 importComment;
+			 distinguishClassAndMetaclass;
+			 yourself).
+	importTask addClass: LANInterface.
+	importer := importTask run.
+
+	comments := importer allElements select: [ :e | 
+		            e class = FamixStComment ].
+	self assert: comments size equals: 2.
+	self
+		assertCollection:
+		(comments collect: [ :comment | comment container ])
+		hasSameElements: { 
+				(importer classes at: LANInterface).
+				(importer classes at: LANInterface class) }
 ]

--- a/src/Moose-SmalltalkImporter/SmalltalkImporter.class.st
+++ b/src/Moose-SmalltalkImporter/SmalltalkImporter.class.st
@@ -143,31 +143,54 @@ SmalltalkImporter >> createAttribute: name for: aClass [
 
 { #category : #'private-entity-creation' }
 SmalltalkImporter >> createClass: aClass [
-	| class inheritance |
-	importingContext shouldMergeClassAndMetaclass
-		ifFalse: [ class := self basicClassCreation: aClass ]
-		ifTrue: [ aClass isMeta
-				ifTrue: [ class := self ensureClass: aClass soleInstance.
-					classes at: aClass put: class ]
-				ifFalse: [ class := self basicClassCreation: aClass ] ].
-	importingContext shouldImportPackage ifTrue: [ class parentPackage: (self ensurePackage: aClass package) ].
-	importingContext shouldImportInheritance
-		ifTrue: [ (aClass superclass isNotNil
-				and: [ importingContext shouldMergeClassAndMetaclass
-						ifFalse: [ true ]
-						ifTrue: [ aClass isMeta not ] ])
-				ifTrue: [ inheritance := self addEntity: self factory inheritance new.
-					inheritance superclass: (self ensureClass: aClass superclass).
-					inheritance subclass: class ] ].
-	aClass isMeta ifFalse: [ self ensureClass: aClass class ].
-	importingContext shouldImportAttribute
-		ifTrue: [ aClass instVarNames do: [ :eachName | self ensureAttribute: eachName for: aClass ].
-			"since the classVar of a class are not the same as the classVar of the class class"
 
-			"with latest pharo class classVar = class class classVar so we should not need that anymore"
-			aClass isMeta
-				ifTrue: [ aClass soleInstance classVarNames do: [ :eachClassVarName | self ensureClassVarAttribute: eachClassVarName for: aClass soleInstance ] ]
-				ifFalse: [ aClass classVarNames do: [ :eachClassVarName | self ensureClassVarAttribute: eachClassVarName for: aClass ] ] ].
+	| class inheritance |
+	class := (importingContext shouldMergeClassAndMetaclass and: [ 
+		          aClass isMeta ])
+		         ifTrue: [ 
+		         classes
+			         at: aClass
+			         put: (self ensureClass: aClass soleInstance) ]
+		         ifFalse: [ self basicClassCreation: aClass ].
+
+	importingContext shouldImportPackage ifTrue: [ 
+		class parentPackage: (self ensurePackage: aClass package) ].
+
+	importingContext shouldImportInheritance ifTrue: [ 
+		(aClass superclass isNotNil and: [ 
+			 importingContext shouldMergeClassAndMetaclass
+				 ifFalse: [ true ]
+				 ifTrue: [ aClass isMeta not ] ]) ifTrue: [ 
+			inheritance := self addEntity: self factory inheritance new.
+			inheritance superclass: (self ensureClass: aClass superclass).
+			inheritance subclass: class ] ].
+
+	aClass isMeta ifFalse: [ self ensureClass: aClass class ].
+
+	importingContext shouldImportAttribute ifTrue: [ 
+		aClass instVarNames do: [ :eachName | 
+			self ensureAttribute: eachName for: aClass ].
+		"since the classVar of a class are not the same as the classVar of the class class"
+		"with latest pharo class classVar = class class classVar so we should not need that anymore"
+		aClass isMeta
+			ifTrue: [ 
+				aClass soleInstance classVarNames do: [ :eachClassVarName | 
+					self
+						ensureClassVarAttribute: eachClassVarName
+						for: aClass soleInstance ] ]
+			ifFalse: [ 
+				aClass classVarNames do: [ :eachClassVarName | 
+					self ensureClassVarAttribute: eachClassVarName for: aClass ] ] ].
+
+	(importingContext shouldImportComment and: [ aClass hasComment ]) 
+		ifTrue: [ 
+			(importingContext shouldMergeClassAndMetaclass and: [ 
+				 aClass isMeta ]) ifFalse: [ 
+				| comment |
+				comment := self addEntity: self factory comment new.
+				comment content: aClass comment asString.
+				comment container: class ] ].
+
 	^ class
 ]
 
@@ -454,29 +477,27 @@ SmalltalkImporter >> famixClasses [
 ]
 
 { #category : #importing }
-SmalltalkImporter >> importClass: aClass [ 
-	 
-	| class comment | 
-	importingContext shouldImportClass 
-		ifTrue: 
-			[class := self ensureClass: aClass. 
-			class stub: false.
-			class attributes do: [ :each | each stub: false ].
-			importingContext shouldImportPackage ifTrue: [
-				class parentPackage stub: false ].
-			importingContext shouldImportSubclasses ifTrue: [aClass subclasses do: [:each | self ensureClass: each]]. 
-			importingContext shouldImportMethod 
-				ifTrue: 
-					[aClass methods do: [:each | (self ensureMethod: each) isStub: false ]. 
-					self checkAbstractClass: class]. 
-			importingContext shouldImportComment 
-				ifTrue: 
-					[aClass hasComment 
-						ifTrue: 
-							[comment := self addEntity: self factory comment new. 
-							comment content: aClass comment asString. 
-							comment container: class]]. 
-			aClass isMeta ifFalse: [self importClass: aClass class]]
+SmalltalkImporter >> importClass: aClass [
+
+	| class |
+	importingContext shouldImportClass ifFalse: [ ^ self ].
+
+	class := self ensureClass: aClass.
+	class stub: false.
+	class attributes do: [ :each | each stub: false ].
+
+	importingContext shouldImportPackage ifTrue: [ 
+		class parentPackage stub: false ].
+
+	importingContext shouldImportSubclasses ifTrue: [ 
+		aClass subclasses do: [ :each | self ensureClass: each ] ].
+
+	importingContext shouldImportMethod ifTrue: [ 
+		aClass methods do: [ :each | 
+			(self ensureMethod: each) isStub: false ].
+		self checkAbstractClass: class ].
+
+	aClass isMeta ifFalse: [ self importClass: aClass class ]
 ]
 
 { #category : #importing }


### PR DESCRIPTION
Fix #519 
In the importer, add the class comment only once if classes and metaclasses are merged.
Tests added accordingly.
+ Small method refactor