### PR TITLE
In mooseNameWithDots, we replaced ^ self mooseName ifNotNil: [ '.' jo…

### DIFF
--- a/src/Famix-Java-Entities/FamixJavaContainerEntity.class.st
+++ b/src/Famix-Java-Entities/FamixJavaContainerEntity.class.st
@@ -37,5 +37,5 @@ FamixJavaContainerEntity >> addInterface: anInterface [
 
 { #category : #'Famix-Java' }
 FamixJavaContainerEntity >> mooseNameWithDots [
-	^ self mooseName ifNotNil: [ '.' join: (self mooseName substrings: '::') ]
+	^ self mooseName ifNotNil: [ :mName |  '.' join: (mName substrings: '::') ]
 ]


### PR DESCRIPTION
…in: (self mooseName substrings: '::') ] by ^ self mooseName ifNotNil: [ :mName |  '.' join: (mName substrings: '::') ]