### PR TITLE
Fix regeneration of methods

### DIFF
--- a/src/Famix-MetamodelBuilder-Core/ClassDescription.extension.st
+++ b/src/Famix-MetamodelBuilder-Core/ClassDescription.extension.st
@@ -2,8 +2,9 @@ Extension { #name : #ClassDescription }
 
 { #category : #'*Famix-MetamodelBuilder-Core' }
 ClassDescription >> needToAdaptToMethod: aRGMethod [
+
 	^ self
-		compiledMethodAt: aRGMethod selector
-		ifPresent: [ :realMethod | (aRGMethod sourceCode = realMethod sourceCode and: [ aRGMethod protocol = realMethod protocol ]) not ]
-		ifAbsent: [ true ]
+		  compiledMethodAt: aRGMethod selector
+		  ifPresent: [ :realMethod | (aRGMethod sourceCode = realMethod sourceCode and: [ aRGMethod protocol = realMethod protocolName ]) not ]
+		  ifAbsent: [ true ]
 ]


### PR DESCRIPTION
The metamodel builder was always considering that manually defined methods in the builder were to be regenerated in P12 because it was comparing a protocol to a protocol name. 

This fixes it