### PR TITLE
Fix inheritance for ParameterizedType and ParameterizableClass

### DIFF
--- a/src/Famix-Java-Entities/FamixJavaParameterizableClass.class.st
+++ b/src/Famix-Java-Entities/FamixJavaParameterizableClass.class.st
@@ -15,6 +15,19 @@ FamixJavaParameterizableClass class >> annotation [
 	^ self
 ]
 
+{ #category : #enumerating }
+FamixJavaParameterizableClass >> allSubclassesDo: aBlock [
+	"override traversal to include subtypes of parameterized types"
+
+	| recursion |
+	recursion := [ :each | 
+	             aBlock value: each subclass.
+	             each subclass allSubclassesDo: aBlock ].
+	self subInheritances do: recursion.
+	self parameterizedTypes do: [ :type | 
+		type subInheritances do: recursion ]
+]
+
 { #category : #accessing }
 FamixJavaParameterizableClass >> parameters [
 	<FMProperty: #parameters type: #FamixJavaParameterType> <multivalued> <derived>
@@ -27,25 +40,4 @@ FamixJavaParameterizableClass >> parameters [
 FamixJavaParameterizableClass >> parameters: aCollection [
 
 	self attributeAt: #parameters put: aCollection
-]
-
-{ #category : #enumerating }
-FamixJavaParameterizableClass >> subclassHierarchy [
-	"has to redefine this method to override the one from TWithInheritance"
-	| superclasses |
-	superclasses := OrderedCollection new.
-	self parameterizedTypes do: [ :parameterizedType | 
-		parameterizedType allSubclassesDo: [ :each | superclasses add: each ] ].
-	^ superclasses
-]
-
-{ #category : #enumerating }
-FamixJavaParameterizableClass >> superclassHierarchy [
-	"has to redefine this method to override the one from TWithInheritance"
-	| superclasses |
-	superclasses := OrderedCollection new.
-	self parameterizedTypes do: [ :parameterizedType | 
-		parameterizedType allSuperclassesDo: [ :each | 
-			superclasses add: each ] ].
-	^ superclasses
 ]

--- a/src/Famix-Java-Entities/FamixJavaParameterizedType.class.st
+++ b/src/Famix-Java-Entities/FamixJavaParameterizedType.class.st
@@ -15,6 +15,19 @@ FamixJavaParameterizedType class >> annotation [
 	^ self
 ]
 
+{ #category : #enumerating }
+FamixJavaParameterizedType >> allSuperclassesDo: aBlock [
+	"override traversal to include supertypes of parameterizable class"
+
+	| recursion |
+	recursion := [ :each | 
+	             aBlock value: each superclass.
+	             each superclass allSuperclassesDo: aBlock ].
+	self superInheritances do: recursion.
+	self parameterizableClass ifNotNil: [ :class | 
+		class superInheritances do: recursion ]
+]
+
 { #category : #printing }
 FamixJavaParameterizedType >> displayStringOn: aStream [
 	self mooseNameOn: aStream

--- a/src/Famix-Traits/FamixTWithParameterizedTypes.trait.st
+++ b/src/Famix-Traits/FamixTWithParameterizedTypes.trait.st
@@ -36,24 +36,3 @@ FamixTWithParameterizedTypes >> parameterizedTypes: anObject [
 	<generated>
 	parameterizedTypes value: anObject
 ]
-
-{ #category : #enumerating }
-FamixTWithParameterizedTypes >> subclassHierarchy [
-
-	| superclasses |
-	superclasses := OrderedCollection new.
-	self parameterizedTypes do: [ :parameterizedType | 
-		parameterizedType allSubclassesDo: [ :each | superclasses add: each ] ].
-	^ superclasses
-]
-
-{ #category : #enumerating }
-FamixTWithParameterizedTypes >> superclassHierarchy [
-
-	| superclasses |
-	superclasses := OrderedCollection new.
-	self parameterizedTypes do: [ :parameterizedType | 
-		parameterizedType allSuperclassesDo: [ :each | 
-			superclasses add: each ] ].
-	^ superclasses
-]


### PR DESCRIPTION
Reverted some changes made in 41cfa98
Now the superclasses of a `ParameterizedType` include the superclasses of its `ParameterizableClass`, and the subclasses of a `ParameterizableClass` include the subclasses of its `ParameterizedType`s.

```st
lazyPojo := FamixJavaClass named: 'LazyPojo'.
apoGWT := FamixJavaClass named: 'AbstractPersistentObjectGWT'.
FamixJavaInheritance new superclass: lazyPojo; subclass: apoGWT.

contextGWT := FamixJavaParameterizableClass named: 'ContextGWT'.
FamixJavaInheritance new superclass: apoGWT; subclass: contextGWT.

contextType := FamixJavaParameterizedType new name: 'ContextGWT';
  parameterizableClass: contextGWT;
  arguments: { FamixJavaClass named: 'String' }.
contextDTO := FamixJavaClass named: 'ContextDTOOmajeGWT'.
FamixJavaInheritance new superclass: contextType; subclass: contextDTO.

contextDTO superclassHierarchy. "ContextGWT, AbstractPersistentObjectGWT, LazyPojo"
lazyPojo subclassHierarchy. "AbstractPersistentObjectGWT, ContextGWT, ContextDTOOmajeGWT"
```