### PR TITLE
Abstract classes in MM

### DIFF
--- a/src/Famix-Java-Entities/FamixJavaEntity.class.st
+++ b/src/Famix-Java-Entities/FamixJavaEntity.class.st
@@ -23,6 +23,13 @@ FamixJavaEntity class >> annotation [
 	^self
 ]
 
+{ #category : #testing }
+FamixJavaEntity class >> isAbstract [
+
+	<generated>
+	^ self == FamixJavaEntity
+]
+
 { #category : #meta }
 FamixJavaEntity class >> metamodel [
 

--- a/src/Famix-MetamodelBuilder-Core/FamixMetamodelBuilder.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FamixMetamodelBuilder.class.st
@@ -133,6 +133,18 @@ FamixMetamodelBuilder >> configuration: anObject [
 ]
 
 { #category : #initialization }
+FamixMetamodelBuilder >> ensureAbstractClassNamed: aString [
+
+	^ self classes
+		  detect: [ :each | each name = aString ]
+		  ifFound: [ :aClass | 
+			  aClass
+				  isAbstractClass: true;
+				  yourself ]
+		  ifNone: [ self newAbstractClassNamed: aString ]
+]
+
+{ #category : #initialization }
 FamixMetamodelBuilder >> ensureClassNamed: aString [
 
 	^ self classes
@@ -148,7 +160,7 @@ FamixMetamodelBuilder >> ensureEntityClassIsTheCommonSuperclass [
 	self classes iterator | #isRoot selectIt
 	| #isMetamodelClassGroup rejectIt | #isModelClass rejectIt
 	| [ :class | class name = #Entity ] rejectIt
-	| [ :class | class --|> (self ensureClassNamed: #Entity) ] doIt
+	| [ :class | class --|> (self ensureAbstractClassNamed: #Entity) ] doIt
 	> NullAddableObject
 ]
 
@@ -396,6 +408,18 @@ FamixMetamodelBuilder >> model [
 	aClass packageName: self configuration packageName.
 	self classes add: aClass.
 	^ aClass
+]
+
+{ #category : #initialization }
+FamixMetamodelBuilder >> newAbstractClassNamed: aClassName [
+
+	(self classes select: [ :each | each name = aClassName ]) 
+		ifNotEmpty: [ FmxMBEntityAlreadyExists signal ].
+
+	^ self newClass
+		  name: aClassName;
+		  isAbstractClass: true;
+		  yourself
 ]
 
 { #category : #initialization }

--- a/src/Famix-MetamodelBuilder-Core/FmxMBBehavior.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxMBBehavior.class.st
@@ -134,7 +134,7 @@ FmxMBBehavior >> generalization: anObject [
 		ifFalse: [ anObject isMetamodelTrait ifTrue: [ self addTraitGeneralization: anObject ] ifFalse: [ self classGeneralization: anObject ] ]
 ]
 
-{ #category : #accessing }
+{ #category : #generating }
 FmxMBBehavior >> generate [
 	^ self subclassResponsibility
 ]

--- a/src/Famix-MetamodelBuilder-Core/FmxMBClass.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxMBClass.class.st
@@ -2,7 +2,8 @@ Class {
 	#name : #FmxMBClass,
 	#superclass : #FmxMBBehavior,
 	#instVars : [
-		'classGeneralization'
+		'classGeneralization',
+		'isAbstractClass'
 	],
 	#category : #'Famix-MetamodelBuilder-Core-Implementation'
 }
@@ -47,33 +48,51 @@ FmxMBClass >> classGeneralization: anObject [
 FmxMBClass >> generate [
 
 	| aClass aSuperclass aClassName |
-	
 	self willGenerate ifFalse: [ ^ self ].
-	
+
 	aClassName := self fullName.
-	
-	aSuperclass := 	self classGeneralization 
-		ifNil: [ self defaultSuperclass ]
-		ifNotNil: [ self classGeneralization realClass ].
-	
-	aClass := self builder environment createClassNamed: aClassName asSymbol superclass: aSuperclass traitNames: self allTraitNames slots: self slotDefinitions in: self packageName overwrite: true.
-	
+
+	aSuperclass := self classGeneralization
+		               ifNil: [ self defaultSuperclass ]
+		               ifNotNil: [ self classGeneralization realClass ].
+
+	aClass := self builder environment
+		          createClassNamed: aClassName asSymbol
+		          superclass: aSuperclass
+		          traitNames: self allTraitNames
+		          slots: self slotDefinitions
+		          in: self packageName
+		          overwrite: true.
+
 	aClass tagWith: self tag.
 	self builder environment setComment: self comment for: aClass.
-			
+
 	self realClass: aClass.
-	
+
 	self generateAccessors.
 	self generateAnnotationIn: aClass as: self name superclass: nil.
-	
+	self generateIsAbstractMethodIfNecessaryIn: aClass.
+
 	self generateTestingMethodsIn: aClass.
 	self generateRootMetamodelMethodIn: aClass.
 
 	self generateMethodsToRemoveFromTraitCompositionFor: aClass.
 	self generatePrecedenceInTraitComposition: aClass.
-	
+
 	self generateNavigationGroupsFor: aClass.
 	self generateAddToCollectionFor: aClass
+]
+
+{ #category : #generating }
+FmxMBClass >> generateIsAbstractMethodIfNecessaryIn: aClass [
+
+	self isAbstractClass ifTrue: [ 
+		aClass classSide
+			compile: ('isAbstract
+
+	<generated>
+	^ self == {1}' format: { aClass name asString })
+			classified: 'testing' ]
 ]
 
 { #category : #generating }
@@ -120,6 +139,18 @@ FmxMBClass >> generateTestingMethodsIn: aClass [
 ]
 
 { #category : #testing }
+FmxMBClass >> isAbstractClass [
+
+	^ isAbstractClass ifNil: [ false ]
+]
+
+{ #category : #accessing }
+FmxMBClass >> isAbstractClass: aBoolean [
+
+	isAbstractClass := aBoolean
+]
+
+{ #category : #testing }
 FmxMBClass >> isMetamodelClass [
 
 	^ true
@@ -130,7 +161,7 @@ FmxMBClass >> isRoot [
 	^ self classGeneralization isNil
 ]
 
-{ #category : #generating }
+{ #category : #generalization }
 FmxMBClass >> subclassOf: aClass [
 	
 	self generalization: aClass

--- a/src/Famix-MetamodelBuilder-Core/FmxMBNonRemoteRelationSideGenerationStrategy.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxMBNonRemoteRelationSideGenerationStrategy.class.st
@@ -4,81 +4,106 @@ Class {
 	#category : #'Famix-MetamodelBuilder-Core-Implementation'
 }
 
-{ #category : #printing }
+{ #category : #generation }
 FmxMBNonRemoteRelationSideGenerationStrategy >> generateGetterCoreIn: aClassOrTrait on: aStream for: aRelationSide [
+
 	aStream
 		tab;
-		nextPutAll: ('<FMProperty: #{1} type: #{2} opposite: #{3}>' format: {aRelationSide name . aRelationSide oppositeType . aRelationSide oppositeName});
+		nextPutAll:
+			('<FMProperty: #{1} type: #{2} opposite: #{3}>' format: { 
+						 aRelationSide name.
+						 aRelationSide oppositeType.
+						 aRelationSide oppositeName });
 		cr.
 
-	aRelationSide
-		remoteBuilderDo: [ :aRemoteBuilder | 
-			aStream
-				tab;
-				nextPutAll: ('<package: #''{1}''>' format: {aRemoteBuilder generator packageName});
-				cr ].
+	aRelationSide remoteBuilderDo: [ :aRemoteBuilder | 
+		aStream
+			tab;
+			nextPutAll: ('<package: #''{1}''>' format:
+						 { aRemoteBuilder generator packageName });
+			cr ].
 
 	aStream
 		tab;
 		nextPutAll: '^ self attributeAt: #';
 		nextPutAll: aRelationSide name.
 
-	aRelationSide isOne ifTrue: [ aStream nextPutAll: ' ifAbsent: [ nil ]' ].
+	aRelationSide isOne ifTrue: [ 
+		aStream nextPutAll: ' ifAbsent: [ nil ]' ].
 
-	(aRelationSide otherSide isOne and: [ aRelationSide isMany ])
-		ifTrue: [ aStream nextPutAll: (' ifAbsentPut: [ FMMultivalueLink on: self opposite: #{1}: ]' format: {aRelationSide otherSide name}) ].
+	(aRelationSide otherSide isOne and: [ aRelationSide isMany ]) 
+		ifTrue: [ 
+			aStream nextPutAll:
+				(' ifAbsentPut: [ FMMultivalueLink on: self opposite: #{1}: ]' 
+					 format: { aRelationSide otherSide name }) ].
 
-	(aRelationSide isMany and: [ aRelationSide otherSide isMany ])
-		ifTrue: [ aStream nextPutAll: (' ifAbsentPut: [ FMMultiMultivalueLink on: self opposite: #{1} ]' format: {aRelationSide otherSide name}) ]
+	(aRelationSide isMany and: [ aRelationSide otherSide isMany ]) 
+		ifTrue: [ 
+			aStream nextPutAll:
+				(' ifAbsentPut: [ FMMultiMultivalueLink on: self opposite: #{1} ]' 
+					 format: { aRelationSide otherSide name }) ]
 ]
 
-{ #category : #printing }
+{ #category : #generation }
 FmxMBNonRemoteRelationSideGenerationStrategy >> generateSetterCoreIn: aClassOrTrait on: aStream for: aRelationSide [
-	(aRelationSide isOne and: [ aRelationSide otherSide isOne ])
-		ifTrue: [ aStream
-				tab;
-				nextPutAll: ('(self attributeAt: #{1} ifAbsentPut: [nil]) == anObject ifTrue: [ ^ anObject ].' format: {aRelationSide name});
-				cr;
-				tab;
-				nextPutAll: 'anObject ifNil: [ | otherSide |';
-				cr;
-				tab;
-				tab;
-				nextPutAll: ('otherSide :=  self {1}.' format: {aRelationSide name});
-				cr;
-				tab;
-				tab;
-				nextPutAll: ('self attributeAt: #{1} put: anObject.' format: {aRelationSide name});
-				cr;
-				tab;
-				tab;
-				nextPutAll: ('otherSide {1}: nil ]' format: {aRelationSide otherSide name});
-				cr;
-				tab;
-				nextPutAll: ('ifNotNil: [ ' format: {aRelationSide otherSide name});
-				cr;
-				tab;
-				tab;
-				nextPutAll: ('self attributeAt: #{1} put: anObject.' format: {aRelationSide name});
-				cr;
-				tab;
-				tab;
-				nextPutAll: ('anObject {1}: self ]' format: {aRelationSide otherSide name}) ].
 
-	aRelationSide isMany
-		ifTrue: [ aStream
-				tab;
-				nextPutAll: ('self {1} value: anObject' format: {aRelationSide name}) ].
+	(aRelationSide isOne and: [ aRelationSide otherSide isOne ]) ifTrue: [ 
+		aStream
+			tab;
+			nextPutAll:
+				('(self attributeAt: #{1} ifAbsentPut: [nil]) == anObject ifTrue: [ ^ anObject ].' 
+					 format: { aRelationSide name });
+			cr;
+			tab;
+			nextPutAll: 'anObject ifNil: [ | otherSide |';
+			cr;
+			tab;
+			tab;
+			nextPutAll:
+				('otherSide :=  self {1}.' format: { aRelationSide name });
+			cr;
+			tab;
+			tab;
+			nextPutAll: ('self attributeAt: #{1} put: anObject.' format:
+						 { aRelationSide name });
+			cr;
+			tab;
+			tab;
+			nextPutAll:
+				('otherSide {1}: nil ]' format: { aRelationSide otherSide name });
+			cr;
+			tab;
+			nextPutAll:
+				('ifNotNil: [ ' format: { aRelationSide otherSide name });
+			cr;
+			tab;
+			tab;
+			nextPutAll: ('self attributeAt: #{1} put: anObject.' format:
+						 { aRelationSide name });
+			cr;
+			tab;
+			tab;
+			nextPutAll:
+				('anObject {1}: self ]' format: { aRelationSide otherSide name }) ].
 
-	(aRelationSide otherSide isMany and: [ aRelationSide isOne ])
-		ifTrue: [ aStream
+	aRelationSide isMany ifTrue: [ 
+		aStream
+			tab;
+			nextPutAll:
+				('self {1} value: anObject' format: { aRelationSide name }) ].
+
+	(aRelationSide otherSide isMany and: [ aRelationSide isOne ]) 
+		ifTrue: [ 
+			aStream
 				tab;
 				nextPutAll:
-					('self attributeAt: #{1} put: (FMMultivalueLink on: self update: #{2} from: self {1} to: anObject).'
-						format: {aRelationSide name . aRelationSide otherSide name}) ]
+					('self attributeAt: #{1} put: (FMMultivalueLink on: self update: #{2} from: self {1} to: anObject).' 
+						 format: { 
+								 aRelationSide name.
+								 aRelationSide otherSide name }) ]
 ]
 
-{ #category : #printing }
+{ #category : #testing }
 FmxMBNonRemoteRelationSideGenerationStrategy >> producesSlot [
 
 	^ false

--- a/src/Famix-MetamodelBuilder-Core/FmxMBRelationSideGenerationStrategy.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxMBRelationSideGenerationStrategy.class.st
@@ -21,81 +21,90 @@ FmxMBRelationSideGenerationStrategy >> category [
 
 { #category : #generation }
 FmxMBRelationSideGenerationStrategy >> compileMethod: methodSource for: aRelationSide in: aClassOrTrait [
-	
-	aRelationSide builder environment compile: methodSource in: aClassOrTrait classified: self category
-	
-	
+
+	aRelationSide builder environment
+		compile: methodSource
+		in: aClassOrTrait
+		classified: self category
 ]
 
-{ #category : #accessing }
+{ #category : #generation }
 FmxMBRelationSideGenerationStrategy >> generateGetterCoreIn: aClassOrTrait on: aStream for: aRelationSide [
+
 	^ self subclassResponsibility
 ]
 
 { #category : #generation }
 FmxMBRelationSideGenerationStrategy >> generateGetterIn: aClassOrTrait for: aRelationSide [
+
 	| methodSource commentDefinition |
-	commentDefinition := aRelationSide comment ifNotEmpty: [ :comment | '<FMComment: {1}>' format: {comment printString} ].
+	commentDefinition := aRelationSide comment ifNotEmpty: [ :comment | 
+		                     '<FMComment: {1}>' format:
+			                     { comment printString } ].
 
-	methodSource := String
-		streamContents: [ :s | 
-			s
-				nextPutAll: aRelationSide name;
-				cr.
-			aRelationSide hasRelation
-				ifTrue: [ s
-						tab;
-						nextPutAll: '"Relation named: #';
-						nextPutAll: relationSide name;
-						nextPutAll: ' type: #';
-						nextPutAll: relationSide oppositeType;
-						nextPutAll: ' opposite: #';
-						nextPutAll: relationSide oppositeName;
-						nextPutAll: '"';
-						cr;
-						cr ].
-			s
-				tab;
-				nextPutAll: '<generated>';
-				cr.
-			commentDefinition
-				ifNotEmpty: [ s
-						tab;
-						nextPutAll: commentDefinition;
-						cr ].
-			aRelationSide isContainer
-				ifTrue: [ s
-						tab;
-						nextPutAll: '<container>';
-						cr ].
-			aRelationSide isDerived
-				ifTrue: [ s
-						tab;
-						nextPutAll: '<derived>';
-						cr ].
-			aRelationSide isSource
-				ifTrue: [ s
-						tab;
-						nextPutAll: '<source>';
-						cr ].
-			aRelationSide isTarget
-				ifTrue: [ s
-						tab;
-						nextPutAll: '<target>';
-						cr ].
+	methodSource := String streamContents: [ :s | 
+		                s
+			                nextPutAll: aRelationSide name;
+			                cr.
+		                aRelationSide hasRelation ifTrue: [ 
+			                s
+				                tab;
+				                nextPutAll: '"Relation named: #';
+				                nextPutAll: relationSide name;
+				                nextPutAll: ' type: #';
+				                nextPutAll: relationSide oppositeType;
+				                nextPutAll: ' opposite: #';
+				                nextPutAll: relationSide oppositeName;
+				                nextPutAll: '"';
+				                cr;
+				                cr ].
+		                s
+			                tab;
+			                nextPutAll: '<generated>';
+			                cr.
+		                commentDefinition ifNotEmpty: [ 
+			                s
+				                tab;
+				                nextPutAll: commentDefinition;
+				                cr ].
+		                aRelationSide isContainer ifTrue: [ 
+			                s
+				                tab;
+				                nextPutAll: '<container>';
+				                cr ].
+		                aRelationSide isDerived ifTrue: [ 
+			                s
+				                tab;
+				                nextPutAll: '<derived>';
+				                cr ].
+		                aRelationSide isSource ifTrue: [ 
+			                s
+				                tab;
+				                nextPutAll: '<source>';
+				                cr ].
+		                aRelationSide isTarget ifTrue: [ 
+			                s
+				                tab;
+				                nextPutAll: '<target>';
+				                cr ].
 
-			self generateGetterCoreIn: aClassOrTrait on: s for: aRelationSide ].
+		                self
+			                generateGetterCoreIn: aClassOrTrait
+			                on: s
+			                for: aRelationSide ].
 
 	self compileMethod: methodSource for: aRelationSide in: aClassOrTrait
 ]
 
-{ #category : #accessing }
+{ #category : #generation }
 FmxMBRelationSideGenerationStrategy >> generateSetterCoreIn: aClassOrTrait on: aStream for: aRelationSide [
+
 	^ self subclassResponsibility
 ]
 
 { #category : #generation }
 FmxMBRelationSideGenerationStrategy >> generateSetterIn: aClassOrTrait for: aRelationSide [
+
 	| methodSource |
 	methodSource := String
 		streamContents: [ :s | 
@@ -115,10 +124,12 @@ FmxMBRelationSideGenerationStrategy >> generateSetterIn: aClassOrTrait for: aRel
 
 { #category : #accessing }
 FmxMBRelationSideGenerationStrategy >> relationSide [
+
 	^ relationSide
 ]
 
 { #category : #accessing }
 FmxMBRelationSideGenerationStrategy >> relationSide: anObject [
+
 	relationSide := anObject
 ]

--- a/src/Famix-MetamodelBuilder-Core/FmxMBRemoteRelationSideGenerationStrategy.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxMBRemoteRelationSideGenerationStrategy.class.st
@@ -4,8 +4,12 @@ Class {
 	#category : #'Famix-MetamodelBuilder-Core-Implementation'
 }
 
-{ #category : #printing }
+{ #category : #generation }
 FmxMBRemoteRelationSideGenerationStrategy >> compileMethod: methodSource for: aRelationSide in: aClassOrTrait [
-		
-	aRelationSide builder environment compile: methodSource in: aClassOrTrait classified: self category package: self relationSide builder parentBuilderPackageName.
+
+	aRelationSide builder environment
+		compile: methodSource
+		in: aClassOrTrait
+		classified: self category
+		package: self relationSide builder parentBuilderPackageName
 ]

--- a/src/Famix-MetamodelBuilder-Core/FmxMBStandardRelationSideGenerationStrategy.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxMBStandardRelationSideGenerationStrategy.class.st
@@ -4,23 +4,27 @@ Class {
 	#category : #'Famix-MetamodelBuilder-Core-Implementation'
 }
 
-{ #category : #accessing }
+{ #category : #generation }
 FmxMBStandardRelationSideGenerationStrategy >> generateGetterCoreIn: aClassOrTrait on: aStream for: aRelationSide [
+
 	aStream
 		tab;
 		nextPutAll: '^ ';
 		nextPutAll: aRelationSide name
 ]
 
-{ #category : #accessing }
+{ #category : #generation }
 FmxMBStandardRelationSideGenerationStrategy >> generateSetterCoreIn: aClassOrTrait on: aStream for: aRelationSide [
+
 	aStream
 		tab;
 		nextPutAll: aRelationSide name.
-	aRelationSide isOne ifTrue: [ aStream nextPutAll: ' := anObject' ] ifFalse: [ aStream nextPutAll: ' value: anObject' ]
+	aRelationSide isOne
+		ifTrue: [ aStream nextPutAll: ' := anObject' ]
+		ifFalse: [ aStream nextPutAll: ' value: anObject' ]
 ]
 
-{ #category : #printing }
+{ #category : #testing }
 FmxMBStandardRelationSideGenerationStrategy >> producesSlot [
 
 	^ true

--- a/src/Famix-PharoSmalltalk-Entities/FamixStEntity.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStEntity.class.st
@@ -13,6 +13,13 @@ FamixStEntity class >> annotation [
 	^self
 ]
 
+{ #category : #testing }
+FamixStEntity class >> isAbstract [
+
+	<generated>
+	^ self == FamixStEntity
+]
+
 { #category : #meta }
 FamixStEntity class >> metamodel [
 

--- a/src/Famix-Test1-Entities/FamixTest1Entity.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1Entity.class.st
@@ -13,6 +13,13 @@ FamixTest1Entity class >> annotation [
 	^self
 ]
 
+{ #category : #testing }
+FamixTest1Entity class >> isAbstract [
+
+	<generated>
+	^ self == FamixTest1Entity
+]
+
 { #category : #meta }
 FamixTest1Entity class >> metamodel [
 

--- a/src/Famix-Test2-Entities/FamixTest2Entity.class.st
+++ b/src/Famix-Test2-Entities/FamixTest2Entity.class.st
@@ -13,6 +13,13 @@ FamixTest2Entity class >> annotation [
 	^self
 ]
 
+{ #category : #testing }
+FamixTest2Entity class >> isAbstract [
+
+	<generated>
+	^ self == FamixTest2Entity
+]
+
 { #category : #meta }
 FamixTest2Entity class >> metamodel [
 

--- a/src/Famix-Test3-Entities/FamixTest3Entity.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3Entity.class.st
@@ -13,6 +13,13 @@ FamixTest3Entity class >> annotation [
 	^self
 ]
 
+{ #category : #testing }
+FamixTest3Entity class >> isAbstract [
+
+	<generated>
+	^ self == FamixTest3Entity
+]
+
 { #category : #meta }
 FamixTest3Entity class >> metamodel [
 

--- a/src/Famix-Test4-Entities/FamixTest4Entity.class.st
+++ b/src/Famix-Test4-Entities/FamixTest4Entity.class.st
@@ -16,6 +16,13 @@ FamixTest4Entity class >> annotation [
 	^self
 ]
 
+{ #category : #testing }
+FamixTest4Entity class >> isAbstract [
+
+	<generated>
+	^ self == FamixTest4Entity
+]
+
 { #category : #meta }
 FamixTest4Entity class >> metamodel [
 

--- a/src/Famix-Test4-Entities/FamixTest4Person.class.st
+++ b/src/Famix-Test4-Entities/FamixTest4Person.class.st
@@ -16,6 +16,13 @@ FamixTest4Person class >> annotation [
 	^self
 ]
 
+{ #category : #testing }
+FamixTest4Person class >> isAbstract [
+
+	<generated>
+	^ self == FamixTest4Person
+]
+
 { #category : #adding }
 FamixTest4Person >> addBook: anObject [
 	<generated>

--- a/src/Famix-Test4-Tests/FamixTest4Test.class.st
+++ b/src/Famix-Test4-Tests/FamixTest4Test.class.st
@@ -52,6 +52,13 @@ FamixTest4Test >> setUp [
 ]
 
 { #category : #tests }
+FamixTest4Test >> testAbstractClasses [
+
+	self assert: FamixTest4Entity isAbstract.
+	self assert: FamixTest4Person isAbstract
+]
+
+{ #category : #tests }
 FamixTest4Test >> testRelations [
 	self assert: (principal books includes: book2).
 	self assert: (student1 books includes: book1).

--- a/src/Famix-Test5-Entities/FamixTest5Entity.class.st
+++ b/src/Famix-Test5-Entities/FamixTest5Entity.class.st
@@ -13,6 +13,13 @@ FamixTest5Entity class >> annotation [
 	^self
 ]
 
+{ #category : #testing }
+FamixTest5Entity class >> isAbstract [
+
+	<generated>
+	^ self == FamixTest5Entity
+]
+
 { #category : #meta }
 FamixTest5Entity class >> metamodel [
 

--- a/src/Famix-Test6-Entities/FamixTest6Entity.class.st
+++ b/src/Famix-Test6-Entities/FamixTest6Entity.class.st
@@ -13,6 +13,13 @@ FamixTest6Entity class >> annotation [
 	^self
 ]
 
+{ #category : #testing }
+FamixTest6Entity class >> isAbstract [
+
+	<generated>
+	^ self == FamixTest6Entity
+]
+
 { #category : #meta }
 FamixTest6Entity class >> metamodel [
 

--- a/src/Famix-Test7-Entities/FamixTest7Entity.class.st
+++ b/src/Famix-Test7-Entities/FamixTest7Entity.class.st
@@ -13,6 +13,13 @@ FamixTest7Entity class >> annotation [
 	^self
 ]
 
+{ #category : #testing }
+FamixTest7Entity class >> isAbstract [
+
+	<generated>
+	^ self == FamixTest7Entity
+]
+
 { #category : #meta }
 FamixTest7Entity class >> metamodel [
 

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed1Method.extension.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed1Method.extension.st
@@ -1,26 +1,26 @@
 Extension { #name : #FamixTestComposed1Method }
 
 { #category : #'*Famix-TestComposedMetamodel-Entities-accessing' }
-FamixTestComposed1Method >> entity [
-	"Relation named: #entity type: #FamixTestComposedEntity opposite: #method"
+FamixTestComposed1Method >> standardEntity [
+	"Relation named: #standardEntity type: #FamixTestComposedStandardEntity opposite: #method"
 
 	<generated>
 	<derived>
-	<FMProperty: #entity type: #FamixTestComposedEntity opposite: #method>
+	<FMProperty: #standardEntity type: #FamixTestComposedStandardEntity opposite: #method>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
-	^ self attributeAt: #entity ifAbsent: [ nil ]
+	^ self attributeAt: #standardEntity ifAbsent: [ nil ]
 ]
 
 { #category : #'*Famix-TestComposedMetamodel-Entities-accessing' }
-FamixTestComposed1Method >> entity: anObject [
+FamixTestComposed1Method >> standardEntity: anObject [
 
 	<generated>
-	(self attributeAt: #entity ifAbsentPut: [nil]) == anObject ifTrue: [ ^ anObject ].
+	(self attributeAt: #standardEntity ifAbsentPut: [nil]) == anObject ifTrue: [ ^ anObject ].
 	anObject ifNil: [ | otherSide |
-		otherSide :=  self entity.
-		self attributeAt: #entity put: anObject.
+		otherSide :=  self standardEntity.
+		self attributeAt: #standardEntity put: anObject.
 		otherSide method: nil ]
 	ifNotNil: [ 
-		self attributeAt: #entity put: anObject.
+		self attributeAt: #standardEntity put: anObject.
 		anObject method: self ]
 ]

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedAssociation.class.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedAssociation.class.st
@@ -1,6 +1,6 @@
 Class {
 	#name : #FamixTestComposedAssociation,
-	#superclass : #FamixTestComposedEntity,
+	#superclass : #FamixTestComposedStandardEntity,
 	#traits : 'FamixTAssociation + TAssociationMetaLevelDependency',
 	#classTraits : 'FamixTAssociation classTrait + TAssociationMetaLevelDependency classTrait',
 	#category : #'Famix-TestComposedMetamodel-Entities-Entities'
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixTestComposedAssociation class >> annotation [
 
-	<FMClass: #Association super: #FamixTestComposedEntity>
+	<FMClass: #Association super: #FamixTestComposedStandardEntity>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 	<generated>
 	^self

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedEntity.class.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedEntity.class.st
@@ -13,6 +13,13 @@ FamixTestComposedEntity class >> annotation [
 	^self
 ]
 
+{ #category : #testing }
+FamixTestComposedEntity class >> isAbstract [
+
+	<generated>
+	^ self == FamixTestComposedEntity
+]
+
 { #category : #meta }
 FamixTestComposedEntity class >> metamodel [
 

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedEntity.class.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedEntity.class.st
@@ -33,26 +33,3 @@ FamixTestComposedEntity >> isAssociation [
 	<generated>
 	^ false
 ]
-
-{ #category : #accessing }
-FamixTestComposedEntity >> method [
-	"Relation named: #method type: #FamixTestComposed1Method opposite: #entity"
-
-	<generated>
-	<FMProperty: #method type: #FamixTestComposed1Method opposite: #entity>
-	^ self attributeAt: #method ifAbsent: [ nil ]
-]
-
-{ #category : #accessing }
-FamixTestComposedEntity >> method: anObject [
-
-	<generated>
-	(self attributeAt: #method ifAbsentPut: [nil]) == anObject ifTrue: [ ^ anObject ].
-	anObject ifNil: [ | otherSide |
-		otherSide :=  self method.
-		self attributeAt: #method put: anObject.
-		otherSide entity: nil ]
-	ifNotNil: [ 
-		self attributeAt: #method put: anObject.
-		anObject entity: self ]
-]

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedStandardEntity.class.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedStandardEntity.class.st
@@ -1,0 +1,37 @@
+Class {
+	#name : #FamixTestComposedStandardEntity,
+	#superclass : #FamixTestComposedEntity,
+	#category : #'Famix-TestComposedMetamodel-Entities-Entities'
+}
+
+{ #category : #meta }
+FamixTestComposedStandardEntity class >> annotation [
+
+	<FMClass: #StandardEntity super: #FamixTestComposedEntity>
+	<package: #'Famix-TestComposedMetamodel-Entities'>
+	<generated>
+	^self
+]
+
+{ #category : #accessing }
+FamixTestComposedStandardEntity >> method [
+	"Relation named: #method type: #FamixTestComposed1Method opposite: #standardEntity"
+
+	<generated>
+	<FMProperty: #method type: #FamixTestComposed1Method opposite: #standardEntity>
+	^ self attributeAt: #method ifAbsent: [ nil ]
+]
+
+{ #category : #accessing }
+FamixTestComposedStandardEntity >> method: anObject [
+
+	<generated>
+	(self attributeAt: #method ifAbsentPut: [nil]) == anObject ifTrue: [ ^ anObject ].
+	anObject ifNil: [ | otherSide |
+		otherSide :=  self method.
+		self attributeAt: #method put: anObject.
+		otherSide standardEntity: nil ]
+	ifNotNil: [ 
+		self attributeAt: #method put: anObject.
+		anObject standardEntity: self ]
+]

--- a/src/Famix-TestComposedMetamodel/FamixTestComposedMetamodels.class.st
+++ b/src/Famix-TestComposedMetamodel/FamixTestComposedMetamodels.class.st
@@ -33,7 +33,6 @@ FamixTestComposedMetamodels >> setUp [
 	model := FamixTestComposedModel new.
 	
 	remoteMethod := FamixTestComposed1Method new.
-	entity := FamixTestComposedEntity new.
 	remoteClass := FamixTestComposed2Class new.
 	
 	c1 := FamixTestComposedCustomEntity1 new.
@@ -51,7 +50,7 @@ FamixTestComposedMetamodels >> setUp [
 	c23 := FamixTestComposed2CustomEntity3 new.
 	c24 := FamixTestComposed2CustomEntity4 new.
 
-	model addAll: { remoteMethod. entity. remoteClass. c1. c2. c3. c4. c11. c12. c13. c14. c21. c22. c23. c24 }.
+	model addAll: { remoteMethod. remoteClass. c1. c2. c3. c4. c11. c12. c13. c14. c21. c22. c23. c24 }.
 	
 	
 ]

--- a/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1Entity.class.st
+++ b/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1Entity.class.st
@@ -13,6 +13,13 @@ FamixTestComposed1Entity class >> annotation [
 	^self
 ]
 
+{ #category : #testing }
+FamixTestComposed1Entity class >> isAbstract [
+
+	<generated>
+	^ self == FamixTestComposed1Entity
+]
+
 { #category : #meta }
 FamixTestComposed1Entity class >> metamodel [
 

--- a/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2Entity.class.st
+++ b/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2Entity.class.st
@@ -13,6 +13,13 @@ FamixTestComposed2Entity class >> annotation [
 	^self
 ]
 
+{ #category : #testing }
+FamixTestComposed2Entity class >> isAbstract [
+
+	<generated>
+	^ self == FamixTestComposed2Entity
+]
+
 { #category : #meta }
 FamixTestComposed2Entity class >> metamodel [
 

--- a/src/Famix-TestGenerators/FamixTest4Generator.class.st
+++ b/src/Famix-TestGenerators/FamixTest4Generator.class.st
@@ -42,10 +42,11 @@ FamixTest4Generator >> adoptBuilder: aBuilder [
 
 { #category : #definition }
 FamixTest4Generator >> defineClasses [
+
 	super defineClasses.
 
 	book := builder newClassNamed: #Book.
-	person := builder newClassNamed: #Person.
+	person := builder newAbstractClassNamed: #Person.
 	principal := builder newClassNamed: #Principal.
 	student := builder newClassNamed: #Student.
 	teacher := builder newClassNamed: #Teacher.

--- a/src/Famix-TestGenerators/FamixTestComposedGenerator.class.st
+++ b/src/Famix-TestGenerators/FamixTestComposedGenerator.class.st
@@ -3,11 +3,11 @@ Class {
 	#superclass : #FamixMetamodelGenerator,
 	#instVars : [
 		'association',
-		'entity',
 		'customEntity1',
 		'customEntity2',
 		'customEntity3',
-		'customEntity4'
+		'customEntity4',
+		'standardEntity'
 	],
 	#category : #'Famix-TestGenerators'
 }
@@ -35,7 +35,7 @@ FamixTestComposedGenerator >> define [
 	| test1Method test1Custom1 test1Custom2 test1Custom3 test1Custom4 test2Custom1 test2Custom2 test2Custom3 test2Custom4 test1Custom5 test2Custom5 |
 	super define.
 
-	entity := builder newClassNamed: #Entity.
+	standardEntity := builder newClassNamed: #StandardEntity.
 
 	test1Method := self remoteEntity: #Method withPrefix: #FamixTestComposed1.
 	self remoteEntity: #Class withPrefix: #FamixTestComposed2.
@@ -55,7 +55,7 @@ FamixTestComposedGenerator >> define [
 	customEntity3 := builder newClassNamed: #CustomEntity3.
 	customEntity4 := builder newClassNamed: #CustomEntity4.
 
-	entity - test1Method.
+	standardEntity - test1Method.
 
 	customEntity1 <>- test1Custom1.
 	customEntity2 -* test1Custom2.
@@ -73,7 +73,7 @@ FamixTestComposedGenerator >> define [
 	(test1Custom4 property: #c24s) *-* (test2Custom4 property: #c14s).
 
 	association := builder newClassNamed: #Association.
-	association --|> entity.
+	association --|> standardEntity.
 	association --|> #TAssociation.
 	association --|> #TAssociationMetaLevelDependency.
 

--- a/src/Moose-Core-Tests-Entities/MooseMSEImporterTestEntity.class.st
+++ b/src/Moose-Core-Tests-Entities/MooseMSEImporterTestEntity.class.st
@@ -13,6 +13,13 @@ MooseMSEImporterTestEntity class >> annotation [
 	^self
 ]
 
+{ #category : #testing }
+MooseMSEImporterTestEntity class >> isAbstract [
+
+	<generated>
+	^ self == MooseMSEImporterTestEntity
+]
+
 { #category : #meta }
 MooseMSEImporterTestEntity class >> metamodel [
 

--- a/src/Moose-Core-Tests/MooseAbstractGroupTest.class.st
+++ b/src/Moose-Core-Tests/MooseAbstractGroupTest.class.st
@@ -39,19 +39,19 @@ MooseAbstractGroupTest >> testAdd [
 
 { #category : #tests }
 MooseAbstractGroupTest >> testAddLast [
-	| entity class method |
-	group addLast: (entity := FamixTest1Entity new).
-	self assert: group last identicalTo: entity.
-
+	| attribute class method |
 	group addLast: (class := FamixTest1Class new).
 	self assert: group last identicalTo: class.
 
 	group addLast: (method := FamixTest1Method new).
 	self assert: group last identicalTo: method.
 
-	self assert: (group at: 1) identicalTo: entity.
-	self assert: (group at: 2) identicalTo: class.
-	self assert: (group at: 3) identicalTo: method
+	group addLast: (attribute := FamixTest1Attribute new).
+	self assert: group last identicalTo: attribute.
+	
+	self assert: (group at: 1) identicalTo: class.
+	self assert: (group at: 2) identicalTo: method.
+	self assert: (group at: 3) identicalTo: attribute
 ]
 
 { #category : #tests }

--- a/src/Moose-Core/MooseSpecializedGroup.class.st
+++ b/src/Moose-Core/MooseSpecializedGroup.class.st
@@ -80,12 +80,13 @@ MooseSpecializedGroup >> species [
 
 { #category : #private }
 MooseSpecializedGroup >> updateTypeAccordingToEntities [
+
 	| common wantedType class |
 	common := self commonEntitiesClass.
 	wantedType := common relatedGroupType.
 	self name = wantedType ifTrue: [ ^ self ].
 	class := MooseAbstractGroup allSubclasses
-		detect: [ :each | each name == wantedType name ]
-		ifNone: [ ^ self changeTypeToDefaultType ].
+		         detect: [ :each | each name == wantedType name ]
+		         ifNone: [ ^ self changeTypeToDefaultType ].
 	self changeTypeTo: class
 ]


### PR DESCRIPTION
FamixXXXEntity, FamixXXXSourcedEntity, ... should be abstract classes.

This PR allows to do this by generating class methods of the form:

```Smalltalk
FamixJavaEntity class >> #isAbstract

    ^ self == FamixJavaEntity
```

To reviewers: please note the 1st commit is the most important change. Following commits are changes in tests and methods formatting
