### PR TITLE
Fix #testReferenceBindingReified in P12

### DIFF
--- a/src/Moose-SmalltalkImporter-Core-Tests/FamixReferenceModelImporterTest.class.st
+++ b/src/Moose-SmalltalkImporter-Core-Tests/FamixReferenceModelImporterTest.class.st
@@ -636,7 +636,7 @@ FamixReferenceModelImporterTest >> testReadAndWrite [
 { #category : #tests }
 FamixReferenceModelImporterTest >> testReferenceBindingReified [
 	| famixClass |
-	famixClass := self model entityNamed: TestRunner class mooseName.
+	famixClass := self model entityNamed: TestCase class mooseName.
 	self assert: famixClass isNotNil
 ]
 


### PR DESCRIPTION
FamixReferenceModelImporterTest>>#testReferenceBindingReified is breaking in P12 because TestRunner was removed from this Pharo version. 

This change the test to use another class that is present in all covered versions of Moose