### PR TITLE
Use ShiftClassInstaller to generate and update generated classes

### DIFF
--- a/src/Famix-MetamodelBuilder-Core/FmxClassAddition.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxClassAddition.class.st
@@ -23,35 +23,30 @@ Class {
 	#name : #FmxClassAddition,
 	#superclass : #FmxCodeChange,
 	#instVars : [
-		'definition'
+		'creationCode'
 	],
 	#category : #'Famix-MetamodelBuilder-Core-Changes'
 }
 
 { #category : #'instance creation' }
-FmxClassAddition class >> definition: aString [
+FmxClassAddition class >> creationCode: aString [
 	^ self new
-		definition: aString;
+		creationCode: aString;
 		yourself
 ]
 
 { #category : #accessing }
 FmxClassAddition >> apply [
 
-	| installation |
-	installation := self definition.
-	"In Pharo 12 the definition string does not install the class, it just builds a builder. Thus we need to install it explicitly.
-	When Moose will have its minimal version on P12 we should probably refactor to not hold a string but manage ShiftClassBuilder instance directly. In the meantime here is a quick fix to have this work in P11 and P12."
-	SystemVersion current major < 12 ifFalse: [ installation := installation , '; install' ].
-	self class compiler evaluate: installation
+	self class compiler evaluate: self creationCode
 ]
 
 { #category : #accessing }
-FmxClassAddition >> definition [
-	^ definition
+FmxClassAddition >> creationCode [
+	^ creationCode
 ]
 
 { #category : #accessing }
-FmxClassAddition >> definition: anObject [
-	definition := anObject
+FmxClassAddition >> creationCode: anObject [
+	creationCode := anObject
 ]

--- a/src/Famix-MetamodelBuilder-Core/FmxMBRealRingEnvironment.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxMBRealRingEnvironment.class.st
@@ -35,7 +35,7 @@ FmxMBRealRingEnvironment >> compile: aSource in: aClass classified: aProtocol pa
 { #category : #installing }
 FmxMBRealRingEnvironment >> recordAdoptionOfClassDefinitionFrom: realClass to: anRGClass [
 
-	| customSlots customSlotNames slotDefinitions slotsString definition traitsString |
+	| customSlots customSlotNames slotDefinitions |
 	(realClass needToAdaptTo: anRGClass) ifFalse: [ ^ self ].
 
 	customSlots := realClass localSlots copyWithoutAll: realClass generatedSlots.
@@ -44,9 +44,17 @@ FmxMBRealRingEnvironment >> recordAdoptionOfClassDefinitionFrom: realClass to: a
 	slotDefinitions addAll: (customSlots collect: #definitionString).
 	slotDefinitions := slotDefinitions sorted.
 
-	slotsString := '{' , (slotDefinitions joinUsing: '. ') , '}'.
-	traitsString := self traitStringFrom: realClass to: anRGClass.
-	definition := 'Smalltalk classInstaller
+	self
+		recordClassAdditionFromClass: anRGClass
+		traits: (self traitStringFrom: realClass to: anRGClass)
+		slots: '{' , (slotDefinitions joinUsing: '. ') , '}'
+		sharedVariables: '{' , ((realClass classVarNames collect: [ :each | '#' , each ]) joinUsing: ' ') , '}'
+]
+
+{ #category : #installing }
+FmxMBRealRingEnvironment >> recordClassAdditionFromClass: aRGClass traits: traitsString slots: slotsString sharedVariables: sharedVariablesString [
+
+	changesToApply add: (FmxClassAddition creationCode: ('Smalltalk classInstaller
 	make: [ :builder |
 		builder 
 			{superclassOrTraitDeclaration};
@@ -56,16 +64,14 @@ FmxMBRealRingEnvironment >> recordAdoptionOfClassDefinitionFrom: realClass to: a
 			sharedVariables: {classVariables};
 			category: {category}
 		 ]' format: (Dictionary newFrom: {
-				               (#superclassOrTraitDeclaration -> (anRGClass isTrait
-					                 ifTrue: [ 'beTrait' ]
-					                 ifFalse: [ 'superclass: ' , anRGClass superclass name ])).
-				               (#className -> anRGClass name asSymbol printString).
-				               (#traits -> traitsString).
-				               (#slots -> slotsString).
-				               (#classVariables -> ('{' , ((realClass classVarNames collect: [ :each | '#' , each ]) joinUsing: ' ') , '}')).
-				               (#category -> realClass category printString) }).
-
-	changesToApply add: (FmxClassAddition definition: definition)
+						   (#superclassOrTraitDeclaration -> (aRGClass isTrait
+							     ifTrue: [ 'beTrait' ]
+							     ifFalse: [ 'superclass: ' , aRGClass superclass name ])).
+						   (#className -> aRGClass name asSymbol printString).
+						   (#traits -> (traitsString ifNil: [ aRGClass traitCompositionString ])).
+						   (#slots -> (slotsString ifNil: [ aRGClass slotDefinitionString ])).
+						   (#classVariables -> (sharedVariablesString ifNil: [ '{}' ])).
+						   (#category -> aRGClass category printString) })))
 ]
 
 { #category : #installing }
@@ -74,20 +80,11 @@ FmxMBRealRingEnvironment >> recordClassChangesFor: anRGClass [
 	| realClass |
 	realClass := self class environment classNamed: anRGClass name.
 	realClass
-		ifNil: [ 
-			changesToApply add:
-				(FmxClassAddition definition: anRGClass definition) ]
-		ifNotNil: [ 
-		self recordAdoptionOfClassDefinitionFrom: realClass to: anRGClass ].
+		ifNil: [ self recordClassAdditionFromClass: anRGClass  traits: nil  slots: nil sharedVariables: nil  ]
+		ifNotNil: [ self recordAdoptionOfClassDefinitionFrom: realClass to: anRGClass ].
 	self recordClassCommentChangeOf: realClass to: anRGClass.
-	self
-		recordMethodsAdoptionsOf: realClass
-		to: anRGClass
-		realClassName: anRGClass name.
-	self
-		recordMethodsAdoptionsOf: (realClass ifNotNil: #class)
-		to: anRGClass classSide
-		realClassName: anRGClass name
+	self recordMethodsAdoptionsOf: realClass to: anRGClass realClassName: anRGClass name.
+	self recordMethodsAdoptionsOf: (realClass ifNotNil: #class) to: anRGClass classSide realClassName: anRGClass name
 ]
 
 { #category : #installing }
@@ -144,8 +141,9 @@ FmxMBRealRingEnvironment >> recordMethodsAdoptionsOf: realClass to: anRGClass re
 
 { #category : #installing }
 FmxMBRealRingEnvironment >> recordPackagesChangesFor: resolvedPackages [
+
 	resolvedPackages
-		select: [ :each | (RPackageOrganizer default includesPackageNamed: each name) not ]
+		reject: [ :each | self packageOrganizer includesPackageNamed: each name ]
 		thenDo: [ :each | changesToApply add: (FmxPackageAddition named: each name) ]
 ]
 

--- a/src/Famix-MetamodelBuilder-Core/FmxMBRealRingEnvironment.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxMBRealRingEnvironment.class.st
@@ -49,10 +49,11 @@ FmxMBRealRingEnvironment >> recordAdoptionOfClassDefinitionFrom: realClass to: a
 		traits: (self traitStringFrom: realClass to: anRGClass)
 		slots: '{' , (slotDefinitions joinUsing: '. ') , '}'
 		sharedVariables: '{' , ((realClass classVarNames collect: [ :each | '#' , each ]) joinUsing: ' ') , '}'
+		category: realClass category
 ]
 
 { #category : #installing }
-FmxMBRealRingEnvironment >> recordClassAdditionFromClass: aRGClass traits: traitsString slots: slotsString sharedVariables: sharedVariablesString [
+FmxMBRealRingEnvironment >> recordClassAdditionFromClass: aRGClass traits: traitsString slots: slotsString sharedVariables: sharedVariablesString category: aString [
 
 	changesToApply add: (FmxClassAddition creationCode: ('Smalltalk classInstaller
 	make: [ :builder |
@@ -71,7 +72,7 @@ FmxMBRealRingEnvironment >> recordClassAdditionFromClass: aRGClass traits: trait
 						   (#traits -> (traitsString ifNil: [ aRGClass traitCompositionString ])).
 						   (#slots -> (slotsString ifNil: [ aRGClass slotDefinitionString ])).
 						   (#classVariables -> (sharedVariablesString ifNil: [ '{}' ])).
-						   (#category -> aRGClass category printString) })))
+						   (#category -> (aString ifNil: [ aRGClass category ]) printString) })))
 ]
 
 { #category : #installing }
@@ -80,7 +81,7 @@ FmxMBRealRingEnvironment >> recordClassChangesFor: anRGClass [
 	| realClass |
 	realClass := self class environment classNamed: anRGClass name.
 	realClass
-		ifNil: [ self recordClassAdditionFromClass: anRGClass  traits: nil  slots: nil sharedVariables: nil  ]
+		ifNil: [ self recordClassAdditionFromClass: anRGClass  traits: nil  slots: nil sharedVariables: nil category: nil  ]
 		ifNotNil: [ self recordAdoptionOfClassDefinitionFrom: realClass to: anRGClass ].
 	self recordClassCommentChangeOf: realClass to: anRGClass.
 	self recordMethodsAdoptionsOf: realClass to: anRGClass realClassName: anRGClass name.

--- a/src/Famix-MetamodelBuilder-Core/FmxMBRealRingEnvironment.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxMBRealRingEnvironment.class.st
@@ -55,6 +55,7 @@ FmxMBRealRingEnvironment >> recordAdoptionOfClassDefinitionFrom: realClass to: a
 { #category : #installing }
 FmxMBRealRingEnvironment >> recordClassAdditionFromClass: aRGClass traits: traitsString slots: slotsString sharedVariables: sharedVariablesString category: aString [
 
+	self flag: #todo. "We will need to remove the use of categories to use packages and tags. I'm just not sure if it is easy to manage this with the ShiftClassBuilder of P11. Maybe we should wait for P12 to be the minimal pharo used or add some comaptibility methods. LEt's see later."
 	changesToApply add: (FmxClassAddition creationCode: ('Smalltalk classInstaller
 	make: [ :builder |
 		builder 
@@ -69,23 +70,29 @@ FmxMBRealRingEnvironment >> recordClassAdditionFromClass: aRGClass traits: trait
 							     ifTrue: [ 'beTrait' ]
 							     ifFalse: [ 'superclass: ' , aRGClass superclass name ])).
 						   (#className -> aRGClass name asSymbol printString).
-						   (#traits -> (traitsString ifNil: [ aRGClass traitCompositionString ])).
-						   (#slots -> (slotsString ifNil: [ aRGClass slotDefinitionString ])).
-						   (#classVariables -> (sharedVariablesString ifNil: [ '{}' ])).
-						   (#category -> (aString ifNil: [ aRGClass category ]) printString) })))
+						   (#traits -> traitsString).
+						   (#slots -> slotsString).
+						   (#classVariables -> sharedVariablesString).
+						   (#category -> aString printString) })))
 ]
 
 { #category : #installing }
-FmxMBRealRingEnvironment >> recordClassChangesFor: anRGClass [
+FmxMBRealRingEnvironment >> recordClassChangesFor: aRGClass [
 
 	| realClass |
-	realClass := self class environment classNamed: anRGClass name.
+	realClass := self class environment classNamed: aRGClass name.
 	realClass
-		ifNil: [ self recordClassAdditionFromClass: anRGClass  traits: nil  slots: nil sharedVariables: nil category: nil  ]
-		ifNotNil: [ self recordAdoptionOfClassDefinitionFrom: realClass to: anRGClass ].
-	self recordClassCommentChangeOf: realClass to: anRGClass.
-	self recordMethodsAdoptionsOf: realClass to: anRGClass realClassName: anRGClass name.
-	self recordMethodsAdoptionsOf: (realClass ifNotNil: #class) to: anRGClass classSide realClassName: anRGClass name
+		ifNil: [
+			self
+				recordClassAdditionFromClass: aRGClass
+				traits: aRGClass traitCompositionString
+				slots: aRGClass slotDefinitionString
+				sharedVariables: '{}'
+				category: aRGClass category ]
+		ifNotNil: [ self recordAdoptionOfClassDefinitionFrom: realClass to: aRGClass ].
+	self recordClassCommentChangeOf: realClass to: aRGClass.
+	self recordMethodsAdoptionsOf: realClass to: aRGClass realClassName: aRGClass name.
+	self recordMethodsAdoptionsOf: (realClass ifNotNil: [ realClass class ]) to: aRGClass classSide realClassName: aRGClass name
 ]
 
 { #category : #installing }

--- a/src/Famix-MetamodelBuilder-Core/FmxMBRealRingEnvironment.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxMBRealRingEnvironment.class.st
@@ -42,47 +42,48 @@ FmxMBRealRingEnvironment >> compile: aSource in: aClass classified: aProtocol pa
 FmxMBRealRingEnvironment >> recordAdoptionOfClassDefinitionFrom: realClass to: anRGClass [
 
 	| customSlots customSlotNames slotDefinitions slotsString definition traitsString |
-
 	(realClass needToAdaptTo: anRGClass) ifFalse: [ ^ self ].
 
-	customSlots := realClass localSlots copyWithoutAll:
-		               realClass generatedSlots.
+	customSlots := realClass localSlots copyWithoutAll: realClass generatedSlots.
 	customSlotNames := customSlots collect: #name.
-	slotDefinitions := ((anRGClass slots reject: [ :each | 
-		                     customSlotNames includes: each name ]) 
-		                    collect: #definitionString) asOrderedCollection.
+	slotDefinitions := ((anRGClass slots reject: [ :each | customSlotNames includes: each name ]) collect: #definitionString) asOrderedCollection.
 	slotDefinitions addAll: (customSlots collect: #definitionString).
 	slotDefinitions := slotDefinitions sorted.
 
 	slotsString := '{' , (slotDefinitions joinUsing: '. ') , '}'.
 	traitsString := self traitStringFrom: realClass to: anRGClass.
 	definition := anRGClass isTrait
-		              ifFalse: [ 
-			              '{superclass} subclass: #{className} 
-		uses: {traits} 
-		slots: {slots} 
-		classVariables: {classVariables}
-		poolDictionaries: ''{poolDictionaries}''
-		category: ''{category}''' format: (Dictionary newFrom: { 
+		              ifFalse: [
+			              'Smalltalk classInstaller
+	make: [ :builder |
+		builder 
+			superclass: {superclass};
+			name: {className};
+			traits: {traits};
+			slots: {slots};
+			sharedVariables: {classVariables};
+			category: {category}
+		 ]' format: (Dictionary newFrom: {
 						               (#superclass -> anRGClass superclass name).
-						               (#className -> anRGClass name).
-						               (#layout -> realClass classLayout class name).
+						               (#className -> anRGClass name asSymbol printString).
 						               (#traits -> traitsString).
 						               (#slots -> slotsString).
-						               (#classVariables
-						                -> (self classVariablesStringFor: realClass)).
-						               (#poolDictionaries -> realClass sharedPoolsString).
-						               (#category -> realClass category) }) ]
-		              ifTrue: [ 
-			              '{superclass} named: #{className} 
-		uses: {traits} 
-		slots: {slots} 
-		category: ''{category}''' format: (Dictionary newFrom: { 
-						               (#superclass -> anRGClass superclass name).
-						               (#className -> anRGClass name).
+						               (#classVariables -> (self classVariablesStringFor: realClass)).
+						               (#category -> realClass category printString) }) ]
+		              ifTrue: [
+			              'Smalltalk classInstaller
+	make: [ :builder |
+		builder 
+			beTrait;
+			name: {className};
+			traits: {traits};
+			slots: {slots};
+			category: {category}
+		 ]' format: (Dictionary newFrom: {
+						               (#className -> anRGClass name asSymbol printString).
 						               (#traits -> traitsString).
 						               (#slots -> slotsString).
-						               (#category -> realClass category) }) ].
+						               (#category -> realClass category printString) }) ].
 
 	changesToApply add: (FmxClassAddition definition: definition)
 ]

--- a/src/Famix-MetamodelBuilder-Core/FmxMBRealRingEnvironment.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxMBRealRingEnvironment.class.st
@@ -13,12 +13,6 @@ FmxMBRealRingEnvironment >> apply [
 	changesToApply do: #apply
 ]
 
-{ #category : #installing }
-FmxMBRealRingEnvironment >> classVariablesStringFor: realClass [
-
-	^ '{', ((realClass classVarNames collect: [ :each | '#', each ]) joinUsing: ' '), '}'
-]
-
 { #category : #accessing }
 FmxMBRealRingEnvironment >> collectChangesToApply [
 	| resolvedClasses resolvedPackages |
@@ -52,38 +46,24 @@ FmxMBRealRingEnvironment >> recordAdoptionOfClassDefinitionFrom: realClass to: a
 
 	slotsString := '{' , (slotDefinitions joinUsing: '. ') , '}'.
 	traitsString := self traitStringFrom: realClass to: anRGClass.
-	definition := anRGClass isTrait
-		              ifFalse: [
-			              'Smalltalk classInstaller
+	definition := 'Smalltalk classInstaller
 	make: [ :builder |
 		builder 
-			superclass: {superclass};
+			{superclassOrTraitDeclaration};
 			name: {className};
 			traits: {traits};
 			slots: {slots};
 			sharedVariables: {classVariables};
 			category: {category}
 		 ]' format: (Dictionary newFrom: {
-						               (#superclass -> anRGClass superclass name).
-						               (#className -> anRGClass name asSymbol printString).
-						               (#traits -> traitsString).
-						               (#slots -> slotsString).
-						               (#classVariables -> (self classVariablesStringFor: realClass)).
-						               (#category -> realClass category printString) }) ]
-		              ifTrue: [
-			              'Smalltalk classInstaller
-	make: [ :builder |
-		builder 
-			beTrait;
-			name: {className};
-			traits: {traits};
-			slots: {slots};
-			category: {category}
-		 ]' format: (Dictionary newFrom: {
-						               (#className -> anRGClass name asSymbol printString).
-						               (#traits -> traitsString).
-						               (#slots -> slotsString).
-						               (#category -> realClass category printString) }) ].
+				               (#superclassOrTraitDeclaration -> (anRGClass isTrait
+					                 ifTrue: [ 'beTrait' ]
+					                 ifFalse: [ 'superclass: ' , anRGClass superclass name ])).
+				               (#className -> anRGClass name asSymbol printString).
+				               (#traits -> traitsString).
+				               (#slots -> slotsString).
+				               (#classVariables -> ('{' , ((realClass classVarNames collect: [ :each | '#' , each ]) joinUsing: ' ') , '}')).
+				               (#category -> realClass category printString) }).
 
 	changesToApply add: (FmxClassAddition definition: definition)
 ]

--- a/src/Famix-MetamodelBuilder-Tests/FmxMBGeneratorCleaningStrategyTest.class.st
+++ b/src/Famix-MetamodelBuilder-Tests/FmxMBGeneratorCleaningStrategyTest.class.st
@@ -120,8 +120,11 @@ FmxMBGeneratorCleaningStrategyTest >> setUp [
 
 { #category : #running }
 FmxMBGeneratorCleaningStrategyTest >> tearDown [
-	[ self packageName asPackage removeFromSystem ] on: NotFound  do: [ ].
-	super tearDown.
+
+	[ self packageName asPackage removeFromSystem ]
+		on: NotFound
+		do: [  ].
+	super tearDown
 ]
 
 { #category : #tests }


### PR DESCRIPTION
This change uses the ShiftClassBuilder to install or update classes instead of the old class definition.

It also factorize the code between installation and update of existing class in order to avoid to have two mechanisms. 

I hope this will help unify P12 and P11

I tried also to use #update:to: instead of #make: in order to update real classes but I have some really really weird bugs :(
This would help use keep the class trait composition, the shared pools and other infos. 

Maybe I could also try #fillFor: but I think Marcus is removing it from P12