### PR TITLE
Remove isInterface and isInterface: from FamixJavaClass

### DIFF
--- a/src/Famix-Java-Entities/FamixJavaClass.class.st
+++ b/src/Famix-Java-Entities/FamixJavaClass.class.st
@@ -113,21 +113,6 @@ FamixJavaClass >> isInheritedBy: anInheritance [
 	^anInheritance superclass == self
 ]
 
-{ #category : #testing }
-FamixJavaClass >> isInterface [
-
-	<FMProperty: #isInterface type: #Boolean>
-	<FMComment: 'This is a boolean flag used to distinguish between classes with implementation and interfaces'>
-
-	^ self attributeAt: #isInterface ifAbsent: [ false ]
-]
-
-{ #category : #testing }
-FamixJavaClass >> isInterface: aBoolean [
-
-	^ self attributeAt: #isInterface put: true
-]
-
 { #category : #private }
 FamixJavaClass >> lookUpInInterfaces: aMethodSignature [
 

--- a/src/Moose-Query-Test/MooseQueryTest.class.st
+++ b/src/Moose-Query-Test/MooseQueryTest.class.st
@@ -364,9 +364,11 @@ MooseQueryTest >> testAtScopeWithPropertyHandleError [
 
 { #category : #tests }
 MooseQueryTest >> testAtScopeWithPropertyOnlyUnderstandByParent [
-	class1 isInterface: true.
-	self assertCollection: (class1 atScopeWithProperty: #isInterface) hasSameElements: {class1}.
-	self assertCollection: (method1 atScopeWithProperty: #isInterface) hasSameElements: {class1}.
+	| interface1 methodInt1 |
+	interface1 := (FamixJavaInterface named: 'interface1').
+	methodInt1 := (FamixJavaMethod named: 'methodInt1') parentType: interface1.
+	self assertCollection: (interface1 atScopeWithProperty: #isInterface) hasSameElements: {interface1}.
+	self assertCollection: (methodInt1 atScopeWithProperty: #isInterface) hasSameElements: {interface1}.
 	self assertCollection: (class2 atScopeWithProperty: #isInterface) hasSameElements: {}.
 	self assertCollection: (method2 atScopeWithProperty: #isInterface) hasSameElements: {}.
 ]


### PR DESCRIPTION
Correct testAtScopeWithPropertyOnlyUnderstandByParent consequently Fix #603