### PR TITLE
Update criticBrowser-baseline.st

### DIFF
--- a/.github/workflows/criticBrowser-baseline.st
+++ b/.github/workflows/criticBrowser-baseline.st
@@ -1,4 +1,5 @@
 Metacello new
   baseline: 'MooseIDE';
   repository: 'github://moosetechnology/MooseIDE:development/src';
+  onConflictUseLoaded;
   load: 'CriticBrowser-Metamodel'


### PR DESCRIPTION
Add #onConflictUseLoaded.
We load the Critic browser after Famix and we want to keep the loaded version of Famix, as it is the version we want to test.