### PR TITLE
Improve logs of testGeneratorsAreUpToDate

### DIFF
--- a/src/Famix-MetamodelBuilder-Core/FamixMetamodelBuilder.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FamixMetamodelBuilder.class.st
@@ -120,6 +120,13 @@ FamixMetamodelBuilder >> behaviorsCount [
 	^ self traits size + self classes size
 ]
 
+{ #category : #generating }
+FamixMetamodelBuilder >> changesToApply [
+
+	self prepareGeneration.
+	^ self environment changesToApply
+]
+
 { #category : #initialization }
 FamixMetamodelBuilder >> classNamed: aClassName [
 
@@ -514,13 +521,6 @@ FamixMetamodelBuilder >> printOn: aStream [
 			nextPut: $(;
 			print: g class;
 			nextPut: $) ]
-]
-
-{ #category : #generating }
-FamixMetamodelBuilder >> regenerationIsNeeded [
-
-	self prepareGeneration.
-	^ self environment regenerationIsNeeded
 ]
 
 { #category : #generating }

--- a/src/Famix-MetamodelBuilder-Core/FamixMetamodelGenerator.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FamixMetamodelGenerator.class.st
@@ -219,6 +219,12 @@ FamixMetamodelGenerator >> builder: anObject [
 	builder := anObject
 ]
 
+{ #category : #testing }
+FamixMetamodelGenerator >> changesToApply [
+	self define.
+	^ self builder changesToApply
+]
+
 { #category : #accessing }
 FamixMetamodelGenerator >> cleaningStrategy [
 	^ cleaningStrategy
@@ -343,12 +349,6 @@ FamixMetamodelGenerator >> packageNameForAnnotations [
 FamixMetamodelGenerator >> prefix [
 
 	^ self class prefix
-]
-
-{ #category : #testing }
-FamixMetamodelGenerator >> regenerationIsNeeded [
-	self define.
-	^ self builder regenerationIsNeeded
 ]
 
 { #category : #definition }

--- a/src/Famix-MetamodelBuilder-Core/FmxClassRemoval.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxClassRemoval.class.st
@@ -46,3 +46,15 @@ FmxClassRemoval >> classToRemove [
 FmxClassRemoval >> classToRemove: anObject [
 	class := anObject
 ]
+
+{ #category : #printing }
+FmxClassRemoval >> printOn: aStream [
+
+	super printOn: aStream.
+	aStream
+		nextPut: $(;
+		nextPutAll: (class
+				 ifNotNil: [ class name ]
+				 ifNil: [ #unamed ]);
+		nextPut: $)
+]

--- a/src/Famix-MetamodelBuilder-Core/FmxLazyClassChange.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxLazyClassChange.class.st
@@ -54,6 +54,16 @@ FmxLazyClassChange >> isClassSide: anObject [
 	isClassSide := anObject
 ]
 
+{ #category : #printing }
+FmxLazyClassChange >> printOn: aStream [
+
+	super printOn: aStream.
+	aStream
+		nextPut: $(;
+		nextPutAll: (className ifNil: [ #unamed ]);
+		nextPut: $)
+]
+
 { #category : #accessing }
 FmxLazyClassChange >> realClass [
 	| class |

--- a/src/Famix-MetamodelBuilder-Core/FmxMBRealRingEnvironment.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxMBRealRingEnvironment.class.st
@@ -13,6 +13,14 @@ FmxMBRealRingEnvironment >> apply [
 	changesToApply do: #apply
 ]
 
+{ #category : #testing }
+FmxMBRealRingEnvironment >> changesToApply [
+	"Return the list of changes to apply if a regeneration would cause changes in the system."
+
+	self collectChangesToApply.
+	^ changesToApply
+]
+
 { #category : #accessing }
 FmxMBRealRingEnvironment >> collectChangesToApply [
 	| resolvedClasses resolvedPackages |
@@ -173,14 +181,6 @@ FmxMBRealRingEnvironment >> recordRemovalOfGeneratedEntitiesIn: resolvedPackages
 			package
 				ifNotNil:
 					[ package definedClasses select: #isMetamodelEntity thenDo: [ :class | resolvedClasses detect: [ :rgClass | rgClass name = class name ] ifNone: [ changesToApply add: (FmxClassRemoval class: class) ] ] ] ]
-]
-
-{ #category : #testing }
-FmxMBRealRingEnvironment >> regenerationIsNeeded [
-	"Return true if a regeneration would cause changes in the system."
-
-	self collectChangesToApply.
-	^ changesToApply isNotEmpty
 ]
 
 { #category : #installing }

--- a/src/Famix-MetamodelBuilder-Core/FmxPackageAddition.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxPackageAddition.class.st
@@ -46,3 +46,13 @@ FmxPackageAddition >> packageName [
 FmxPackageAddition >> packageName: aPackageName [
 	packageName := aPackageName
 ]
+
+{ #category : #printing }
+FmxPackageAddition >> printOn: aStream [
+
+	super printOn: aStream.
+	aStream
+		nextPut: $(;
+		nextPutAll: (packageName ifNil: [ #unamed ]);
+		nextPut: $)
+]

--- a/src/Famix-MetamodelBuilder-Tests/FmxMBGeneratorTest.class.st
+++ b/src/Famix-MetamodelBuilder-Tests/FmxMBGeneratorTest.class.st
@@ -35,11 +35,14 @@ FmxMBGeneratorTest >> testGeneratedClassesDoNotOverrideMethodsWithGeneratedPragm
 
 { #category : #tests }
 FmxMBGeneratorTest >> testGeneratorsAreUpToDate [
-	FamixMetamodelGenerator generatorsToKeepUpToDate
-		do: [ :mm | 
-			self
-				deny: mm new regenerationIsNeeded
-				description: 'The generator ' , mm asString , ' is not in sync with its meta-model. Please, regenerate your MMs with `FamixMetamodelGenerator generateAllMetamodels.' ]
+
+	FamixMetamodelGenerator generatorsToKeepUpToDate do: [ :mm |
+		| changes |
+		changes := mm new changesToApply.
+		self assert: changes isEmpty description: [
+			'The generator ' , mm asString
+			, ' is not in sync with its meta-model. Please, regenerate your MMs with `FamixMetamodelGenerator generateAllMetamodels`. List of changes: '
+			, changes printString ] ]
 ]
 
 { #category : #tests }


### PR DESCRIPTION
testGeneratorsAreUpToDate breaks easily and sometimes it's hard to know what is not up to date. Here I'm updating this test in order to improve the display of changes and to give the list of the changes in the description of the test failure