### PR TITLE
Fix deprecated slots

### DIFF
--- a/src/Moose-Core/FamixDeprecatedSlot.class.st
+++ b/src/Moose-Core/FamixDeprecatedSlot.class.st
@@ -59,18 +59,26 @@ FamixDeprecatedSlot >> printOn: aStream [
 
 { #category : #'meta-object-protocol' }
 FamixDeprecatedSlot >> read: anObject [
-	FamixSlotDeprecation new
-		context: thisContext;
-		explanation: self message;
-		signal.
+
+	"In case this is ShiftClassInstaller then we are migrating the instances and we should not raise a deprecation"
+	thisContext sender contextClass = ShiftClassInstaller ifFalse: [
+		FamixSlotDeprecation new
+			context: thisContext;
+			explanation: self message;
+			signal ].
+
 	super read: anObject
 ]
 
 { #category : #'meta-object-protocol' }
 FamixDeprecatedSlot >> write: aValue to: anObject [
-	FamixSlotDeprecation new
-		context: thisContext;
-		explanation: self message;
-		signal.
+
+	"In case this is ShiftClassInstaller then we are migrating the instances and we should not raise a deprecation"
+	thisContext sender contextClass = ShiftClassInstaller ifFalse: [
+		FamixSlotDeprecation new
+			context: thisContext;
+			explanation: self message;
+			signal ].
+
 	super write: aValue to: anObject
 ]

--- a/src/Moose-Core/FamixSlotDeprecation.class.st
+++ b/src/Moose-Core/FamixSlotDeprecation.class.st
@@ -13,7 +13,7 @@ FamixSlotDeprecation >> messageText [
 				nextPutAll: 'The instance variable ';
 				nextPutAll: context receiver name;
 				nextPutAll: ' accessed in ';
-				nextPutAll: context sender method name;
+				nextPutAll: context sender homeMethod name;
 				nextPutAll: ' has been deprecated. ';
 				nextPutAll: explanationString ]
 ]


### PR DESCRIPTION
There were 2 problems:
- The message text of the slot deprecation was calling the wrong method to display the method reading the slot
- We were triggering the deprecation while migrating instances of the class

This PR fixes both problems