### PR TITLE
Introduce #isRoot boolean property

### DIFF
--- a/src/Moose-Core-Tests/MooseEntityTest.class.st
+++ b/src/Moose-Core-Tests/MooseEntityTest.class.st
@@ -31,17 +31,6 @@ MooseEntityTest >> testBookmark [
 ]
 
 { #category : #tests }
-MooseEntityTest >> testIsRoot [
-	| entity |
-	entity := self actualClass new.
-	entity stub parents willReturn: {  }.
-	self assert: entity isRoot.
-	
-	entity stub parents willReturn: { MooseEntity new }.
-	self deny: entity isRoot
-]
-
-{ #category : #tests }
 MooseEntityTest >> testIsStub [
 	self deny: self actualClass new isStub.
 	self

--- a/src/Moose-Core/MooseEntity.class.st
+++ b/src/Moose-Core/MooseEntity.class.st
@@ -185,13 +185,6 @@ MooseEntity >> isMooseEntity [
 ]
 
 { #category : #testing }
-MooseEntity >> isRoot [
-	"Return true if the entity is not contained in any other entity."
-
-	^ self parents isEmpty
-]
-
-{ #category : #testing }
 MooseEntity >> isStub [
 	^ self attributeAt: #privateIsStub ifAbsent: [ false ]
 ]

--- a/src/Moose-Query/TEntityMetaLevelDependency.trait.st
+++ b/src/Moose-Query/TEntityMetaLevelDependency.trait.st
@@ -699,6 +699,16 @@ TEntityMetaLevelDependency >> isIncludedIn: anEntity parentSelectorsCache: paren
 	^ false
 ]
 
+{ #category : #testing }
+TEntityMetaLevelDependency >> isRoot [
+
+	<FMProperty: #isRoot type: #Boolean>
+	<derived>
+	<FMComment:
+	'An entity is root if it has no parent in the model. This is useful for example to be able to build visualization where the displayed elements are the roots of the model and to let those elements be expanded to display their children.'>
+	^ self parents isEmpty
+]
+
 { #category : #accessing }
 TEntityMetaLevelDependency >> numberOfChildren [
 	<FMProperty: #numberOfChildren type: #Number>


### PR DESCRIPTION
I want to build a visualization starting with the "root" entities of a model (aka the entities without parent). To make this easy in the query browser I propose to introduce a #isRoot boolean property. 

I introduced it on TEntityMetalevelDependency since this is the trait bringing the concept of parents. While I tired to add tests I found out that we also had some root concept on MooseEntity but I think it is a bad idea to have it there because MooseEntity has no concept of parent. So I removed it.

Fixes #679