### PR TITLE
Adapt to P11 deprecations.

### DIFF
--- a/src/Moose-Core/MooseAbstractGroup.class.st
+++ b/src/Moose-Core/MooseAbstractGroup.class.st
@@ -174,6 +174,12 @@ MooseAbstractGroup >> asBag [
 ]
 
 { #category : #converting }
+MooseAbstractGroup >> asCollection [
+
+	^ self entityStorage asCollection
+]
+
+{ #category : #converting }
 MooseAbstractGroup >> asMooseGroup [ 
 	^ self 
 ]

--- a/src/Moose-SmalltalkImporter/AbstractSmalltalkMethodVisitor.class.st
+++ b/src/Moose-SmalltalkImporter/AbstractSmalltalkMethodVisitor.class.st
@@ -166,12 +166,16 @@ AbstractSmalltalkMethodVisitor >> resolveInstanceSide: aNamedEntity [
 ]
 
 { #category : #accessing }
-AbstractSmalltalkMethodVisitor >> runWith: aCompiledMethod and: anEntity [ 
-	| parseTree |
-	self initializeForMethod: anEntity inClass: aCompiledMethod methodClass.
+AbstractSmalltalkMethodVisitor >> runWith: aCompiledMethod and: anEntity [
 
-	parseTree := theClass parseTreeFor: aCompiledMethod selector.
-	parseTree ifNotNil: [ self visitMethodNode: parseTree	"sourceCodeAt:" ]
+	| parseTree |
+	self
+		initializeForMethod: anEntity
+		inClass: aCompiledMethod methodClass.
+
+	parseTree := theClass parseTreeForSelector: aCompiledMethod selector.
+	parseTree ifNotNil: [
+		self visitMethodNode: parseTree "sourceCodeAt:" ]
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
Automatic transformations + add #asCollection to MooseAbstractGroup.