### PR TITLE
Fix #600.

### DIFF
--- a/src/Famix-PharoSmalltalk-Entities/FamixStClass.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStClass.class.st
@@ -25,6 +25,16 @@ FamixStClass >> accessedAttributes [
 	^ self methodsWithoutSutbsAndConstructors asOrderedCollection flatCollect: [ :method | method accessedAttributes ]
 ]
 
+{ #category : #testing }
+FamixStClass >> addMethodOverriding: aMethod in: aCollection [
+
+	self directSubclasses do: [ :subClass |
+		subClass methods
+			detect: [ :method | method signature = aMethod signature ]
+			ifFound: [ :overridingMethod | aCollection add: overridingMethod ]
+			ifNone: [ subClass addMethodOverriding: aMethod in: aCollection ] ]
+]
+
 { #category : #accessing }
 FamixStClass >> classSide [
 	^ self isClassSide

--- a/src/Famix-PharoSmalltalk-Entities/FamixStMethod.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStMethod.class.st
@@ -237,6 +237,23 @@ FamixStMethod >> numberOfStatements [
 		computedAs: [ self computeNumberOfStatements ]
 ]
 
+{ #category : #protocol }
+FamixStMethod >> overriddenMethod [
+"currently does not take into account traits"
+	^ (self parentType superclass ifNotNil: [ :superclass |
+		   superclass lookUp: self signature ]) 
+]
+
+{ #category : #testing }
+FamixStMethod >> overridingMethods [
+
+	| overridingMethods |
+	overridingMethods := OrderedCollection new.
+
+	self parentType addMethodOverriding: self in: overridingMethods.
+	^ overridingMethods
+]
+
 { #category : #'Famix-Extensions-metrics-support' }
 FamixStMethod >> printProtocol [
 

--- a/src/Famix-PharoSmalltalk-Tests/FamixPharoMethodTest.class.st
+++ b/src/Famix-PharoSmalltalk-Tests/FamixPharoMethodTest.class.st
@@ -1,8 +1,23 @@
 Class {
 	#name : #FamixPharoMethodTest,
 	#superclass : #TestCase,
+	#instVars : [
+		'method',
+		'signature'
+	],
 	#category : #'Famix-PharoSmalltalk-Tests'
 }
+
+{ #category : #running }
+FamixPharoMethodTest >> setUp [
+
+	super setUp.
+
+	"Put here a common initialization logic for tests"
+	method := FamixStMethod new.
+	signature := 'pharoMethod'.
+	method signature: signature.
+]
 
 { #category : #tests }
 FamixPharoMethodTest >> testIsClassSide [
@@ -10,4 +25,130 @@ FamixPharoMethodTest >> testIsClassSide [
 	method := FamixStMethod new.
 	method isClassSide: true.
 	self assert: method isClassSide .
+]
+
+{ #category : #tests }
+FamixPharoMethodTest >> testOverriddenMethod [
+
+	| overriddenMethod localClass superclass |
+	
+	overriddenMethod := FamixStMethod new signature: signature.
+
+	localClass := FamixStClass named: #LocalClass.
+	superclass := FamixStClass named: #Superclass.
+
+	localClass addMethod: method.
+	superclass addMethod: overriddenMethod.
+
+	FamixStInheritance new
+		superclass: superclass;
+		subclass: localClass.
+
+	self assert: method overriddenMethod equals: overriddenMethod
+]
+
+{ #category : #tests }
+FamixPharoMethodTest >> testOverriddenMethodOnlyOneLevel [
+
+	| overriddenMethod localClass superclass superSuperclass otherOverriddenMethod |
+
+	overriddenMethod := FamixStMethod new signature: signature.
+	otherOverriddenMethod := FamixStMethod new signature: signature.
+
+	localClass := FamixStClass named: #LocalClass.
+	superclass := FamixStClass named: #Superclass.
+	superSuperclass := FamixStClass named: #SuperSuperclass.
+
+	localClass addMethod: method.
+	superclass addMethod: overriddenMethod.
+	superSuperclass addMethod: otherOverriddenMethod.
+
+	FamixStInheritance new
+		superclass: superclass;
+		subclass: localClass.
+	FamixStInheritance new
+		superclass: superSuperclass;
+		subclass: superclass.
+
+	self assert: method overriddenMethod equals: overriddenMethod
+]
+
+{ #category : #tests }
+FamixPharoMethodTest >> testOverridingMethods [
+
+	| signature overridingMethod c1 c2 |
+	signature := 'pharoMethod'.
+	method signature: signature.
+	overridingMethod := FamixStMethod new signature: signature.
+
+	c1 := FamixStClass new.
+	c2 := FamixStClass new.
+
+	c1 addMethod: method.
+	c2 addMethod: overridingMethod.
+
+	FamixStInheritance new
+		superclass: c1;
+		subclass: c2.
+
+	self
+		assertCollection: method overridingMethods
+		hasSameElements: { overridingMethod }
+]
+
+{ #category : #tests }
+FamixPharoMethodTest >> testOverridingMethodsOnlyOneLevel [
+
+	| overridingMethod otherOverridingMethod localClass subclass subSubclass |
+
+	overridingMethod := FamixStMethod new signature: signature.
+	otherOverridingMethod := FamixStMethod new signature: signature.
+
+	localClass := FamixStClass new.
+	subclass := FamixStClass new.
+	subSubclass := FamixStClass new.
+
+	localClass addMethod: method.
+	subclass addMethod: overridingMethod.
+	subSubclass addMethod: otherOverridingMethod.
+
+	FamixStInheritance new
+		superclass: localClass;
+		subclass: subclass.
+	FamixStInheritance new
+		superclass: subclass;
+		subclass: subSubclass.
+
+	self
+		assertCollection: method overridingMethods
+		hasSameElements: { overridingMethod }
+]
+
+{ #category : #tests }
+FamixPharoMethodTest >> testSeveralOverridingMethods [
+
+	| signature overridingMethod otherOverridingMethod localClass subclass otherSubclass |
+	signature := 'pharoMethod'.
+	method signature: signature.
+	overridingMethod := FamixStMethod new signature: signature.
+	otherOverridingMethod := FamixStMethod new signature: signature.
+
+	localClass := FamixStClass new.
+	subclass := FamixStClass new.
+	otherSubclass := FamixStClass new.
+
+	localClass addMethod: method.
+	subclass addMethod: overridingMethod.
+	otherSubclass addMethod: otherOverridingMethod.
+
+	FamixStInheritance new
+		superclass: localClass;
+		subclass: subclass.
+	FamixStInheritance new
+		superclass: localClass;
+		subclass: otherSubclass.
+
+	self assertCollection: method overridingMethods hasSameElements: {
+			overridingMethod.
+			otherOverridingMethod }
 ]


### PR DESCRIPTION
Add methods to manage overriding and overridden methods in Pharo. Traits are not taken into account in this computation.