### PR TITLE
Make generated class comments more readable

### DIFF
--- a/src/Famix-Deprecated/FamixTHasModifiers.trait.st
+++ b/src/Famix-Deprecated/FamixTHasModifiers.trait.st
@@ -2,7 +2,8 @@
 ## Properties
 ======================
 
-- Named: #modifiers Type: String Comment: Generic container for language dependent modifiers.
+| Name | Type | Comment |
+| `modifiers` | String | Generic container for language dependent modifiers.|
 
 "
 Trait {

--- a/src/Famix-Java-Entities/FamixJavaAccess.class.st
+++ b/src/Famix-Java-Entities/FamixJavaAccess.class.st
@@ -3,19 +3,26 @@
 ======================
 
 ### Association source
-- Relation: #accessor Type: #FamixTWithAccesses Opposite: #accesses Comment: Behavioural entity making the access to the variable. from-side of the association
+| Relation | Type | Opposite | Comment |
+| `accessor` | `FamixTWithAccesses` | `accesses` | Behavioural entity making the access to the variable. from-side of the association|
+
 ### Association target
-- Relation: #variable Type: #FamixTAccessible Opposite: #incomingAccesses Comment: Variable accessed. to-side of the association
+| Relation | Type | Opposite | Comment |
+| `variable` | `FamixTAccessible` | `incomingAccesses` | Variable accessed. to-side of the association|
+
 ### Other
-- Relation: #next Type: #FamixTAssociation Opposite: #previous Comment: Next association in an ordered collection of associations. Currently not supported by the Moose importer
-- Relation: #previous Type: #FamixTAssociation Opposite: #next Comment: Previous association in an ordered collection of associations. Currently not supported by the Moose importer
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
+| Relation | Type | Opposite | Comment |
+| `next` | `FamixTAssociation` | `previous` | Next association in an ordered collection of associations. Currently not supported by the Moose importer|
+| `previous` | `FamixTAssociation` | `next` | Previous association in an ordered collection of associations. Currently not supported by the Moose importer|
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
-- Named: #isWrite Type: Boolean Comment: Write access
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
+| `isWrite` | Boolean | Write access|
 
 "
 Class {

--- a/src/Famix-Java-Entities/FamixJavaAnnotationInstance.class.st
+++ b/src/Famix-Java-Entities/FamixJavaAnnotationInstance.class.st
@@ -3,10 +3,14 @@
 ======================
 
 ### Children
-- Relation: #attributes Type: #FamixTAnnotationInstanceAttribute Opposite: #parentAnnotationInstance Comment: This corresponds to the actual values of the attributes in an AnnotationInstance
+| Relation | Type | Opposite | Comment |
+| `attributes` | `FamixTAnnotationInstanceAttribute` | `parentAnnotationInstance` | This corresponds to the actual values of the attributes in an AnnotationInstance|
+
 ### Other
-- Relation: #annotatedEntity Type: #FamixTWithAnnotationInstances Opposite: #annotationInstances Comment: The NamedEntity on which the annotation occurs.
-- Relation: #annotationType Type: #FamixTAnnotationType Opposite: #instances Comment: Refers to the type of an annotation. (In some languages, Java and C#, an annotation as an explicit type). 
+| Relation | Type | Opposite | Comment |
+| `annotatedEntity` | `FamixTWithAnnotationInstances` | `annotationInstances` | The NamedEntity on which the annotation occurs.|
+| `annotationType` | `FamixTAnnotationType` | `instances` | Refers to the type of an annotation. (In some languages, Java and C#, an annotation as an explicit type). |
+
 
 
 "

--- a/src/Famix-Java-Entities/FamixJavaAnnotationInstanceAttribute.class.st
+++ b/src/Famix-Java-Entities/FamixJavaAnnotationInstanceAttribute.class.st
@@ -3,14 +3,19 @@
 ======================
 
 ### Parents
-- Relation: #parentAnnotationInstance Type: #FamixTWithAnnotationInstanceAttributes Opposite: #attributes Comment: The instance of the annotation in which the attribute is used.
+| Relation | Type | Opposite | Comment |
+| `parentAnnotationInstance` | `FamixTWithAnnotationInstanceAttributes` | `attributes` | The instance of the annotation in which the attribute is used.|
+
 ### Other
-- Relation: #annotationTypeAttribute Type: #FamixTAnnotationTypeAttribute Opposite: #annotationAttributeInstances Comment: This corresponds to the type of the attribute in an AnnotationInstance
+| Relation | Type | Opposite | Comment |
+| `annotationTypeAttribute` | `FamixTAnnotationTypeAttribute` | `annotationAttributeInstances` | This corresponds to the type of the attribute in an AnnotationInstance|
+
 
 ## Properties
 ======================
 
-- Named: #value Type: String Comment: Actual value of the attribute used in an annotation
+| Name | Type | Comment |
+| `value` | String | Actual value of the attribute used in an annotation|
 
 "
 Class {

--- a/src/Famix-Java-Entities/FamixJavaAnnotationType.class.st
+++ b/src/Famix-Java-Entities/FamixJavaAnnotationType.class.st
@@ -3,23 +3,34 @@
 ======================
 
 ### Parents
-- Relation: #annotationTypesContainer Type: #FamixTWithAnnotationTypes Opposite: #definedAnnotationTypes Comment: Container in which an AnnotationType may reside
-- Relation: #parentPackage Type: #FamixTPackage Opposite: #childEntities Comment: Package containing the entity in the code structure (if applicable)
+| Relation | Type | Opposite | Comment |
+| `annotationTypesContainer` | `FamixTWithAnnotationTypes` | `definedAnnotationTypes` | Container in which an AnnotationType may reside|
+| `parentPackage` | `FamixTPackage` | `childEntities` | Package containing the entity in the code structure (if applicable)|
+
 ### Children
-- Relation: #attributes Type: #FamixTAttribute Opposite: #parentType Comment: List of attributes declared by this type.
+| Relation | Type | Opposite | Comment |
+| `attributes` | `FamixTAttribute` | `parentType` | List of attributes declared by this type.|
+
 ### Outgoing dependencies
-- Relation: #superInheritances Type: #FamixTInheritance Opposite: #subclass Comment: Superinheritance relationships, i.e. known superclasses of this type.
+| Relation | Type | Opposite | Comment |
+| `superInheritances` | `FamixTInheritance` | `subclass` | Superinheritance relationships, i.e. known superclasses of this type.|
+
 ### Incoming dependencies
-- Relation: #implementations Type: #FamixTImplementation Opposite: #interface Comment: Implementation relationships.
-- Relation: #subInheritances Type: #FamixTInheritance Opposite: #superclass Comment: Subinheritance relationships, i.e. known subclasses of this type.
+| Relation | Type | Opposite | Comment |
+| `implementations` | `FamixTImplementation` | `interface` | Implementation relationships.|
+| `subInheritances` | `FamixTInheritance` | `superclass` | Subinheritance relationships, i.e. known subclasses of this type.|
+
 ### Other
-- Relation: #comments Type: #FamixTComment Opposite: #commentedEntity Comment: List of comments for the entity
-- Relation: #instances Type: #FamixTTypedAnnotationInstance Opposite: #annotationType Comment: Annotations of this type
+| Relation | Type | Opposite | Comment |
+| `comments` | `FamixTComment` | `commentedEntity` | List of comments for the entity|
+| `instances` | `FamixTTypedAnnotationInstance` | `annotationType` | Annotations of this type|
+
 
 ## Properties
 ======================
 
-- Named: #visibility Type: String Comment: Visibility of the entity
+| Name | Type | Comment |
+| `visibility` | String | Visibility of the entity|
 
 "
 Class {

--- a/src/Famix-Java-Entities/FamixJavaAnnotationTypeAttribute.class.st
+++ b/src/Famix-Java-Entities/FamixJavaAnnotationTypeAttribute.class.st
@@ -3,21 +3,28 @@
 ======================
 
 ### Parents
-- Relation: #parentType Type: #FamixTWithAttributes Opposite: #attributes Comment: Type declaring the attribute. belongsTo implementation
+| Relation | Type | Opposite | Comment |
+| `parentType` | `FamixTWithAttributes` | `attributes` | Type declaring the attribute. belongsTo implementation|
+
 ### Incoming dependencies
-- Relation: #incomingAccesses Type: #FamixTAccess Opposite: #variable Comment: All Famix accesses pointing to this structural entity
+| Relation | Type | Opposite | Comment |
+| `incomingAccesses` | `FamixTAccess` | `variable` | All Famix accesses pointing to this structural entity|
+
 ### Other
-- Relation: #annotationAttributeInstances Type: #FamixTTypedAnnotationInstanceAttribute Opposite: #annotationTypeAttribute Comment: A collection of AnnotationInstanceAttribute which hold the usages of this attribute in actual AnnotationInstances
-- Relation: #annotationTypeAttribute Type: #FamixTAnnotationTypeAttribute Opposite: #annotationAttributeInstances Comment: This corresponds to the type of the attribute in an AnnotationInstance
-- Relation: #comments Type: #FamixTComment Opposite: #commentedEntity Comment: List of comments for the entity
-- Relation: #declaredType Type: #FamixTType Opposite: #typedEntities Comment: Type of the entity, if any
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
+| Relation | Type | Opposite | Comment |
+| `annotationAttributeInstances` | `FamixTTypedAnnotationInstanceAttribute` | `annotationTypeAttribute` | A collection of AnnotationInstanceAttribute which hold the usages of this attribute in actual AnnotationInstances|
+| `annotationTypeAttribute` | `FamixTAnnotationTypeAttribute` | `annotationAttributeInstances` | This corresponds to the type of the attribute in an AnnotationInstance|
+| `comments` | `FamixTComment` | `commentedEntity` | List of comments for the entity|
+| `declaredType` | `FamixTType` | `typedEntities` | Type of the entity, if any|
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
-- Named: #name Type: String Comment: Basic name of the entity, not full reference.
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
+| `name` | String | Basic name of the entity, not full reference.|
 
 "
 Class {

--- a/src/Famix-Java-Entities/FamixJavaAttribute.class.st
+++ b/src/Famix-Java-Entities/FamixJavaAttribute.class.st
@@ -3,25 +3,32 @@
 ======================
 
 ### Parents
-- Relation: #parentType Type: #FamixTWithAttributes Opposite: #attributes Comment: Type declaring the attribute. belongsTo implementation
+| Relation | Type | Opposite | Comment |
+| `parentType` | `FamixTWithAttributes` | `attributes` | Type declaring the attribute. belongsTo implementation|
+
 ### Incoming dependencies
-- Relation: #incomingAccesses Type: #FamixTAccess Opposite: #variable Comment: All Famix accesses pointing to this structural entity
+| Relation | Type | Opposite | Comment |
+| `incomingAccesses` | `FamixTAccess` | `variable` | All Famix accesses pointing to this structural entity|
+
 ### Other
-- Relation: #comments Type: #FamixTComment Opposite: #commentedEntity Comment: List of comments for the entity
-- Relation: #declaredType Type: #FamixTType Opposite: #typedEntities Comment: Type of the entity, if any
-- Relation: #receivingInvocations Type: #FamixTInvocation Opposite: #receiver Comment: List of invocations performed on this entity (considered as the receiver)
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
+| Relation | Type | Opposite | Comment |
+| `comments` | `FamixTComment` | `commentedEntity` | List of comments for the entity|
+| `declaredType` | `FamixTType` | `typedEntities` | Type of the entity, if any|
+| `receivingInvocations` | `FamixTInvocation` | `receiver` | List of invocations performed on this entity (considered as the receiver)|
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+
 
 ## Properties
 ======================
 
-- Named: #isClassSide Type: Boolean Comment: Entity can be declared class side i.e. static
-- Named: #isFinal Type: Boolean Comment: Entity can be declared final
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
-- Named: #isTransient Type: Boolean Comment: Entity can be declared transient
-- Named: #isVolatile Type: Boolean Comment: Entity can be declared volatile
-- Named: #name Type: String Comment: Basic name of the entity, not full reference.
-- Named: #visibility Type: String Comment: Visibility of the entity
+| Name | Type | Comment |
+| `isClassSide` | Boolean | Entity can be declared class side i.e. static|
+| `isFinal` | Boolean | Entity can be declared final|
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
+| `isTransient` | Boolean | Entity can be declared transient|
+| `isVolatile` | Boolean | Entity can be declared volatile|
+| `name` | String | Basic name of the entity, not full reference.|
+| `visibility` | String | Visibility of the entity|
 
 "
 Class {

--- a/src/Famix-Java-Entities/FamixJavaClass.class.st
+++ b/src/Famix-Java-Entities/FamixJavaClass.class.st
@@ -3,34 +3,45 @@
 ======================
 
 ### Parents
-- Relation: #parentPackage Type: #FamixTPackage Opposite: #childEntities Comment: Package containing the entity in the code structure (if applicable)
-- Relation: #typeContainer Type: #FamixTWithTypes Opposite: #types Comment: Container entity to which this type belongs. Container is a namespace, not a package (Smalltalk).
+| Relation | Type | Opposite | Comment |
+| `parentPackage` | `FamixTPackage` | `childEntities` | Package containing the entity in the code structure (if applicable)|
+| `typeContainer` | `FamixTWithTypes` | `types` | Container entity to which this type belongs. Container is a namespace, not a package (Smalltalk).|
+
 ### Children
-- Relation: #attributes Type: #FamixTAttribute Opposite: #parentType Comment: List of attributes declared by this type.
-- Relation: #methods Type: #FamixTMethod Opposite: #parentType Comment: Methods declared by this type.
+| Relation | Type | Opposite | Comment |
+| `attributes` | `FamixTAttribute` | `parentType` | List of attributes declared by this type.|
+| `methods` | `FamixTMethod` | `parentType` | Methods declared by this type.|
+
 ### Outgoing dependencies
-- Relation: #interfaceImplementations Type: #FamixTImplementation Opposite: #implementingClass Comment: Implementation relationships
-- Relation: #outgoingImports Type: #FamixTImport Opposite: #importingEntity
-- Relation: #superInheritances Type: #FamixTInheritance Opposite: #subclass Comment: Superinheritance relationships, i.e. known superclasses of this type.
+| Relation | Type | Opposite | Comment |
+| `interfaceImplementations` | `FamixTImplementation` | `implementingClass` | Implementation relationships|
+| `outgoingImports` | `FamixTImport` | `importingEntity` | |
+| `superInheritances` | `FamixTInheritance` | `subclass` | Superinheritance relationships, i.e. known superclasses of this type.|
+
 ### Incoming dependencies
-- Relation: #incomingImports Type: #FamixTImport Opposite: #importedEntity Comment: List of imports of this entity
-- Relation: #incomingReferences Type: #FamixTReference Opposite: #referredType Comment: References to this entity by other entities.
-- Relation: #subInheritances Type: #FamixTInheritance Opposite: #superclass Comment: Subinheritance relationships, i.e. known subclasses of this type.
+| Relation | Type | Opposite | Comment |
+| `incomingImports` | `FamixTImport` | `importedEntity` | List of imports of this entity|
+| `incomingReferences` | `FamixTReference` | `referredType` | References to this entity by other entities.|
+| `subInheritances` | `FamixTInheritance` | `superclass` | Subinheritance relationships, i.e. known subclasses of this type.|
+
 ### Other
-- Relation: #comments Type: #FamixTComment Opposite: #commentedEntity Comment: List of comments for the entity
-- Relation: #receivingInvocations Type: #FamixTInvocation Opposite: #receiver Comment: List of invocations performed on this entity (considered as the receiver)
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
-- Relation: #typedEntities Type: #FamixTTypedEntity Opposite: #declaredType Comment: Entities that have this type as declaredType
+| Relation | Type | Opposite | Comment |
+| `comments` | `FamixTComment` | `commentedEntity` | List of comments for the entity|
+| `receivingInvocations` | `FamixTInvocation` | `receiver` | List of invocations performed on this entity (considered as the receiver)|
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+| `typedEntities` | `FamixTTypedEntity` | `declaredType` | Entities that have this type as declaredType|
+
 
 ## Properties
 ======================
 
-- Named: #isAbstract Type: Boolean Comment: Entity can be declared abstract
-- Named: #isClassSide Type: Boolean Comment: Entity can be declared class side i.e. static
-- Named: #isFinal Type: Boolean Comment: Entity can be declared final
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
-- Named: #name Type: String Comment: Basic name of the entity, not full reference.
-- Named: #visibility Type: String Comment: Visibility of the entity
+| Name | Type | Comment |
+| `isAbstract` | Boolean | Entity can be declared abstract|
+| `isClassSide` | Boolean | Entity can be declared class side i.e. static|
+| `isFinal` | Boolean | Entity can be declared final|
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
+| `name` | String | Basic name of the entity, not full reference.|
+| `visibility` | String | Visibility of the entity|
 
 "
 Class {

--- a/src/Famix-Java-Entities/FamixJavaComment.class.st
+++ b/src/Famix-Java-Entities/FamixJavaComment.class.st
@@ -3,12 +3,15 @@
 ======================
 
 ### Other
-- Relation: #commentedEntity Type: #FamixTWithComments Opposite: #comments Comment: Source code commented by the comment
+| Relation | Type | Opposite | Comment |
+| `commentedEntity` | `FamixTWithComments` | `comments` | Source code commented by the comment|
+
 
 ## Properties
 ======================
 
-- Named: #content Type: String Comment: Content of the comment as a String
+| Name | Type | Comment |
+| `content` | String | Content of the comment as a String|
 
 "
 Class {

--- a/src/Famix-Java-Entities/FamixJavaContainerEntity.class.st
+++ b/src/Famix-Java-Entities/FamixJavaContainerEntity.class.st
@@ -3,9 +3,11 @@
 ======================
 
 ### Children
-- Relation: #definedAnnotationTypes Type: #FamixTAnnotationType Opposite: #annotationTypesContainer Comment: The container in which the AnnotationTypes may be declared
-- Relation: #types Type: #FamixTType Opposite: #typeContainer Comment: Types contained (declared) in this entity, if any.
-#types is declared in ContainerEntity because different kinds of container can embed types. Types are usually contained in a Famix.Namespace. But types can also be contained in a Famix.Class or Famix.Method (in Java with inner classes for example). Famix.Function can also contain some types such as structs.
+| Relation | Type | Opposite | Comment |
+| `definedAnnotationTypes` | `FamixTAnnotationType` | `annotationTypesContainer` | The container in which the AnnotationTypes may be declared|
+| `types` | `FamixTType` | `typeContainer` | Types contained (declared) in this entity, if any.
+#types is declared in ContainerEntity because different kinds of container can embed types. Types are usually contained in a Famix.Namespace. But types can also be contained in a Famix.Class or Famix.Method (in Java with inner classes for example). Famix.Function can also contain some types such as structs.|
+
 
 
 "

--- a/src/Famix-Java-Entities/FamixJavaEnum.class.st
+++ b/src/Famix-Java-Entities/FamixJavaEnum.class.st
@@ -3,29 +3,40 @@
 ======================
 
 ### Parents
-- Relation: #typeContainer Type: #FamixTWithTypes Opposite: #types Comment: Container entity to which this type belongs. Container is a namespace, not a package (Smalltalk).
+| Relation | Type | Opposite | Comment |
+| `typeContainer` | `FamixTWithTypes` | `types` | Container entity to which this type belongs. Container is a namespace, not a package (Smalltalk).|
+
 ### Children
-- Relation: #attributes Type: #FamixTAttribute Opposite: #parentType Comment: List of attributes declared by this type.
-- Relation: #enumValues Type: #FamixTEnumValue Opposite: #parentEnum
-- Relation: #methods Type: #FamixTMethod Opposite: #parentType Comment: Methods declared by this type.
+| Relation | Type | Opposite | Comment |
+| `attributes` | `FamixTAttribute` | `parentType` | List of attributes declared by this type.|
+| `enumValues` | `FamixTEnumValue` | `parentEnum` | |
+| `methods` | `FamixTMethod` | `parentType` | Methods declared by this type.|
+
 ### Outgoing dependencies
-- Relation: #outgoingImports Type: #FamixTImport Opposite: #importingEntity
-- Relation: #superInheritances Type: #FamixTInheritance Opposite: #subclass Comment: Superinheritance relationships, i.e. known superclasses of this type.
+| Relation | Type | Opposite | Comment |
+| `outgoingImports` | `FamixTImport` | `importingEntity` | |
+| `superInheritances` | `FamixTInheritance` | `subclass` | Superinheritance relationships, i.e. known superclasses of this type.|
+
 ### Incoming dependencies
-- Relation: #incomingImports Type: #FamixTImport Opposite: #importedEntity Comment: List of imports of this entity
-- Relation: #incomingReferences Type: #FamixTReference Opposite: #referredType Comment: References to this entity by other entities.
-- Relation: #subInheritances Type: #FamixTInheritance Opposite: #superclass Comment: Subinheritance relationships, i.e. known subclasses of this type.
+| Relation | Type | Opposite | Comment |
+| `incomingImports` | `FamixTImport` | `importedEntity` | List of imports of this entity|
+| `incomingReferences` | `FamixTReference` | `referredType` | References to this entity by other entities.|
+| `subInheritances` | `FamixTInheritance` | `superclass` | Subinheritance relationships, i.e. known subclasses of this type.|
+
 ### Other
-- Relation: #comments Type: #FamixTComment Opposite: #commentedEntity Comment: List of comments for the entity
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
-- Relation: #typedEntities Type: #FamixTTypedEntity Opposite: #declaredType Comment: Entities that have this type as declaredType
+| Relation | Type | Opposite | Comment |
+| `comments` | `FamixTComment` | `commentedEntity` | List of comments for the entity|
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+| `typedEntities` | `FamixTTypedEntity` | `declaredType` | Entities that have this type as declaredType|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
-- Named: #name Type: String Comment: Basic name of the entity, not full reference.
-- Named: #visibility Type: String Comment: Visibility of the entity
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
+| `name` | String | Basic name of the entity, not full reference.|
+| `visibility` | String | Visibility of the entity|
 
 "
 Class {

--- a/src/Famix-Java-Entities/FamixJavaEnumValue.class.st
+++ b/src/Famix-Java-Entities/FamixJavaEnumValue.class.st
@@ -3,19 +3,26 @@
 ======================
 
 ### Parents
-- Relation: #parentEnum Type: #FamixTWithEnumValues Opposite: #enumValues Comment: The Enum declaring this value. It offers the implementation of belongsTo
+| Relation | Type | Opposite | Comment |
+| `parentEnum` | `FamixTWithEnumValues` | `enumValues` | The Enum declaring this value. It offers the implementation of belongsTo|
+
 ### Incoming dependencies
-- Relation: #incomingAccesses Type: #FamixTAccess Opposite: #variable Comment: All Famix accesses pointing to this structural entity
+| Relation | Type | Opposite | Comment |
+| `incomingAccesses` | `FamixTAccess` | `variable` | All Famix accesses pointing to this structural entity|
+
 ### Other
-- Relation: #comments Type: #FamixTComment Opposite: #commentedEntity Comment: List of comments for the entity
-- Relation: #declaredType Type: #FamixTType Opposite: #typedEntities Comment: Type of the entity, if any
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
+| Relation | Type | Opposite | Comment |
+| `comments` | `FamixTComment` | `commentedEntity` | List of comments for the entity|
+| `declaredType` | `FamixTType` | `typedEntities` | Type of the entity, if any|
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
-- Named: #name Type: String Comment: Basic name of the entity, not full reference.
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
+| `name` | String | Basic name of the entity, not full reference.|
 
 "
 Class {

--- a/src/Famix-Java-Entities/FamixJavaException.class.st
+++ b/src/Famix-Java-Entities/FamixJavaException.class.st
@@ -3,34 +3,45 @@
 ======================
 
 ### Parents
-- Relation: #typeContainer Type: #FamixTWithTypes Opposite: #types Comment: Container entity to which this type belongs. Container is a namespace, not a package (Smalltalk).
+| Relation | Type | Opposite | Comment |
+| `typeContainer` | `FamixTWithTypes` | `types` | Container entity to which this type belongs. Container is a namespace, not a package (Smalltalk).|
+
 ### Children
-- Relation: #attributes Type: #FamixTAttribute Opposite: #parentType Comment: List of attributes declared by this type.
-- Relation: #methods Type: #FamixTMethod Opposite: #parentType Comment: Methods declared by this type.
-- Relation: #types Type: #FamixTType Opposite: #typeContainer Comment: Types contained (declared) in this entity, if any.
-#types is declared in ContainerEntity because different kinds of container can embed types. Types are usually contained in a Famix.Namespace. But types can also be contained in a Famix.Class or Famix.Method (in Java with inner classes for example). Famix.Function can also contain some types such as structs.
+| Relation | Type | Opposite | Comment |
+| `attributes` | `FamixTAttribute` | `parentType` | List of attributes declared by this type.|
+| `methods` | `FamixTMethod` | `parentType` | Methods declared by this type.|
+| `types` | `FamixTType` | `typeContainer` | Types contained (declared) in this entity, if any.
+#types is declared in ContainerEntity because different kinds of container can embed types. Types are usually contained in a Famix.Namespace. But types can also be contained in a Famix.Class or Famix.Method (in Java with inner classes for example). Famix.Function can also contain some types such as structs.|
+
 ### Outgoing dependencies
-- Relation: #interfaceImplementations Type: #FamixTImplementation Opposite: #implementingClass Comment: Implementation relationships
-- Relation: #superInheritances Type: #FamixTInheritance Opposite: #subclass Comment: Superinheritance relationships, i.e. known superclasses of this type.
+| Relation | Type | Opposite | Comment |
+| `interfaceImplementations` | `FamixTImplementation` | `implementingClass` | Implementation relationships|
+| `superInheritances` | `FamixTInheritance` | `subclass` | Superinheritance relationships, i.e. known superclasses of this type.|
+
 ### Incoming dependencies
-- Relation: #incomingReferences Type: #FamixTReference Opposite: #referredType Comment: References to this entity by other entities.
-- Relation: #subInheritances Type: #FamixTInheritance Opposite: #superclass Comment: Subinheritance relationships, i.e. known subclasses of this type.
+| Relation | Type | Opposite | Comment |
+| `incomingReferences` | `FamixTReference` | `referredType` | References to this entity by other entities.|
+| `subInheritances` | `FamixTInheritance` | `superclass` | Subinheritance relationships, i.e. known subclasses of this type.|
+
 ### Other
-- Relation: #annotationInstances Type: #FamixTAnnotationInstance Opposite: #annotatedEntity Comment: This property corresponds to the set of annotations associated to the entity
-- Relation: #catchingEntities Type: #FamixTWithExceptions Opposite: #caughtExceptions
-- Relation: #comments Type: #FamixTComment Opposite: #commentedEntity Comment: List of comments for the entity
-- Relation: #declaringEntities Type: #FamixTWithExceptions Opposite: #declaredExceptions
-- Relation: #receivingInvocations Type: #FamixTInvocation Opposite: #receiver Comment: List of invocations performed on this entity (considered as the receiver)
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
-- Relation: #throwingEntities Type: #FamixTWithExceptions Opposite: #thrownExceptions
-- Relation: #typedEntities Type: #FamixTTypedEntity Opposite: #declaredType Comment: Entities that have this type as declaredType
+| Relation | Type | Opposite | Comment |
+| `annotationInstances` | `FamixTAnnotationInstance` | `annotatedEntity` | This property corresponds to the set of annotations associated to the entity|
+| `catchingEntities` | `FamixTWithExceptions` | `caughtExceptions` | |
+| `comments` | `FamixTComment` | `commentedEntity` | List of comments for the entity|
+| `declaringEntities` | `FamixTWithExceptions` | `declaredExceptions` | |
+| `receivingInvocations` | `FamixTInvocation` | `receiver` | List of invocations performed on this entity (considered as the receiver)|
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+| `throwingEntities` | `FamixTWithExceptions` | `thrownExceptions` | |
+| `typedEntities` | `FamixTTypedEntity` | `declaredType` | Entities that have this type as declaredType|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
-- Named: #name Type: String Comment: Basic name of the entity, not full reference.
-- Named: #visibility Type: String Comment: Visibility of the entity
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
+| `name` | String | Basic name of the entity, not full reference.|
+| `visibility` | String | Visibility of the entity|
 
 "
 Class {

--- a/src/Famix-Java-Entities/FamixJavaImplementation.class.st
+++ b/src/Famix-Java-Entities/FamixJavaImplementation.class.st
@@ -3,18 +3,25 @@
 ======================
 
 ### Association source
-- Relation: #implementingClass Type: #FamixTCanImplement Opposite: #interfaceImplementations Comment: Class linked to in this relationship. from-side of the association
+| Relation | Type | Opposite | Comment |
+| `implementingClass` | `FamixTCanImplement` | `interfaceImplementations` | Class linked to in this relationship. from-side of the association|
+
 ### Association target
-- Relation: #interface Type: #FamixTImplementable Opposite: #implementations Comment: Interface linked to in this relationship. to-side of the association
+| Relation | Type | Opposite | Comment |
+| `interface` | `FamixTImplementable` | `implementations` | Interface linked to in this relationship. to-side of the association|
+
 ### Other
-- Relation: #next Type: #FamixTAssociation Opposite: #previous Comment: Next association in an ordered collection of associations. Currently not supported by the Moose importer
-- Relation: #previous Type: #FamixTAssociation Opposite: #next Comment: Previous association in an ordered collection of associations. Currently not supported by the Moose importer
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
+| Relation | Type | Opposite | Comment |
+| `next` | `FamixTAssociation` | `previous` | Next association in an ordered collection of associations. Currently not supported by the Moose importer|
+| `previous` | `FamixTAssociation` | `next` | Previous association in an ordered collection of associations. Currently not supported by the Moose importer|
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
 
 "
 Class {

--- a/src/Famix-Java-Entities/FamixJavaImplicitVariable.class.st
+++ b/src/Famix-Java-Entities/FamixJavaImplicitVariable.class.st
@@ -3,19 +3,26 @@
 ======================
 
 ### Parents
-- Relation: #parentBehaviouralEntity Type: #FamixTWithImplicitVariables Opposite: #implicitVariables Comment: The behaviour containing this implicit variable. belongsTo implementation
+| Relation | Type | Opposite | Comment |
+| `parentBehaviouralEntity` | `FamixTWithImplicitVariables` | `implicitVariables` | The behaviour containing this implicit variable. belongsTo implementation|
+
 ### Incoming dependencies
-- Relation: #incomingAccesses Type: #FamixTAccess Opposite: #variable Comment: All Famix accesses pointing to this structural entity
+| Relation | Type | Opposite | Comment |
+| `incomingAccesses` | `FamixTAccess` | `variable` | All Famix accesses pointing to this structural entity|
+
 ### Other
-- Relation: #declaredType Type: #FamixTType Opposite: #typedEntities Comment: Type of the entity, if any
-- Relation: #receivingInvocations Type: #FamixTInvocation Opposite: #receiver Comment: List of invocations performed on this entity (considered as the receiver)
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
+| Relation | Type | Opposite | Comment |
+| `declaredType` | `FamixTType` | `typedEntities` | Type of the entity, if any|
+| `receivingInvocations` | `FamixTInvocation` | `receiver` | List of invocations performed on this entity (considered as the receiver)|
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
-- Named: #name Type: String Comment: Basic name of the entity, not full reference.
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
+| `name` | String | Basic name of the entity, not full reference.|
 
 "
 Class {

--- a/src/Famix-Java-Entities/FamixJavaImport.class.st
+++ b/src/Famix-Java-Entities/FamixJavaImport.class.st
@@ -3,18 +3,25 @@
 ======================
 
 ### Association source
-- Relation: #importingEntity Type: #FamixTWithImports Opposite: #outgoingImports Comment: Importing entity
+| Relation | Type | Opposite | Comment |
+| `importingEntity` | `FamixTWithImports` | `outgoingImports` | Importing entity|
+
 ### Association target
-- Relation: #importedEntity Type: #FamixTImportable Opposite: #incomingImports Comment: Imported entity
+| Relation | Type | Opposite | Comment |
+| `importedEntity` | `FamixTImportable` | `incomingImports` | Imported entity|
+
 ### Other
-- Relation: #next Type: #FamixTAssociation Opposite: #previous Comment: Next association in an ordered collection of associations. Currently not supported by the Moose importer
-- Relation: #previous Type: #FamixTAssociation Opposite: #next Comment: Previous association in an ordered collection of associations. Currently not supported by the Moose importer
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
+| Relation | Type | Opposite | Comment |
+| `next` | `FamixTAssociation` | `previous` | Next association in an ordered collection of associations. Currently not supported by the Moose importer|
+| `previous` | `FamixTAssociation` | `next` | Previous association in an ordered collection of associations. Currently not supported by the Moose importer|
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
 
 "
 Class {

--- a/src/Famix-Java-Entities/FamixJavaIndexedFileAnchor.class.st
+++ b/src/Famix-Java-Entities/FamixJavaIndexedFileAnchor.class.st
@@ -2,11 +2,12 @@
 ## Properties
 ======================
 
-- Named: #correspondingFile Type: FamixTFile Comment: File associated to this source anchor
-- Named: #encoding Type: String Comment: A string representing the encoding of a file
-- Named: #endPos Type: Number Comment: Stop position in the source
-- Named: #fileName Type: String Comment: Name of the source file
-- Named: #startPos Type: Number Comment: Start position in the source
+| Name | Type | Comment |
+| `correspondingFile` | FamixTFile | File associated to this source anchor|
+| `encoding` | String | A string representing the encoding of a file|
+| `endPos` | Number | Stop position in the source|
+| `fileName` | String | Name of the source file|
+| `startPos` | Number | Start position in the source|
 
 "
 Class {

--- a/src/Famix-Java-Entities/FamixJavaInheritance.class.st
+++ b/src/Famix-Java-Entities/FamixJavaInheritance.class.st
@@ -3,18 +3,25 @@
 ======================
 
 ### Association source
-- Relation: #subclass Type: #FamixTWithInheritances Opposite: #superInheritances Comment: Subclass linked to in this relationship. from-side of the association
+| Relation | Type | Opposite | Comment |
+| `subclass` | `FamixTWithInheritances` | `superInheritances` | Subclass linked to in this relationship. from-side of the association|
+
 ### Association target
-- Relation: #superclass Type: #FamixTWithInheritances Opposite: #subInheritances Comment: Superclass linked to in this relationship. to-side of the association
+| Relation | Type | Opposite | Comment |
+| `superclass` | `FamixTWithInheritances` | `subInheritances` | Superclass linked to in this relationship. to-side of the association|
+
 ### Other
-- Relation: #next Type: #FamixTAssociation Opposite: #previous Comment: Next association in an ordered collection of associations. Currently not supported by the Moose importer
-- Relation: #previous Type: #FamixTAssociation Opposite: #next Comment: Previous association in an ordered collection of associations. Currently not supported by the Moose importer
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
+| Relation | Type | Opposite | Comment |
+| `next` | `FamixTAssociation` | `previous` | Next association in an ordered collection of associations. Currently not supported by the Moose importer|
+| `previous` | `FamixTAssociation` | `next` | Previous association in an ordered collection of associations. Currently not supported by the Moose importer|
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
 
 "
 Class {

--- a/src/Famix-Java-Entities/FamixJavaInterface.class.st
+++ b/src/Famix-Java-Entities/FamixJavaInterface.class.st
@@ -3,27 +3,38 @@
 ======================
 
 ### Parents
-- Relation: #parentPackage Type: #FamixTPackage Opposite: #childEntities Comment: Package containing the entity in the code structure (if applicable)
+| Relation | Type | Opposite | Comment |
+| `parentPackage` | `FamixTPackage` | `childEntities` | Package containing the entity in the code structure (if applicable)|
+
 ### Children
-- Relation: #attributes Type: #FamixTAttribute Opposite: #parentType Comment: List of attributes declared by this type.
-- Relation: #methods Type: #FamixTMethod Opposite: #parentType Comment: Methods declared by this type.
+| Relation | Type | Opposite | Comment |
+| `attributes` | `FamixTAttribute` | `parentType` | List of attributes declared by this type.|
+| `methods` | `FamixTMethod` | `parentType` | Methods declared by this type.|
+
 ### Outgoing dependencies
-- Relation: #outgoingImports Type: #FamixTImport Opposite: #importingEntity
-- Relation: #superInheritances Type: #FamixTInheritance Opposite: #subclass Comment: Superinheritance relationships, i.e. known superclasses of this type.
+| Relation | Type | Opposite | Comment |
+| `outgoingImports` | `FamixTImport` | `importingEntity` | |
+| `superInheritances` | `FamixTInheritance` | `subclass` | Superinheritance relationships, i.e. known superclasses of this type.|
+
 ### Incoming dependencies
-- Relation: #implementations Type: #FamixTImplementation Opposite: #interface Comment: Implementation relationships.
-- Relation: #incomingImports Type: #FamixTImport Opposite: #importedEntity Comment: List of imports of this entity
-- Relation: #subInheritances Type: #FamixTInheritance Opposite: #superclass Comment: Subinheritance relationships, i.e. known subclasses of this type.
+| Relation | Type | Opposite | Comment |
+| `implementations` | `FamixTImplementation` | `interface` | Implementation relationships.|
+| `incomingImports` | `FamixTImport` | `importedEntity` | List of imports of this entity|
+| `subInheritances` | `FamixTInheritance` | `superclass` | Subinheritance relationships, i.e. known subclasses of this type.|
+
 ### Other
-- Relation: #comments Type: #FamixTComment Opposite: #commentedEntity Comment: List of comments for the entity
-- Relation: #receivingInvocations Type: #FamixTInvocation Opposite: #receiver Comment: List of invocations performed on this entity (considered as the receiver)
+| Relation | Type | Opposite | Comment |
+| `comments` | `FamixTComment` | `commentedEntity` | List of comments for the entity|
+| `receivingInvocations` | `FamixTInvocation` | `receiver` | List of invocations performed on this entity (considered as the receiver)|
+
 
 ## Properties
 ======================
 
-- Named: #isClassSide Type: Boolean Comment: Entity can be declared class side i.e. static
-- Named: #isFinal Type: Boolean Comment: Entity can be declared final
-- Named: #visibility Type: String Comment: Visibility of the entity
+| Name | Type | Comment |
+| `isClassSide` | Boolean | Entity can be declared class side i.e. static|
+| `isFinal` | Boolean | Entity can be declared final|
+| `visibility` | String | Visibility of the entity|
 
 "
 Class {

--- a/src/Famix-Java-Entities/FamixJavaInvocation.class.st
+++ b/src/Famix-Java-Entities/FamixJavaInvocation.class.st
@@ -3,20 +3,27 @@
 ======================
 
 ### Association source
-- Relation: #sender Type: #FamixTWithInvocations Opposite: #outgoingInvocations Comment: Behavioural entity making the call. from-side of the association
+| Relation | Type | Opposite | Comment |
+| `sender` | `FamixTWithInvocations` | `outgoingInvocations` | Behavioural entity making the call. from-side of the association|
+
 ### Association target
-- Relation: #candidates Type: #FamixTInvocable Opposite: #incomingInvocations Comment: List of candidate behavioural entities for receiving the invocation
+| Relation | Type | Opposite | Comment |
+| `candidates` | `FamixTInvocable` | `incomingInvocations` | List of candidate behavioural entities for receiving the invocation|
+
 ### Other
-- Relation: #next Type: #FamixTAssociation Opposite: #previous Comment: Next association in an ordered collection of associations. Currently not supported by the Moose importer
-- Relation: #previous Type: #FamixTAssociation Opposite: #next Comment: Previous association in an ordered collection of associations. Currently not supported by the Moose importer
-- Relation: #receiver Type: #FamixTInvocationsReceiver Opposite: #receivingInvocations Comment: Named entity (variable, class...) receiving the invocation. to-side of the association
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
+| Relation | Type | Opposite | Comment |
+| `next` | `FamixTAssociation` | `previous` | Next association in an ordered collection of associations. Currently not supported by the Moose importer|
+| `previous` | `FamixTAssociation` | `next` | Previous association in an ordered collection of associations. Currently not supported by the Moose importer|
+| `receiver` | `FamixTInvocationsReceiver` | `receivingInvocations` | Named entity (variable, class...) receiving the invocation. to-side of the association|
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
-- Named: #signature Type: String Comment: Signature of the message being sent
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
+| `signature` | String | Signature of the message being sent|
 
 "
 Class {

--- a/src/Famix-Java-Entities/FamixJavaLocalVariable.class.st
+++ b/src/Famix-Java-Entities/FamixJavaLocalVariable.class.st
@@ -3,21 +3,28 @@
 ======================
 
 ### Parents
-- Relation: #parentBehaviouralEntity Type: #FamixTWithLocalVariables Opposite: #localVariables Comment: Behavioural entity declaring this local variable. belongsTo implementation
+| Relation | Type | Opposite | Comment |
+| `parentBehaviouralEntity` | `FamixTWithLocalVariables` | `localVariables` | Behavioural entity declaring this local variable. belongsTo implementation|
+
 ### Incoming dependencies
-- Relation: #incomingAccesses Type: #FamixTAccess Opposite: #variable Comment: All Famix accesses pointing to this structural entity
+| Relation | Type | Opposite | Comment |
+| `incomingAccesses` | `FamixTAccess` | `variable` | All Famix accesses pointing to this structural entity|
+
 ### Other
-- Relation: #comments Type: #FamixTComment Opposite: #commentedEntity Comment: List of comments for the entity
-- Relation: #declaredType Type: #FamixTType Opposite: #typedEntities Comment: Type of the entity, if any
-- Relation: #receivingInvocations Type: #FamixTInvocation Opposite: #receiver Comment: List of invocations performed on this entity (considered as the receiver)
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
+| Relation | Type | Opposite | Comment |
+| `comments` | `FamixTComment` | `commentedEntity` | List of comments for the entity|
+| `declaredType` | `FamixTType` | `typedEntities` | Type of the entity, if any|
+| `receivingInvocations` | `FamixTInvocation` | `receiver` | List of invocations performed on this entity (considered as the receiver)|
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+
 
 ## Properties
 ======================
 
-- Named: #isFinal Type: Boolean Comment: Entity can be declared final
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
-- Named: #name Type: String Comment: Basic name of the entity, not full reference.
+| Name | Type | Comment |
+| `isFinal` | Boolean | Entity can be declared final|
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
+| `name` | String | Basic name of the entity, not full reference.|
 
 "
 Class {

--- a/src/Famix-Java-Entities/FamixJavaMethod.class.st
+++ b/src/Famix-Java-Entities/FamixJavaMethod.class.st
@@ -3,38 +3,49 @@
 ======================
 
 ### Parents
-- Relation: #parentType Type: #FamixTWithMethods Opposite: #methods Comment: Type declaring the method. It provides the implementation for belongsTo.
+| Relation | Type | Opposite | Comment |
+| `parentType` | `FamixTWithMethods` | `methods` | Type declaring the method. It provides the implementation for belongsTo.|
+
 ### Children
-- Relation: #implicitVariables Type: #FamixTImplicitVariable Opposite: #parentBehaviouralEntity Comment: Implicit variables used locally by this behaviour.
-- Relation: #localVariables Type: #FamixTLocalVariable Opposite: #parentBehaviouralEntity Comment: Variables locally defined by this behaviour.
-- Relation: #parameters Type: #FamixTParameter Opposite: #parentBehaviouralEntity Comment: List of formal parameters declared by this behaviour.
+| Relation | Type | Opposite | Comment |
+| `implicitVariables` | `FamixTImplicitVariable` | `parentBehaviouralEntity` | Implicit variables used locally by this behaviour.|
+| `localVariables` | `FamixTLocalVariable` | `parentBehaviouralEntity` | Variables locally defined by this behaviour.|
+| `parameters` | `FamixTParameter` | `parentBehaviouralEntity` | List of formal parameters declared by this behaviour.|
+
 ### Outgoing dependencies
-- Relation: #accesses Type: #FamixTAccess Opposite: #accessor Comment: Accesses to variables made by this behaviour.
-- Relation: #outgoingInvocations Type: #FamixTInvocation Opposite: #sender Comment: Outgoing invocations sent by this behaviour.
-- Relation: #outgoingReferences Type: #FamixTReference Opposite: #referencer Comment: References from this entity to other entities.
+| Relation | Type | Opposite | Comment |
+| `accesses` | `FamixTAccess` | `accessor` | Accesses to variables made by this behaviour.|
+| `outgoingInvocations` | `FamixTInvocation` | `sender` | Outgoing invocations sent by this behaviour.|
+| `outgoingReferences` | `FamixTReference` | `referencer` | References from this entity to other entities.|
+
 ### Incoming dependencies
-- Relation: #incomingImports Type: #FamixTImport Opposite: #importedEntity Comment: List of imports of this entity
-- Relation: #incomingInvocations Type: #FamixTInvocation Opposite: #candidates Comment: Incoming invocations from other behaviours computed by the candidate operator.
+| Relation | Type | Opposite | Comment |
+| `incomingImports` | `FamixTImport` | `importedEntity` | List of imports of this entity|
+| `incomingInvocations` | `FamixTInvocation` | `candidates` | Incoming invocations from other behaviours computed by the candidate operator.|
+
 ### Other
-- Relation: #caughtExceptions Type: #FamixTException Opposite: #catchingEntities Comment: The exceptions caught by the method
-- Relation: #comments Type: #FamixTComment Opposite: #commentedEntity Comment: List of comments for the entity
-- Relation: #declaredExceptions Type: #FamixTException Opposite: #declaringEntities Comment: The exceptions declared by the method
-- Relation: #declaredType Type: #FamixTType Opposite: #typedEntities Comment: Type of the entity, if any
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
-- Relation: #thrownExceptions Type: #FamixTException Opposite: #throwingEntities Comment: The exceptions thrown by the method
+| Relation | Type | Opposite | Comment |
+| `caughtExceptions` | `FamixTException` | `catchingEntities` | The exceptions caught by the method|
+| `comments` | `FamixTComment` | `commentedEntity` | List of comments for the entity|
+| `declaredExceptions` | `FamixTException` | `declaringEntities` | The exceptions declared by the method|
+| `declaredType` | `FamixTType` | `typedEntities` | Type of the entity, if any|
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+| `thrownExceptions` | `FamixTException` | `throwingEntities` | The exceptions thrown by the method|
+
 
 ## Properties
 ======================
 
-- Named: #isAbstract Type: Boolean Comment: Entity can be declared abstract
-- Named: #isClassSide Type: Boolean Comment: Entity can be declared class side i.e. static
-- Named: #isFinal Type: Boolean Comment: Entity can be declared final
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
-- Named: #isSynchronized Type: Boolean Comment: Entity can be declared synchronized
-- Named: #kind Type: String Comment: Tag indicating a setter, getter, constant, constructor method
-- Named: #name Type: String Comment: Basic name of the entity, not full reference.
-- Named: #signature Type: String Comment: Signature of the message being sent
-- Named: #visibility Type: String Comment: Visibility of the entity
+| Name | Type | Comment |
+| `isAbstract` | Boolean | Entity can be declared abstract|
+| `isClassSide` | Boolean | Entity can be declared class side i.e. static|
+| `isFinal` | Boolean | Entity can be declared final|
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
+| `isSynchronized` | Boolean | Entity can be declared synchronized|
+| `kind` | String | Tag indicating a setter, getter, constant, constructor method|
+| `name` | String | Basic name of the entity, not full reference.|
+| `signature` | String | Signature of the message being sent|
+| `visibility` | String | Visibility of the entity|
 
 "
 Class {

--- a/src/Famix-Java-Entities/FamixJavaNamedEntity.class.st
+++ b/src/Famix-Java-Entities/FamixJavaNamedEntity.class.st
@@ -3,13 +3,16 @@
 ======================
 
 ### Other
-- Relation: #annotationInstances Type: #FamixTAnnotationInstance Opposite: #annotatedEntity Comment: This property corresponds to the set of annotations associated to the entity
-- Relation: #receivingInvocations Type: #FamixTInvocation Opposite: #receiver Comment: List of invocations performed on this entity (considered as the receiver)
+| Relation | Type | Opposite | Comment |
+| `annotationInstances` | `FamixTAnnotationInstance` | `annotatedEntity` | This property corresponds to the set of annotations associated to the entity|
+| `receivingInvocations` | `FamixTInvocation` | `receiver` | List of invocations performed on this entity (considered as the receiver)|
+
 
 ## Properties
 ======================
 
-- Named: #name Type: String Comment: Basic name of the entity, not full reference.
+| Name | Type | Comment |
+| `name` | String | Basic name of the entity, not full reference.|
 
 "
 Class {

--- a/src/Famix-Java-Entities/FamixJavaPackage.class.st
+++ b/src/Famix-Java-Entities/FamixJavaPackage.class.st
@@ -3,20 +3,29 @@
 ======================
 
 ### Parents
-- Relation: #parentPackage Type: #FamixTPackage Opposite: #childEntities Comment: Package containing the entity in the code structure (if applicable)
+| Relation | Type | Opposite | Comment |
+| `parentPackage` | `FamixTPackage` | `childEntities` | Package containing the entity in the code structure (if applicable)|
+
 ### Children
-- Relation: #childEntities Type: #FamixTPackageable Opposite: #parentPackage
+| Relation | Type | Opposite | Comment |
+| `childEntities` | `FamixTPackageable` | `parentPackage` | |
+
 ### Incoming dependencies
-- Relation: #incomingImports Type: #FamixTImport Opposite: #importedEntity Comment: List of imports of this entity
+| Relation | Type | Opposite | Comment |
+| `incomingImports` | `FamixTImport` | `importedEntity` | List of imports of this entity|
+
 ### Other
-- Relation: #comments Type: #FamixTComment Opposite: #commentedEntity Comment: List of comments for the entity
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
+| Relation | Type | Opposite | Comment |
+| `comments` | `FamixTComment` | `commentedEntity` | List of comments for the entity|
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
-- Named: #name Type: String Comment: Basic name of the entity, not full reference.
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
+| `name` | String | Basic name of the entity, not full reference.|
 
 "
 Class {

--- a/src/Famix-Java-Entities/FamixJavaParameter.class.st
+++ b/src/Famix-Java-Entities/FamixJavaParameter.class.st
@@ -3,20 +3,27 @@
 ======================
 
 ### Parents
-- Relation: #parentBehaviouralEntity Type: #FamixTWithParameters Opposite: #parameters Comment: Behavioural entity containing this parameter. belongsTo implementation
+| Relation | Type | Opposite | Comment |
+| `parentBehaviouralEntity` | `FamixTWithParameters` | `parameters` | Behavioural entity containing this parameter. belongsTo implementation|
+
 ### Incoming dependencies
-- Relation: #incomingAccesses Type: #FamixTAccess Opposite: #variable Comment: All Famix accesses pointing to this structural entity
+| Relation | Type | Opposite | Comment |
+| `incomingAccesses` | `FamixTAccess` | `variable` | All Famix accesses pointing to this structural entity|
+
 ### Other
-- Relation: #comments Type: #FamixTComment Opposite: #commentedEntity Comment: List of comments for the entity
-- Relation: #declaredType Type: #FamixTType Opposite: #typedEntities Comment: Type of the entity, if any
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
+| Relation | Type | Opposite | Comment |
+| `comments` | `FamixTComment` | `commentedEntity` | List of comments for the entity|
+| `declaredType` | `FamixTType` | `typedEntities` | Type of the entity, if any|
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+
 
 ## Properties
 ======================
 
-- Named: #isFinal Type: Boolean Comment: Entity can be declared final
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
-- Named: #name Type: String Comment: Basic name of the entity, not full reference.
+| Name | Type | Comment |
+| `isFinal` | Boolean | Entity can be declared final|
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
+| `name` | String | Basic name of the entity, not full reference.|
 
 "
 Class {

--- a/src/Famix-Java-Entities/FamixJavaParameterizableClass.class.st
+++ b/src/Famix-Java-Entities/FamixJavaParameterizableClass.class.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Other
-- Relation: #parameterizedTypes Type: #FamixTParameterizedType Opposite: #parameterizableClass
+| Relation | Type | Opposite | Comment |
+| `parameterizedTypes` | `FamixTParameterizedType` | `parameterizableClass` | |
+
 
 
 "

--- a/src/Famix-Java-Entities/FamixJavaParameterizableException.class.st
+++ b/src/Famix-Java-Entities/FamixJavaParameterizableException.class.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Other
-- Relation: #parameterizedTypes Type: #FamixTParameterizedType Opposite: #parameterizableClass
+| Relation | Type | Opposite | Comment |
+| `parameterizedTypes` | `FamixTParameterizedType` | `parameterizableClass` | |
+
 
 
 "

--- a/src/Famix-Java-Entities/FamixJavaParameterizableInterface.class.st
+++ b/src/Famix-Java-Entities/FamixJavaParameterizableInterface.class.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Other
-- Relation: #parameterizedTypes Type: #FamixTParameterizedType Opposite: #parameterizableClass
+| Relation | Type | Opposite | Comment |
+| `parameterizedTypes` | `FamixTParameterizedType` | `parameterizableClass` | |
+
 
 
 "

--- a/src/Famix-Java-Entities/FamixJavaParameterizedType.class.st
+++ b/src/Famix-Java-Entities/FamixJavaParameterizedType.class.st
@@ -3,14 +3,20 @@
 ======================
 
 ### Outgoing dependencies
-- Relation: #interfaceImplementations Type: #FamixTImplementation Opposite: #implementingClass Comment: Implementation relationships
-- Relation: #superInheritances Type: #FamixTInheritance Opposite: #subclass Comment: Superinheritance relationships, i.e. known superclasses of this type.
+| Relation | Type | Opposite | Comment |
+| `interfaceImplementations` | `FamixTImplementation` | `implementingClass` | Implementation relationships|
+| `superInheritances` | `FamixTInheritance` | `subclass` | Superinheritance relationships, i.e. known superclasses of this type.|
+
 ### Incoming dependencies
-- Relation: #implementations Type: #FamixTImplementation Opposite: #interface Comment: Implementation relationships.
-- Relation: #subInheritances Type: #FamixTInheritance Opposite: #superclass Comment: Subinheritance relationships, i.e. known subclasses of this type.
+| Relation | Type | Opposite | Comment |
+| `implementations` | `FamixTImplementation` | `interface` | Implementation relationships.|
+| `subInheritances` | `FamixTInheritance` | `superclass` | Subinheritance relationships, i.e. known subclasses of this type.|
+
 ### Other
-- Relation: #arguments Type: #FamixTParameterizedTypeUser Opposite: #argumentsInParameterizedTypes
-- Relation: #parameterizableClass Type: #FamixTWithParameterizedTypes Opposite: #parameterizedTypes Comment: Base type of this parameterized type.
+| Relation | Type | Opposite | Comment |
+| `arguments` | `FamixTParameterizedTypeUser` | `argumentsInParameterizedTypes` | |
+| `parameterizableClass` | `FamixTWithParameterizedTypes` | `parameterizedTypes` | Base type of this parameterized type.|
+
 
 
 "

--- a/src/Famix-Java-Entities/FamixJavaPrimitiveType.class.st
+++ b/src/Famix-Java-Entities/FamixJavaPrimitiveType.class.st
@@ -3,18 +3,25 @@
 ======================
 
 ### Parents
-- Relation: #typeContainer Type: #FamixTWithTypes Opposite: #types Comment: Container entity to which this type belongs. Container is a namespace, not a package (Smalltalk).
+| Relation | Type | Opposite | Comment |
+| `typeContainer` | `FamixTWithTypes` | `types` | Container entity to which this type belongs. Container is a namespace, not a package (Smalltalk).|
+
 ### Incoming dependencies
-- Relation: #incomingReferences Type: #FamixTReference Opposite: #referredType Comment: References to this entity by other entities.
+| Relation | Type | Opposite | Comment |
+| `incomingReferences` | `FamixTReference` | `referredType` | References to this entity by other entities.|
+
 ### Other
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
-- Relation: #typedEntities Type: #FamixTTypedEntity Opposite: #declaredType Comment: Entities that have this type as declaredType
+| Relation | Type | Opposite | Comment |
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+| `typedEntities` | `FamixTTypedEntity` | `declaredType` | Entities that have this type as declaredType|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
-- Named: #name Type: String Comment: Basic name of the entity, not full reference.
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
+| `name` | String | Basic name of the entity, not full reference.|
 
 "
 Class {

--- a/src/Famix-Java-Entities/FamixJavaReference.class.st
+++ b/src/Famix-Java-Entities/FamixJavaReference.class.st
@@ -3,18 +3,25 @@
 ======================
 
 ### Association source
-- Relation: #referencer Type: #FamixTWithReferences Opposite: #outgoingReferences Comment: Source entity making the reference. from-side of the association
+| Relation | Type | Opposite | Comment |
+| `referencer` | `FamixTWithReferences` | `outgoingReferences` | Source entity making the reference. from-side of the association|
+
 ### Association target
-- Relation: #referredType Type: #FamixTReferenceable Opposite: #incomingReferences Comment: Target entity referenced. to-side of the association
+| Relation | Type | Opposite | Comment |
+| `referredType` | `FamixTReferenceable` | `incomingReferences` | Target entity referenced. to-side of the association|
+
 ### Other
-- Relation: #next Type: #FamixTAssociation Opposite: #previous Comment: Next association in an ordered collection of associations. Currently not supported by the Moose importer
-- Relation: #previous Type: #FamixTAssociation Opposite: #next Comment: Previous association in an ordered collection of associations. Currently not supported by the Moose importer
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
+| Relation | Type | Opposite | Comment |
+| `next` | `FamixTAssociation` | `previous` | Next association in an ordered collection of associations. Currently not supported by the Moose importer|
+| `previous` | `FamixTAssociation` | `next` | Previous association in an ordered collection of associations. Currently not supported by the Moose importer|
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
 
 "
 Class {

--- a/src/Famix-Java-Entities/FamixJavaSourceAnchor.class.st
+++ b/src/Famix-Java-Entities/FamixJavaSourceAnchor.class.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Other
-- Relation: #element Type: #FamixTSourceEntity Opposite: #sourceAnchor Comment: Enable the accessibility to the famix entity that this class is a source pointer for
+| Relation | Type | Opposite | Comment |
+| `element` | `FamixTSourceEntity` | `sourceAnchor` | Enable the accessibility to the famix entity that this class is a source pointer for|
+
 
 
 "

--- a/src/Famix-Java-Entities/FamixJavaSourceLanguage.class.st
+++ b/src/Famix-Java-Entities/FamixJavaSourceLanguage.class.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Other
-- Relation: #sourcedEntities Type: #FamixTWithSourceLanguages Opposite: #declaredSourceLanguage Comment: References to the entities saying explicitly that are written in this language.
+| Relation | Type | Opposite | Comment |
+| `sourcedEntities` | `FamixTWithSourceLanguages` | `declaredSourceLanguage` | References to the entities saying explicitly that are written in this language.|
+
 
 
 "

--- a/src/Famix-Java-Entities/FamixJavaSourceTextAnchor.class.st
+++ b/src/Famix-Java-Entities/FamixJavaSourceTextAnchor.class.st
@@ -3,12 +3,15 @@
 ======================
 
 ### Other
-- Relation: #element Type: #FamixTSourceEntity Opposite: #sourceAnchor Comment: Enable the accessibility to the famix entity that this class is a source pointer for
+| Relation | Type | Opposite | Comment |
+| `element` | `FamixTSourceEntity` | `sourceAnchor` | Enable the accessibility to the famix entity that this class is a source pointer for|
+
 
 ## Properties
 ======================
 
-- Named: #source Type: String Comment: Actual source code of the source entity
+| Name | Type | Comment |
+| `source` | String | Actual source code of the source entity|
 
 "
 Class {

--- a/src/Famix-Java-Entities/FamixJavaSourcedEntity.class.st
+++ b/src/Famix-Java-Entities/FamixJavaSourcedEntity.class.st
@@ -3,12 +3,15 @@
 ======================
 
 ### Other
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
+| Relation | Type | Opposite | Comment |
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
 
 "
 Class {

--- a/src/Famix-Java-Entities/FamixJavaTCanBeSynchronized.trait.st
+++ b/src/Famix-Java-Entities/FamixJavaTCanBeSynchronized.trait.st
@@ -15,7 +15,8 @@ public class SynchronizedCounter {
 ## Properties
 ======================
 
-- Named: #isSynchronized Type: Boolean Comment: Entity can be declared synchronized
+| Name | Type | Comment |
+| `isSynchronized` | Boolean | Entity can be declared synchronized|
 
 "
 Trait {

--- a/src/Famix-Java-Entities/FamixJavaTCanBeTransient.trait.st
+++ b/src/Famix-Java-Entities/FamixJavaTCanBeTransient.trait.st
@@ -11,7 +11,8 @@ public class Student implements Serializable{
 ## Properties
 ======================
 
-- Named: #isTransient Type: Boolean Comment: Entity can be declared transient
+| Name | Type | Comment |
+| `isTransient` | Boolean | Entity can be declared transient|
 
 "
 Trait {

--- a/src/Famix-Java-Entities/FamixJavaTCanBeVolatile.trait.st
+++ b/src/Famix-Java-Entities/FamixJavaTCanBeVolatile.trait.st
@@ -11,7 +11,8 @@ public class SharedObject {
 ## Properties
 ======================
 
-- Named: #isVolatile Type: Boolean Comment: Entity can be declared volatile
+| Name | Type | Comment |
+| `isVolatile` | Boolean | Entity can be declared volatile|
 
 "
 Trait {

--- a/src/Famix-Java-Entities/FamixJavaTWithInterfaces.trait.st
+++ b/src/Famix-Java-Entities/FamixJavaTWithInterfaces.trait.st
@@ -5,8 +5,10 @@ I can contain interfaces (Packages, Methods, Classes...)
 ======================
 
 ### Children
-- Relation: #types Type: #FamixTType Opposite: #typeContainer Comment: Types contained (declared) in this entity, if any.
-#types is declared in ContainerEntity because different kinds of container can embed types. Types are usually contained in a Famix.Namespace. But types can also be contained in a Famix.Class or Famix.Method (in Java with inner classes for example). Famix.Function can also contain some types such as structs.
+| Relation | Type | Opposite | Comment |
+| `types` | `FamixTType` | `typeContainer` | Types contained (declared) in this entity, if any.
+#types is declared in ContainerEntity because different kinds of container can embed types. Types are usually contained in a Famix.Namespace. But types can also be contained in a Famix.Class or Famix.Method (in Java with inner classes for example). Famix.Function can also contain some types such as structs.|
+
 
 
 "

--- a/src/Famix-Java-Entities/FamixJavaType.class.st
+++ b/src/Famix-Java-Entities/FamixJavaType.class.st
@@ -3,21 +3,30 @@
 ======================
 
 ### Parents
-- Relation: #typeContainer Type: #FamixTWithTypes Opposite: #types Comment: Container entity to which this type belongs. Container is a namespace, not a package (Smalltalk).
+| Relation | Type | Opposite | Comment |
+| `typeContainer` | `FamixTWithTypes` | `types` | Container entity to which this type belongs. Container is a namespace, not a package (Smalltalk).|
+
 ### Children
-- Relation: #methods Type: #FamixTMethod Opposite: #parentType Comment: Methods declared by this type.
+| Relation | Type | Opposite | Comment |
+| `methods` | `FamixTMethod` | `parentType` | Methods declared by this type.|
+
 ### Incoming dependencies
-- Relation: #incomingReferences Type: #FamixTReference Opposite: #referredType Comment: References to this entity by other entities.
+| Relation | Type | Opposite | Comment |
+| `incomingReferences` | `FamixTReference` | `referredType` | References to this entity by other entities.|
+
 ### Other
-- Relation: #argumentsInParameterizedTypes Type: #FamixTWithParameterizedTypeUsers Opposite: #arguments
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
-- Relation: #typedEntities Type: #FamixTTypedEntity Opposite: #declaredType Comment: Entities that have this type as declaredType
+| Relation | Type | Opposite | Comment |
+| `argumentsInParameterizedTypes` | `FamixTWithParameterizedTypeUsers` | `arguments` | |
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+| `typedEntities` | `FamixTTypedEntity` | `declaredType` | Entities that have this type as declaredType|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
-- Named: #name Type: String Comment: Basic name of the entity, not full reference.
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
+| `name` | String | Basic name of the entity, not full reference.|
 
 "
 Class {

--- a/src/Famix-Java-Entities/FamixJavaUnknownSourceLanguage.class.st
+++ b/src/Famix-Java-Entities/FamixJavaUnknownSourceLanguage.class.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Other
-- Relation: #sourcedEntities Type: #FamixTWithSourceLanguages Opposite: #declaredSourceLanguage Comment: References to the entities saying explicitly that are written in this language.
+| Relation | Type | Opposite | Comment |
+| `sourcedEntities` | `FamixTWithSourceLanguages` | `declaredSourceLanguage` | References to the entities saying explicitly that are written in this language.|
+
 
 
 "

--- a/src/Famix-Java-Entities/FamixJavaUnknownVariable.class.st
+++ b/src/Famix-Java-Entities/FamixJavaUnknownVariable.class.st
@@ -3,17 +3,22 @@
 ======================
 
 ### Incoming dependencies
-- Relation: #incomingAccesses Type: #FamixTAccess Opposite: #variable Comment: All Famix accesses pointing to this structural entity
+| Relation | Type | Opposite | Comment |
+| `incomingAccesses` | `FamixTAccess` | `variable` | All Famix accesses pointing to this structural entity|
+
 ### Other
-- Relation: #declaredType Type: #FamixTType Opposite: #typedEntities Comment: Type of the entity, if any
-- Relation: #receivingInvocations Type: #FamixTInvocation Opposite: #receiver Comment: List of invocations performed on this entity (considered as the receiver)
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
+| Relation | Type | Opposite | Comment |
+| `declaredType` | `FamixTType` | `typedEntities` | Type of the entity, if any|
+| `receivingInvocations` | `FamixTInvocation` | `receiver` | List of invocations performed on this entity (considered as the receiver)|
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
-- Named: #name Type: String Comment: Basic name of the entity, not full reference.
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
+| `name` | String | Basic name of the entity, not full reference.|
 
 "
 Class {

--- a/src/Famix-MetamodelBuilder-Core/FmxMBBehavior.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxMBBehavior.class.st
@@ -146,26 +146,26 @@ FmxMBBehavior >> commentWithRelations [
 							  aStream
 								  nextPutAll: '### ';
 								  nextPutAll: relationKind;
+								  cr;
+								  nextPutAll: '| Relation | Type | Opposite | Comment |';
 								  cr.
-
 							  (parents sorted: [ :parent | parent side generationStrategy relationSide name ] ascending) do: [ :parent |
 								  | strategy |
 								  strategy := parent side generationStrategy.
 
 								  aStream
-									  nextPutAll: '- Relation: #';
+									  nextPutAll: '| `';
 									  nextPutAll: strategy relationSide name;
-									  nextPutAll: ' Type: #';
+									  nextPutAll: '` | `';
 									  nextPutAll: strategy relationSide oppositeType;
-									  nextPutAll: ' Opposite: #';
-									  nextPutAll: strategy relationSide oppositeName.
+									  nextPutAll: '` | `';
+									  nextPutAll: strategy relationSide oppositeName;
+									  nextPutAll: '` | ';
+									  nextPutAll: strategy relationSide comment;
+									  nextPut: $|;
+									  cr ].
 
-								  strategy relationSide comment ifNotEmpty: [ :com |
-									  aStream
-										  nextPutAll: ' Comment: ';
-										  nextPutAll: com ].
-
-								  aStream cr ] ] ].
+							  aStream cr ] ].
 			  aStream cr ].
 
 		  (self allProperties reject: [ :p | p isRelation ]) ifNotEmpty: [ :props |
@@ -173,20 +173,20 @@ FmxMBBehavior >> commentWithRelations [
 				  nextPutAll: '## Properties
 ======================';
 				  cr;
+				  cr;
+				  nextPutAll: '| Name | Type | Comment |';
 				  cr.
 
 			  (props sorted: #name ascending) do: [ :property |
 				  aStream
-					  nextPutAll: '- Named: #';
+					  nextPutAll: '| `';
 					  nextPutAll: property name;
-					  nextPutAll: ' Type: ';
-					  nextPutAll: property propertyType.
-
-				  property comment ifNotEmpty: [ :com |
-					  aStream
-						  nextPutAll: ' Comment: ';
-						  nextPutAll: com ].
-				  aStream cr ] ] ]
+					  nextPutAll: '` | ';
+					  nextPutAll: property propertyType;
+					  nextPutAll: ' | ';
+					  nextPutAll: property comment;
+					  nextPut: $|;
+					  cr ] ] ]
 ]
 
 { #category : #'settings - default' }

--- a/src/Famix-PharoSmalltalk-Entities/FamixStAccess.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStAccess.class.st
@@ -3,19 +3,26 @@
 ======================
 
 ### Association source
-- Relation: #accessor Type: #FamixTWithAccesses Opposite: #accesses Comment: Behavioural entity making the access to the variable. from-side of the association
+| Relation | Type | Opposite | Comment |
+| `accessor` | `FamixTWithAccesses` | `accesses` | Behavioural entity making the access to the variable. from-side of the association|
+
 ### Association target
-- Relation: #variable Type: #FamixTAccessible Opposite: #incomingAccesses Comment: Variable accessed. to-side of the association
+| Relation | Type | Opposite | Comment |
+| `variable` | `FamixTAccessible` | `incomingAccesses` | Variable accessed. to-side of the association|
+
 ### Other
-- Relation: #next Type: #FamixTAssociation Opposite: #previous Comment: Next association in an ordered collection of associations. Currently not supported by the Moose importer
-- Relation: #previous Type: #FamixTAssociation Opposite: #next Comment: Previous association in an ordered collection of associations. Currently not supported by the Moose importer
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
+| Relation | Type | Opposite | Comment |
+| `next` | `FamixTAssociation` | `previous` | Next association in an ordered collection of associations. Currently not supported by the Moose importer|
+| `previous` | `FamixTAssociation` | `next` | Previous association in an ordered collection of associations. Currently not supported by the Moose importer|
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
-- Named: #isWrite Type: Boolean Comment: Write access
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
+| `isWrite` | Boolean | Write access|
 
 "
 Class {

--- a/src/Famix-PharoSmalltalk-Entities/FamixStAnnotationInstance.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStAnnotationInstance.class.st
@@ -3,10 +3,14 @@
 ======================
 
 ### Children
-- Relation: #attributes Type: #FamixTAnnotationInstanceAttribute Opposite: #parentAnnotationInstance Comment: This corresponds to the actual values of the attributes in an AnnotationInstance
+| Relation | Type | Opposite | Comment |
+| `attributes` | `FamixTAnnotationInstanceAttribute` | `parentAnnotationInstance` | This corresponds to the actual values of the attributes in an AnnotationInstance|
+
 ### Other
-- Relation: #annotatedEntity Type: #FamixTWithAnnotationInstances Opposite: #annotationInstances Comment: The NamedEntity on which the annotation occurs.
-- Relation: #annotationType Type: #FamixTAnnotationType Opposite: #instances Comment: Refers to the type of an annotation. (In some languages, Java and C#, an annotation as an explicit type). 
+| Relation | Type | Opposite | Comment |
+| `annotatedEntity` | `FamixTWithAnnotationInstances` | `annotationInstances` | The NamedEntity on which the annotation occurs.|
+| `annotationType` | `FamixTAnnotationType` | `instances` | Refers to the type of an annotation. (In some languages, Java and C#, an annotation as an explicit type). |
+
 
 
 "

--- a/src/Famix-PharoSmalltalk-Entities/FamixStAnnotationInstanceAttribute.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStAnnotationInstanceAttribute.class.st
@@ -3,14 +3,19 @@
 ======================
 
 ### Parents
-- Relation: #parentAnnotationInstance Type: #FamixTWithAnnotationInstanceAttributes Opposite: #attributes Comment: The instance of the annotation in which the attribute is used.
+| Relation | Type | Opposite | Comment |
+| `parentAnnotationInstance` | `FamixTWithAnnotationInstanceAttributes` | `attributes` | The instance of the annotation in which the attribute is used.|
+
 ### Other
-- Relation: #annotationTypeAttribute Type: #FamixTAnnotationTypeAttribute Opposite: #annotationAttributeInstances Comment: This corresponds to the type of the attribute in an AnnotationInstance
+| Relation | Type | Opposite | Comment |
+| `annotationTypeAttribute` | `FamixTAnnotationTypeAttribute` | `annotationAttributeInstances` | This corresponds to the type of the attribute in an AnnotationInstance|
+
 
 ## Properties
 ======================
 
-- Named: #value Type: String Comment: Actual value of the attribute used in an annotation
+| Name | Type | Comment |
+| `value` | String | Actual value of the attribute used in an annotation|
 
 "
 Class {

--- a/src/Famix-PharoSmalltalk-Entities/FamixStAnnotationType.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStAnnotationType.class.st
@@ -3,12 +3,18 @@
 ======================
 
 ### Parents
-- Relation: #annotationTypesContainer Type: #FamixTWithAnnotationTypes Opposite: #definedAnnotationTypes Comment: Container in which an AnnotationType may reside
-- Relation: #parentPackage Type: #FamixTPackage Opposite: #childEntities Comment: Package containing the entity in the code structure (if applicable)
+| Relation | Type | Opposite | Comment |
+| `annotationTypesContainer` | `FamixTWithAnnotationTypes` | `definedAnnotationTypes` | Container in which an AnnotationType may reside|
+| `parentPackage` | `FamixTPackage` | `childEntities` | Package containing the entity in the code structure (if applicable)|
+
 ### Children
-- Relation: #attributes Type: #FamixTAttribute Opposite: #parentType Comment: List of attributes declared by this type.
+| Relation | Type | Opposite | Comment |
+| `attributes` | `FamixTAttribute` | `parentType` | List of attributes declared by this type.|
+
 ### Other
-- Relation: #instances Type: #FamixTTypedAnnotationInstance Opposite: #annotationType Comment: Annotations of this type
+| Relation | Type | Opposite | Comment |
+| `instances` | `FamixTTypedAnnotationInstance` | `annotationType` | Annotations of this type|
+
 
 
 "

--- a/src/Famix-PharoSmalltalk-Entities/FamixStAnnotationTypeAttribute.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStAnnotationTypeAttribute.class.st
@@ -3,20 +3,27 @@
 ======================
 
 ### Parents
-- Relation: #parentType Type: #FamixTWithAttributes Opposite: #attributes Comment: Type declaring the attribute. belongsTo implementation
+| Relation | Type | Opposite | Comment |
+| `parentType` | `FamixTWithAttributes` | `attributes` | Type declaring the attribute. belongsTo implementation|
+
 ### Incoming dependencies
-- Relation: #incomingAccesses Type: #FamixTAccess Opposite: #variable Comment: All Famix accesses pointing to this structural entity
+| Relation | Type | Opposite | Comment |
+| `incomingAccesses` | `FamixTAccess` | `variable` | All Famix accesses pointing to this structural entity|
+
 ### Other
-- Relation: #annotationAttributeInstances Type: #FamixTTypedAnnotationInstanceAttribute Opposite: #annotationTypeAttribute Comment: A collection of AnnotationInstanceAttribute which hold the usages of this attribute in actual AnnotationInstances
-- Relation: #annotationTypeAttribute Type: #FamixTAnnotationTypeAttribute Opposite: #annotationAttributeInstances Comment: This corresponds to the type of the attribute in an AnnotationInstance
-- Relation: #declaredType Type: #FamixTType Opposite: #typedEntities Comment: Type of the entity, if any
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
+| Relation | Type | Opposite | Comment |
+| `annotationAttributeInstances` | `FamixTTypedAnnotationInstanceAttribute` | `annotationTypeAttribute` | A collection of AnnotationInstanceAttribute which hold the usages of this attribute in actual AnnotationInstances|
+| `annotationTypeAttribute` | `FamixTAnnotationTypeAttribute` | `annotationAttributeInstances` | This corresponds to the type of the attribute in an AnnotationInstance|
+| `declaredType` | `FamixTType` | `typedEntities` | Type of the entity, if any|
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
-- Named: #name Type: String Comment: Basic name of the entity, not full reference.
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
+| `name` | String | Basic name of the entity, not full reference.|
 
 "
 Class {

--- a/src/Famix-PharoSmalltalk-Entities/FamixStAttribute.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStAttribute.class.st
@@ -3,20 +3,27 @@
 ======================
 
 ### Parents
-- Relation: #parentType Type: #FamixTWithAttributes Opposite: #attributes Comment: Type declaring the attribute. belongsTo implementation
+| Relation | Type | Opposite | Comment |
+| `parentType` | `FamixTWithAttributes` | `attributes` | Type declaring the attribute. belongsTo implementation|
+
 ### Incoming dependencies
-- Relation: #incomingAccesses Type: #FamixTAccess Opposite: #variable Comment: All Famix accesses pointing to this structural entity
+| Relation | Type | Opposite | Comment |
+| `incomingAccesses` | `FamixTAccess` | `variable` | All Famix accesses pointing to this structural entity|
+
 ### Other
-- Relation: #declaredType Type: #FamixTType Opposite: #typedEntities Comment: Type of the entity, if any
-- Relation: #receivingInvocations Type: #FamixTInvocation Opposite: #receiver Comment: List of invocations performed on this entity (considered as the receiver)
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
+| Relation | Type | Opposite | Comment |
+| `declaredType` | `FamixTType` | `typedEntities` | Type of the entity, if any|
+| `receivingInvocations` | `FamixTInvocation` | `receiver` | List of invocations performed on this entity (considered as the receiver)|
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+
 
 ## Properties
 ======================
 
-- Named: #isClassSide Type: Boolean Comment: Entity can be declared class side i.e. static
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
-- Named: #name Type: String Comment: Basic name of the entity, not full reference.
+| Name | Type | Comment |
+| `isClassSide` | Boolean | Entity can be declared class side i.e. static|
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
+| `name` | String | Basic name of the entity, not full reference.|
 
 "
 Class {

--- a/src/Famix-PharoSmalltalk-Entities/FamixStClass.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStClass.class.st
@@ -3,28 +3,39 @@
 ======================
 
 ### Parents
-- Relation: #parentPackage Type: #FamixTPackage Opposite: #childEntities Comment: Package containing the entity in the code structure (if applicable)
-- Relation: #typeContainer Type: #FamixTWithTypes Opposite: #types Comment: Container entity to which this type belongs. Container is a namespace, not a package (Smalltalk).
+| Relation | Type | Opposite | Comment |
+| `parentPackage` | `FamixTPackage` | `childEntities` | Package containing the entity in the code structure (if applicable)|
+| `typeContainer` | `FamixTWithTypes` | `types` | Container entity to which this type belongs. Container is a namespace, not a package (Smalltalk).|
+
 ### Children
-- Relation: #attributes Type: #FamixTAttribute Opposite: #parentType Comment: List of attributes declared by this type.
-- Relation: #methods Type: #FamixTMethod Opposite: #parentType Comment: Methods declared by this type.
+| Relation | Type | Opposite | Comment |
+| `attributes` | `FamixTAttribute` | `parentType` | List of attributes declared by this type.|
+| `methods` | `FamixTMethod` | `parentType` | Methods declared by this type.|
+
 ### Outgoing dependencies
-- Relation: #superInheritances Type: #FamixTInheritance Opposite: #subclass Comment: Superinheritance relationships, i.e. known superclasses of this type.
+| Relation | Type | Opposite | Comment |
+| `superInheritances` | `FamixTInheritance` | `subclass` | Superinheritance relationships, i.e. known superclasses of this type.|
+
 ### Incoming dependencies
-- Relation: #incomingReferences Type: #FamixTReference Opposite: #referredType Comment: References to this entity by other entities.
-- Relation: #subInheritances Type: #FamixTInheritance Opposite: #superclass Comment: Subinheritance relationships, i.e. known subclasses of this type.
+| Relation | Type | Opposite | Comment |
+| `incomingReferences` | `FamixTReference` | `referredType` | References to this entity by other entities.|
+| `subInheritances` | `FamixTInheritance` | `superclass` | Subinheritance relationships, i.e. known subclasses of this type.|
+
 ### Other
-- Relation: #comments Type: #FamixTComment Opposite: #commentedEntity Comment: List of comments for the entity
-- Relation: #receivingInvocations Type: #FamixTInvocation Opposite: #receiver Comment: List of invocations performed on this entity (considered as the receiver)
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
-- Relation: #typedEntities Type: #FamixTTypedEntity Opposite: #declaredType Comment: Entities that have this type as declaredType
+| Relation | Type | Opposite | Comment |
+| `comments` | `FamixTComment` | `commentedEntity` | List of comments for the entity|
+| `receivingInvocations` | `FamixTInvocation` | `receiver` | List of invocations performed on this entity (considered as the receiver)|
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+| `typedEntities` | `FamixTTypedEntity` | `declaredType` | Entities that have this type as declaredType|
+
 
 ## Properties
 ======================
 
-- Named: #isAbstract Type: Boolean Comment: Entity can be declared abstract
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
-- Named: #name Type: String Comment: Basic name of the entity, not full reference.
+| Name | Type | Comment |
+| `isAbstract` | Boolean | Entity can be declared abstract|
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
+| `name` | String | Basic name of the entity, not full reference.|
 
 "
 Class {

--- a/src/Famix-PharoSmalltalk-Entities/FamixStComment.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStComment.class.st
@@ -3,12 +3,15 @@
 ======================
 
 ### Other
-- Relation: #commentedEntity Type: #FamixTWithComments Opposite: #comments Comment: Source code commented by the comment
+| Relation | Type | Opposite | Comment |
+| `commentedEntity` | `FamixTWithComments` | `comments` | Source code commented by the comment|
+
 
 ## Properties
 ======================
 
-- Named: #content Type: String Comment: Content of the comment as a String
+| Name | Type | Comment |
+| `content` | String | Content of the comment as a String|
 
 "
 Class {

--- a/src/Famix-PharoSmalltalk-Entities/FamixStGlobalVariable.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStGlobalVariable.class.st
@@ -3,19 +3,26 @@
 ======================
 
 ### Parents
-- Relation: #parentScope Type: #FamixTWithGlobalVariables Opposite: #globalVariables Comment: Scope declaring the global variable. belongsTo implementation
+| Relation | Type | Opposite | Comment |
+| `parentScope` | `FamixTWithGlobalVariables` | `globalVariables` | Scope declaring the global variable. belongsTo implementation|
+
 ### Incoming dependencies
-- Relation: #incomingAccesses Type: #FamixTAccess Opposite: #variable Comment: All Famix accesses pointing to this structural entity
+| Relation | Type | Opposite | Comment |
+| `incomingAccesses` | `FamixTAccess` | `variable` | All Famix accesses pointing to this structural entity|
+
 ### Other
-- Relation: #declaredType Type: #FamixTType Opposite: #typedEntities Comment: Type of the entity, if any
-- Relation: #receivingInvocations Type: #FamixTInvocation Opposite: #receiver Comment: List of invocations performed on this entity (considered as the receiver)
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
+| Relation | Type | Opposite | Comment |
+| `declaredType` | `FamixTType` | `typedEntities` | Type of the entity, if any|
+| `receivingInvocations` | `FamixTInvocation` | `receiver` | List of invocations performed on this entity (considered as the receiver)|
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
-- Named: #name Type: String Comment: Basic name of the entity, not full reference.
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
+| `name` | String | Basic name of the entity, not full reference.|
 
 "
 Class {

--- a/src/Famix-PharoSmalltalk-Entities/FamixStImplicitVariable.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStImplicitVariable.class.st
@@ -3,19 +3,26 @@
 ======================
 
 ### Parents
-- Relation: #parentBehaviouralEntity Type: #FamixTWithImplicitVariables Opposite: #implicitVariables Comment: The behaviour containing this implicit variable. belongsTo implementation
+| Relation | Type | Opposite | Comment |
+| `parentBehaviouralEntity` | `FamixTWithImplicitVariables` | `implicitVariables` | The behaviour containing this implicit variable. belongsTo implementation|
+
 ### Incoming dependencies
-- Relation: #incomingAccesses Type: #FamixTAccess Opposite: #variable Comment: All Famix accesses pointing to this structural entity
+| Relation | Type | Opposite | Comment |
+| `incomingAccesses` | `FamixTAccess` | `variable` | All Famix accesses pointing to this structural entity|
+
 ### Other
-- Relation: #declaredType Type: #FamixTType Opposite: #typedEntities Comment: Type of the entity, if any
-- Relation: #receivingInvocations Type: #FamixTInvocation Opposite: #receiver Comment: List of invocations performed on this entity (considered as the receiver)
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
+| Relation | Type | Opposite | Comment |
+| `declaredType` | `FamixTType` | `typedEntities` | Type of the entity, if any|
+| `receivingInvocations` | `FamixTInvocation` | `receiver` | List of invocations performed on this entity (considered as the receiver)|
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
-- Named: #name Type: String Comment: Basic name of the entity, not full reference.
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
+| `name` | String | Basic name of the entity, not full reference.|
 
 "
 Class {

--- a/src/Famix-PharoSmalltalk-Entities/FamixStInheritance.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStInheritance.class.st
@@ -3,18 +3,25 @@
 ======================
 
 ### Association source
-- Relation: #subclass Type: #FamixTWithInheritances Opposite: #superInheritances Comment: Subclass linked to in this relationship. from-side of the association
+| Relation | Type | Opposite | Comment |
+| `subclass` | `FamixTWithInheritances` | `superInheritances` | Subclass linked to in this relationship. from-side of the association|
+
 ### Association target
-- Relation: #superclass Type: #FamixTWithInheritances Opposite: #subInheritances Comment: Superclass linked to in this relationship. to-side of the association
+| Relation | Type | Opposite | Comment |
+| `superclass` | `FamixTWithInheritances` | `subInheritances` | Superclass linked to in this relationship. to-side of the association|
+
 ### Other
-- Relation: #next Type: #FamixTAssociation Opposite: #previous Comment: Next association in an ordered collection of associations. Currently not supported by the Moose importer
-- Relation: #previous Type: #FamixTAssociation Opposite: #next Comment: Previous association in an ordered collection of associations. Currently not supported by the Moose importer
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
+| Relation | Type | Opposite | Comment |
+| `next` | `FamixTAssociation` | `previous` | Next association in an ordered collection of associations. Currently not supported by the Moose importer|
+| `previous` | `FamixTAssociation` | `next` | Previous association in an ordered collection of associations. Currently not supported by the Moose importer|
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
 
 "
 Class {

--- a/src/Famix-PharoSmalltalk-Entities/FamixStInvocation.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStInvocation.class.st
@@ -3,20 +3,27 @@
 ======================
 
 ### Association source
-- Relation: #sender Type: #FamixTWithInvocations Opposite: #outgoingInvocations Comment: Behavioural entity making the call. from-side of the association
+| Relation | Type | Opposite | Comment |
+| `sender` | `FamixTWithInvocations` | `outgoingInvocations` | Behavioural entity making the call. from-side of the association|
+
 ### Association target
-- Relation: #candidates Type: #FamixTInvocable Opposite: #incomingInvocations Comment: List of candidate behavioural entities for receiving the invocation
+| Relation | Type | Opposite | Comment |
+| `candidates` | `FamixTInvocable` | `incomingInvocations` | List of candidate behavioural entities for receiving the invocation|
+
 ### Other
-- Relation: #next Type: #FamixTAssociation Opposite: #previous Comment: Next association in an ordered collection of associations. Currently not supported by the Moose importer
-- Relation: #previous Type: #FamixTAssociation Opposite: #next Comment: Previous association in an ordered collection of associations. Currently not supported by the Moose importer
-- Relation: #receiver Type: #FamixTInvocationsReceiver Opposite: #receivingInvocations Comment: Named entity (variable, class...) receiving the invocation. to-side of the association
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
+| Relation | Type | Opposite | Comment |
+| `next` | `FamixTAssociation` | `previous` | Next association in an ordered collection of associations. Currently not supported by the Moose importer|
+| `previous` | `FamixTAssociation` | `next` | Previous association in an ordered collection of associations. Currently not supported by the Moose importer|
+| `receiver` | `FamixTInvocationsReceiver` | `receivingInvocations` | Named entity (variable, class...) receiving the invocation. to-side of the association|
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
-- Named: #signature Type: String Comment: Signature of the message being sent
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
+| `signature` | String | Signature of the message being sent|
 
 "
 Class {

--- a/src/Famix-PharoSmalltalk-Entities/FamixStLocalVariable.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStLocalVariable.class.st
@@ -3,19 +3,26 @@
 ======================
 
 ### Parents
-- Relation: #parentBehaviouralEntity Type: #FamixTWithLocalVariables Opposite: #localVariables Comment: Behavioural entity declaring this local variable. belongsTo implementation
+| Relation | Type | Opposite | Comment |
+| `parentBehaviouralEntity` | `FamixTWithLocalVariables` | `localVariables` | Behavioural entity declaring this local variable. belongsTo implementation|
+
 ### Incoming dependencies
-- Relation: #incomingAccesses Type: #FamixTAccess Opposite: #variable Comment: All Famix accesses pointing to this structural entity
+| Relation | Type | Opposite | Comment |
+| `incomingAccesses` | `FamixTAccess` | `variable` | All Famix accesses pointing to this structural entity|
+
 ### Other
-- Relation: #declaredType Type: #FamixTType Opposite: #typedEntities Comment: Type of the entity, if any
-- Relation: #receivingInvocations Type: #FamixTInvocation Opposite: #receiver Comment: List of invocations performed on this entity (considered as the receiver)
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
+| Relation | Type | Opposite | Comment |
+| `declaredType` | `FamixTType` | `typedEntities` | Type of the entity, if any|
+| `receivingInvocations` | `FamixTInvocation` | `receiver` | List of invocations performed on this entity (considered as the receiver)|
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
-- Named: #name Type: String Comment: Basic name of the entity, not full reference.
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
+| `name` | String | Basic name of the entity, not full reference.|
 
 "
 Class {

--- a/src/Famix-PharoSmalltalk-Entities/FamixStMethod.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStMethod.class.st
@@ -3,35 +3,46 @@
 ======================
 
 ### Parents
-- Relation: #parentPackage Type: #FamixTPackage Opposite: #childEntities Comment: Package containing the entity in the code structure (if applicable)
-- Relation: #parentType Type: #FamixTWithMethods Opposite: #methods Comment: Type declaring the method. It provides the implementation for belongsTo.
+| Relation | Type | Opposite | Comment |
+| `parentPackage` | `FamixTPackage` | `childEntities` | Package containing the entity in the code structure (if applicable)|
+| `parentType` | `FamixTWithMethods` | `methods` | Type declaring the method. It provides the implementation for belongsTo.|
+
 ### Children
-- Relation: #definedAnnotationTypes Type: #FamixTAnnotationType Opposite: #annotationTypesContainer Comment: The container in which the AnnotationTypes may be declared
-- Relation: #implicitVariables Type: #FamixTImplicitVariable Opposite: #parentBehaviouralEntity Comment: Implicit variables used locally by this behaviour.
-- Relation: #localVariables Type: #FamixTLocalVariable Opposite: #parentBehaviouralEntity Comment: Variables locally defined by this behaviour.
-- Relation: #parameters Type: #FamixTParameter Opposite: #parentBehaviouralEntity Comment: List of formal parameters declared by this behaviour.
+| Relation | Type | Opposite | Comment |
+| `definedAnnotationTypes` | `FamixTAnnotationType` | `annotationTypesContainer` | The container in which the AnnotationTypes may be declared|
+| `implicitVariables` | `FamixTImplicitVariable` | `parentBehaviouralEntity` | Implicit variables used locally by this behaviour.|
+| `localVariables` | `FamixTLocalVariable` | `parentBehaviouralEntity` | Variables locally defined by this behaviour.|
+| `parameters` | `FamixTParameter` | `parentBehaviouralEntity` | List of formal parameters declared by this behaviour.|
+
 ### Outgoing dependencies
-- Relation: #accesses Type: #FamixTAccess Opposite: #accessor Comment: Accesses to variables made by this behaviour.
-- Relation: #outgoingInvocations Type: #FamixTInvocation Opposite: #sender Comment: Outgoing invocations sent by this behaviour.
-- Relation: #outgoingReferences Type: #FamixTReference Opposite: #referencer Comment: References from this entity to other entities.
+| Relation | Type | Opposite | Comment |
+| `accesses` | `FamixTAccess` | `accessor` | Accesses to variables made by this behaviour.|
+| `outgoingInvocations` | `FamixTInvocation` | `sender` | Outgoing invocations sent by this behaviour.|
+| `outgoingReferences` | `FamixTReference` | `referencer` | References from this entity to other entities.|
+
 ### Incoming dependencies
-- Relation: #incomingInvocations Type: #FamixTInvocation Opposite: #candidates Comment: Incoming invocations from other behaviours computed by the candidate operator.
+| Relation | Type | Opposite | Comment |
+| `incomingInvocations` | `FamixTInvocation` | `candidates` | Incoming invocations from other behaviours computed by the candidate operator.|
+
 ### Other
-- Relation: #annotationInstances Type: #FamixTAnnotationInstance Opposite: #annotatedEntity Comment: This property corresponds to the set of annotations associated to the entity
-- Relation: #comments Type: #FamixTComment Opposite: #commentedEntity Comment: List of comments for the entity
-- Relation: #declaredType Type: #FamixTType Opposite: #typedEntities Comment: Type of the entity, if any
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
+| Relation | Type | Opposite | Comment |
+| `annotationInstances` | `FamixTAnnotationInstance` | `annotatedEntity` | This property corresponds to the set of annotations associated to the entity|
+| `comments` | `FamixTComment` | `commentedEntity` | List of comments for the entity|
+| `declaredType` | `FamixTType` | `typedEntities` | Type of the entity, if any|
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+
 
 ## Properties
 ======================
 
-- Named: #isAbstract Type: Boolean Comment: Entity can be declared abstract
-- Named: #isClassSide Type: Boolean Comment: Entity can be declared class side i.e. static
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
-- Named: #kind Type: String Comment: Tag indicating a setter, getter, constant, constructor method
-- Named: #name Type: String Comment: Basic name of the entity, not full reference.
-- Named: #protocol Type: String Comment: Protocol of the method
-- Named: #signature Type: String Comment: Signature of the message being sent
+| Name | Type | Comment |
+| `isAbstract` | Boolean | Entity can be declared abstract|
+| `isClassSide` | Boolean | Entity can be declared class side i.e. static|
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
+| `kind` | String | Tag indicating a setter, getter, constant, constructor method|
+| `name` | String | Basic name of the entity, not full reference.|
+| `protocol` | String | Protocol of the method|
+| `signature` | String | Signature of the message being sent|
 
 "
 Class {

--- a/src/Famix-PharoSmalltalk-Entities/FamixStNamedEntity.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStNamedEntity.class.st
@@ -3,12 +3,15 @@
 ======================
 
 ### Other
-- Relation: #receivingInvocations Type: #FamixTInvocation Opposite: #receiver Comment: List of invocations performed on this entity (considered as the receiver)
+| Relation | Type | Opposite | Comment |
+| `receivingInvocations` | `FamixTInvocation` | `receiver` | List of invocations performed on this entity (considered as the receiver)|
+
 
 ## Properties
 ======================
 
-- Named: #name Type: String Comment: Basic name of the entity, not full reference.
+| Name | Type | Comment |
+| `name` | String | Basic name of the entity, not full reference.|
 
 "
 Class {

--- a/src/Famix-PharoSmalltalk-Entities/FamixStNamespace.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStNamespace.class.st
@@ -3,18 +3,23 @@
 ======================
 
 ### Children
-- Relation: #globalVariables Type: #FamixTGlobalVariable Opposite: #parentScope Comment: Global variables defined in the scope, if any.
-- Relation: #types Type: #FamixTType Opposite: #typeContainer Comment: Types contained (declared) in this entity, if any.
-#types is declared in ContainerEntity because different kinds of container can embed types. Types are usually contained in a Famix.Namespace. But types can also be contained in a Famix.Class or Famix.Method (in Java with inner classes for example). Famix.Function can also contain some types such as structs.
+| Relation | Type | Opposite | Comment |
+| `globalVariables` | `FamixTGlobalVariable` | `parentScope` | Global variables defined in the scope, if any.|
+| `types` | `FamixTType` | `typeContainer` | Types contained (declared) in this entity, if any.
+#types is declared in ContainerEntity because different kinds of container can embed types. Types are usually contained in a Famix.Namespace. But types can also be contained in a Famix.Class or Famix.Method (in Java with inner classes for example). Famix.Function can also contain some types such as structs.|
+
 ### Other
-- Relation: #receivingInvocations Type: #FamixTInvocation Opposite: #receiver Comment: List of invocations performed on this entity (considered as the receiver)
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
+| Relation | Type | Opposite | Comment |
+| `receivingInvocations` | `FamixTInvocation` | `receiver` | List of invocations performed on this entity (considered as the receiver)|
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
-- Named: #name Type: String Comment: Basic name of the entity, not full reference.
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
+| `name` | String | Basic name of the entity, not full reference.|
 
 "
 Class {

--- a/src/Famix-PharoSmalltalk-Entities/FamixStPackage.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStPackage.class.st
@@ -3,18 +3,23 @@
 ======================
 
 ### Children
-- Relation: #childEntities Type: #FamixTPackageable Opposite: #parentPackage
-- Relation: #globalVariables Type: #FamixTGlobalVariable Opposite: #parentScope Comment: Global variables defined in the scope, if any.
-- Relation: #types Type: #FamixTType Opposite: #typeContainer Comment: Types contained (declared) in this entity, if any.
-#types is declared in ContainerEntity because different kinds of container can embed types. Types are usually contained in a Famix.Namespace. But types can also be contained in a Famix.Class or Famix.Method (in Java with inner classes for example). Famix.Function can also contain some types such as structs.
+| Relation | Type | Opposite | Comment |
+| `childEntities` | `FamixTPackageable` | `parentPackage` | |
+| `globalVariables` | `FamixTGlobalVariable` | `parentScope` | Global variables defined in the scope, if any.|
+| `types` | `FamixTType` | `typeContainer` | Types contained (declared) in this entity, if any.
+#types is declared in ContainerEntity because different kinds of container can embed types. Types are usually contained in a Famix.Namespace. But types can also be contained in a Famix.Class or Famix.Method (in Java with inner classes for example). Famix.Function can also contain some types such as structs.|
+
 ### Other
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
+| Relation | Type | Opposite | Comment |
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
-- Named: #name Type: String Comment: Basic name of the entity, not full reference.
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
+| `name` | String | Basic name of the entity, not full reference.|
 
 "
 Class {

--- a/src/Famix-PharoSmalltalk-Entities/FamixStParameter.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStParameter.class.st
@@ -3,19 +3,26 @@
 ======================
 
 ### Parents
-- Relation: #parentBehaviouralEntity Type: #FamixTWithParameters Opposite: #parameters Comment: Behavioural entity containing this parameter. belongsTo implementation
+| Relation | Type | Opposite | Comment |
+| `parentBehaviouralEntity` | `FamixTWithParameters` | `parameters` | Behavioural entity containing this parameter. belongsTo implementation|
+
 ### Incoming dependencies
-- Relation: #incomingAccesses Type: #FamixTAccess Opposite: #variable Comment: All Famix accesses pointing to this structural entity
+| Relation | Type | Opposite | Comment |
+| `incomingAccesses` | `FamixTAccess` | `variable` | All Famix accesses pointing to this structural entity|
+
 ### Other
-- Relation: #declaredType Type: #FamixTType Opposite: #typedEntities Comment: Type of the entity, if any
-- Relation: #receivingInvocations Type: #FamixTInvocation Opposite: #receiver Comment: List of invocations performed on this entity (considered as the receiver)
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
+| Relation | Type | Opposite | Comment |
+| `declaredType` | `FamixTType` | `typedEntities` | Type of the entity, if any|
+| `receivingInvocations` | `FamixTInvocation` | `receiver` | List of invocations performed on this entity (considered as the receiver)|
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
-- Named: #name Type: String Comment: Basic name of the entity, not full reference.
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
+| `name` | String | Basic name of the entity, not full reference.|
 
 "
 Class {

--- a/src/Famix-PharoSmalltalk-Entities/FamixStPharoEntitySourceAnchor.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStPharoEntitySourceAnchor.class.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Other
-- Relation: #element Type: #FamixTSourceEntity Opposite: #sourceAnchor Comment: Enable the accessibility to the famix entity that this class is a source pointer for
+| Relation | Type | Opposite | Comment |
+| `element` | `FamixTSourceEntity` | `sourceAnchor` | Enable the accessibility to the famix entity that this class is a source pointer for|
+
 
 
 "

--- a/src/Famix-PharoSmalltalk-Entities/FamixStReference.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStReference.class.st
@@ -3,18 +3,25 @@
 ======================
 
 ### Association source
-- Relation: #referencer Type: #FamixTWithReferences Opposite: #outgoingReferences Comment: Source entity making the reference. from-side of the association
+| Relation | Type | Opposite | Comment |
+| `referencer` | `FamixTWithReferences` | `outgoingReferences` | Source entity making the reference. from-side of the association|
+
 ### Association target
-- Relation: #referredType Type: #FamixTReferenceable Opposite: #incomingReferences Comment: Target entity referenced. to-side of the association
+| Relation | Type | Opposite | Comment |
+| `referredType` | `FamixTReferenceable` | `incomingReferences` | Target entity referenced. to-side of the association|
+
 ### Other
-- Relation: #next Type: #FamixTAssociation Opposite: #previous Comment: Next association in an ordered collection of associations. Currently not supported by the Moose importer
-- Relation: #previous Type: #FamixTAssociation Opposite: #next Comment: Previous association in an ordered collection of associations. Currently not supported by the Moose importer
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
+| Relation | Type | Opposite | Comment |
+| `next` | `FamixTAssociation` | `previous` | Next association in an ordered collection of associations. Currently not supported by the Moose importer|
+| `previous` | `FamixTAssociation` | `next` | Previous association in an ordered collection of associations. Currently not supported by the Moose importer|
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
 
 "
 Class {

--- a/src/Famix-PharoSmalltalk-Entities/FamixStSourceAnchor.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStSourceAnchor.class.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Other
-- Relation: #element Type: #FamixTSourceEntity Opposite: #sourceAnchor Comment: Enable the accessibility to the famix entity that this class is a source pointer for
+| Relation | Type | Opposite | Comment |
+| `element` | `FamixTSourceEntity` | `sourceAnchor` | Enable the accessibility to the famix entity that this class is a source pointer for|
+
 
 
 "

--- a/src/Famix-PharoSmalltalk-Entities/FamixStSourceLanguage.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStSourceLanguage.class.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Other
-- Relation: #sourcedEntities Type: #FamixTWithSourceLanguages Opposite: #declaredSourceLanguage Comment: References to the entities saying explicitly that are written in this language.
+| Relation | Type | Opposite | Comment |
+| `sourcedEntities` | `FamixTWithSourceLanguages` | `declaredSourceLanguage` | References to the entities saying explicitly that are written in this language.|
+
 
 
 "

--- a/src/Famix-PharoSmalltalk-Entities/FamixStSourceTextAnchor.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStSourceTextAnchor.class.st
@@ -3,12 +3,15 @@
 ======================
 
 ### Other
-- Relation: #element Type: #FamixTSourceEntity Opposite: #sourceAnchor Comment: Enable the accessibility to the famix entity that this class is a source pointer for
+| Relation | Type | Opposite | Comment |
+| `element` | `FamixTSourceEntity` | `sourceAnchor` | Enable the accessibility to the famix entity that this class is a source pointer for|
+
 
 ## Properties
 ======================
 
-- Named: #source Type: String Comment: Actual source code of the source entity
+| Name | Type | Comment |
+| `source` | String | Actual source code of the source entity|
 
 "
 Class {

--- a/src/Famix-PharoSmalltalk-Entities/FamixStSourcedEntity.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStSourcedEntity.class.st
@@ -3,12 +3,15 @@
 ======================
 
 ### Other
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
+| Relation | Type | Opposite | Comment |
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
 
 "
 Class {

--- a/src/Famix-PharoSmalltalk-Entities/FamixStUnknownSourceLanguage.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStUnknownSourceLanguage.class.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Other
-- Relation: #sourcedEntities Type: #FamixTWithSourceLanguages Opposite: #declaredSourceLanguage Comment: References to the entities saying explicitly that are written in this language.
+| Relation | Type | Opposite | Comment |
+| `sourcedEntities` | `FamixTWithSourceLanguages` | `declaredSourceLanguage` | References to the entities saying explicitly that are written in this language.|
+
 
 
 "

--- a/src/Famix-PharoSmalltalk-Entities/FamixStUnknownVariable.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStUnknownVariable.class.st
@@ -3,17 +3,22 @@
 ======================
 
 ### Incoming dependencies
-- Relation: #incomingAccesses Type: #FamixTAccess Opposite: #variable Comment: All Famix accesses pointing to this structural entity
+| Relation | Type | Opposite | Comment |
+| `incomingAccesses` | `FamixTAccess` | `variable` | All Famix accesses pointing to this structural entity|
+
 ### Other
-- Relation: #declaredType Type: #FamixTType Opposite: #typedEntities Comment: Type of the entity, if any
-- Relation: #receivingInvocations Type: #FamixTInvocation Opposite: #receiver Comment: List of invocations performed on this entity (considered as the receiver)
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
+| Relation | Type | Opposite | Comment |
+| `declaredType` | `FamixTType` | `typedEntities` | Type of the entity, if any|
+| `receivingInvocations` | `FamixTInvocation` | `receiver` | List of invocations performed on this entity (considered as the receiver)|
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
-- Named: #name Type: String Comment: Basic name of the entity, not full reference.
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
+| `name` | String | Basic name of the entity, not full reference.|
 
 "
 Class {

--- a/src/Famix-Test1-Entities/FamixTest1Association.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1Association.class.st
@@ -3,14 +3,17 @@
 ======================
 
 ### Other
-- Relation: #next Type: #FamixTAssociation Opposite: #previous Comment: Next association in an ordered collection of associations. Currently not supported by the Moose importer
-- Relation: #previous Type: #FamixTAssociation Opposite: #next Comment: Previous association in an ordered collection of associations. Currently not supported by the Moose importer
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
+| Relation | Type | Opposite | Comment |
+| `next` | `FamixTAssociation` | `previous` | Next association in an ordered collection of associations. Currently not supported by the Moose importer|
+| `previous` | `FamixTAssociation` | `next` | Previous association in an ordered collection of associations. Currently not supported by the Moose importer|
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
 
 "
 Class {

--- a/src/Famix-Test1-Entities/FamixTest1Attribute.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1Attribute.class.st
@@ -3,20 +3,27 @@
 ======================
 
 ### Parents
-- Relation: #parentType Type: #FamixTWithAttributes Opposite: #attributes Comment: Type declaring the attribute. belongsTo implementation
+| Relation | Type | Opposite | Comment |
+| `parentType` | `FamixTWithAttributes` | `attributes` | Type declaring the attribute. belongsTo implementation|
+
 ### Incoming dependencies
-- Relation: #incomingAccesses Type: #FamixTAccess Opposite: #variable Comment: All Famix accesses pointing to this structural entity
+| Relation | Type | Opposite | Comment |
+| `incomingAccesses` | `FamixTAccess` | `variable` | All Famix accesses pointing to this structural entity|
+
 ### Other
-- Relation: #declaredSourceLanguage Type: #FamixTSourceLanguage Opposite: #sourcedEntities Comment: The declared SourceLanguage for the source code of this entity
-- Relation: #declaredType Type: #FamixTType Opposite: #typedEntities Comment: Type of the entity, if any
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
+| Relation | Type | Opposite | Comment |
+| `declaredSourceLanguage` | `FamixTSourceLanguage` | `sourcedEntities` | The declared SourceLanguage for the source code of this entity|
+| `declaredType` | `FamixTType` | `typedEntities` | Type of the entity, if any|
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+
 
 ## Properties
 ======================
 
-- Named: #isClassSide Type: Boolean Comment: Entity can be declared class side i.e. static
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
-- Named: #name Type: String Comment: Basic name of the entity, not full reference.
+| Name | Type | Comment |
+| `isClassSide` | Boolean | Entity can be declared class side i.e. static|
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
+| `name` | String | Basic name of the entity, not full reference.|
 
 "
 Class {

--- a/src/Famix-Test1-Entities/FamixTest1Class.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1Class.class.st
@@ -5,28 +5,39 @@ This a comment for the Class entity
 ======================
 
 ### Parents
-- Relation: #parentPackage Type: #FamixTPackage Opposite: #childEntities Comment: Package containing the entity in the code structure (if applicable)
-- Relation: #typeContainer Type: #FamixTWithTypes Opposite: #types Comment: Container entity to which this type belongs. Container is a namespace, not a package (Smalltalk).
+| Relation | Type | Opposite | Comment |
+| `parentPackage` | `FamixTPackage` | `childEntities` | Package containing the entity in the code structure (if applicable)|
+| `typeContainer` | `FamixTWithTypes` | `types` | Container entity to which this type belongs. Container is a namespace, not a package (Smalltalk).|
+
 ### Children
-- Relation: #attributes Type: #FamixTAttribute Opposite: #parentType Comment: List of attributes declared by this type.
-- Relation: #methods Type: #FamixTMethod Opposite: #parentType Comment: Methods declared by this type.
+| Relation | Type | Opposite | Comment |
+| `attributes` | `FamixTAttribute` | `parentType` | List of attributes declared by this type.|
+| `methods` | `FamixTMethod` | `parentType` | Methods declared by this type.|
+
 ### Outgoing dependencies
-- Relation: #superInheritances Type: #FamixTInheritance Opposite: #subclass Comment: Superinheritance relationships, i.e. known superclasses of this type.
+| Relation | Type | Opposite | Comment |
+| `superInheritances` | `FamixTInheritance` | `subclass` | Superinheritance relationships, i.e. known superclasses of this type.|
+
 ### Incoming dependencies
-- Relation: #incomingReferences Type: #FamixTReference Opposite: #referredType Comment: References to this entity by other entities.
-- Relation: #subInheritances Type: #FamixTInheritance Opposite: #superclass Comment: Subinheritance relationships, i.e. known subclasses of this type.
+| Relation | Type | Opposite | Comment |
+| `incomingReferences` | `FamixTReference` | `referredType` | References to this entity by other entities.|
+| `subInheritances` | `FamixTInheritance` | `superclass` | Subinheritance relationships, i.e. known subclasses of this type.|
+
 ### Other
-- Relation: #comments Type: #FamixTComment Opposite: #commentedEntity Comment: List of comments for the entity
-- Relation: #declaredSourceLanguage Type: #FamixTSourceLanguage Opposite: #sourcedEntities Comment: The declared SourceLanguage for the source code of this entity
-- Relation: #receivingInvocations Type: #FamixTInvocation Opposite: #receiver Comment: List of invocations performed on this entity (considered as the receiver)
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
-- Relation: #typedEntities Type: #FamixTTypedEntity Opposite: #declaredType Comment: Entities that have this type as declaredType
+| Relation | Type | Opposite | Comment |
+| `comments` | `FamixTComment` | `commentedEntity` | List of comments for the entity|
+| `declaredSourceLanguage` | `FamixTSourceLanguage` | `sourcedEntities` | The declared SourceLanguage for the source code of this entity|
+| `receivingInvocations` | `FamixTInvocation` | `receiver` | List of invocations performed on this entity (considered as the receiver)|
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+| `typedEntities` | `FamixTTypedEntity` | `declaredType` | Entities that have this type as declaredType|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
-- Named: #name Type: String Comment: Basic name of the entity, not full reference.
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
+| `name` | String | Basic name of the entity, not full reference.|
 
 "
 Class {

--- a/src/Famix-Test1-Entities/FamixTest1Comment.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1Comment.class.st
@@ -3,12 +3,15 @@
 ======================
 
 ### Other
-- Relation: #commentedEntity Type: #FamixTWithComments Opposite: #comments Comment: Source code commented by the comment
+| Relation | Type | Opposite | Comment |
+| `commentedEntity` | `FamixTWithComments` | `comments` | Source code commented by the comment|
+
 
 ## Properties
 ======================
 
-- Named: #content Type: String Comment: Content of the comment as a String
+| Name | Type | Comment |
+| `content` | String | Content of the comment as a String|
 
 "
 Class {

--- a/src/Famix-Test1-Entities/FamixTest1File.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1File.class.st
@@ -3,9 +3,13 @@
 ======================
 
 ### Parents
-- Relation: #parentFolder Type: #FamixTFolder Opposite: #childrenFileSystemEntities Comment: Folder entity containing this file.
+| Relation | Type | Opposite | Comment |
+| `parentFolder` | `FamixTFolder` | `childrenFileSystemEntities` | Folder entity containing this file.|
+
 ### Other
-- Relation: #entities Type: #FamixTWithFiles Opposite: #containerFiles Comment: List of entities defined in the file
+| Relation | Type | Opposite | Comment |
+| `entities` | `FamixTWithFiles` | `containerFiles` | List of entities defined in the file|
+
 
 
 "

--- a/src/Famix-Test1-Entities/FamixTest1FileAnchor.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1FileAnchor.class.st
@@ -2,13 +2,14 @@
 ## Properties
 ======================
 
-- Named: #correspondingFile Type: FamixTFile Comment: File associated to this source anchor
-- Named: #encoding Type: String Comment: A string representing the encoding of a file
-- Named: #endColumn Type: Number Comment: Number of the end column
-- Named: #endLine Type: Number Comment: Number of the end line
-- Named: #fileName Type: String Comment: Name of the source file
-- Named: #startColumn Type: Number Comment: Number of the start column
-- Named: #startLine Type: Number Comment: Number of the start line
+| Name | Type | Comment |
+| `correspondingFile` | FamixTFile | File associated to this source anchor|
+| `encoding` | String | A string representing the encoding of a file|
+| `endColumn` | Number | Number of the end column|
+| `endLine` | Number | Number of the end line|
+| `fileName` | String | Name of the source file|
+| `startColumn` | Number | Number of the start column|
+| `startLine` | Number | Number of the start line|
 
 "
 Class {

--- a/src/Famix-Test1-Entities/FamixTest1Folder.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1Folder.class.st
@@ -3,9 +3,13 @@
 ======================
 
 ### Parents
-- Relation: #parentFolder Type: #FamixTFolder Opposite: #childrenFileSystemEntities Comment: Folder entity containing this file.
+| Relation | Type | Opposite | Comment |
+| `parentFolder` | `FamixTFolder` | `childrenFileSystemEntities` | Folder entity containing this file.|
+
 ### Children
-- Relation: #childrenFileSystemEntities Type: #FamixTFileSystemEntity Opposite: #parentFolder Comment: List of entities contained in this folder.
+| Relation | Type | Opposite | Comment |
+| `childrenFileSystemEntities` | `FamixTFileSystemEntity` | `parentFolder` | List of entities contained in this folder.|
+
 
 
 "

--- a/src/Famix-Test1-Entities/FamixTest1IndexedFileAnchor.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1IndexedFileAnchor.class.st
@@ -2,11 +2,12 @@
 ## Properties
 ======================
 
-- Named: #correspondingFile Type: FamixTFile Comment: File associated to this source anchor
-- Named: #encoding Type: String Comment: A string representing the encoding of a file
-- Named: #endPos Type: Number Comment: Stop position in the source
-- Named: #fileName Type: String Comment: Name of the source file
-- Named: #startPos Type: Number Comment: Start position in the source
+| Name | Type | Comment |
+| `correspondingFile` | FamixTFile | File associated to this source anchor|
+| `encoding` | String | A string representing the encoding of a file|
+| `endPos` | Number | Stop position in the source|
+| `fileName` | String | Name of the source file|
+| `startPos` | Number | Start position in the source|
 
 "
 Class {

--- a/src/Famix-Test1-Entities/FamixTest1Method.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1Method.class.st
@@ -3,31 +3,42 @@
 ======================
 
 ### Parents
-- Relation: #parentType Type: #FamixTWithMethods Opposite: #methods Comment: Type declaring the method. It provides the implementation for belongsTo.
+| Relation | Type | Opposite | Comment |
+| `parentType` | `FamixTWithMethods` | `methods` | Type declaring the method. It provides the implementation for belongsTo.|
+
 ### Children
-- Relation: #implicitVariables Type: #FamixTImplicitVariable Opposite: #parentBehaviouralEntity Comment: Implicit variables used locally by this behaviour.
-- Relation: #localVariables Type: #FamixTLocalVariable Opposite: #parentBehaviouralEntity Comment: Variables locally defined by this behaviour.
-- Relation: #parameters Type: #FamixTParameter Opposite: #parentBehaviouralEntity Comment: List of formal parameters declared by this behaviour.
+| Relation | Type | Opposite | Comment |
+| `implicitVariables` | `FamixTImplicitVariable` | `parentBehaviouralEntity` | Implicit variables used locally by this behaviour.|
+| `localVariables` | `FamixTLocalVariable` | `parentBehaviouralEntity` | Variables locally defined by this behaviour.|
+| `parameters` | `FamixTParameter` | `parentBehaviouralEntity` | List of formal parameters declared by this behaviour.|
+
 ### Outgoing dependencies
-- Relation: #accesses Type: #FamixTAccess Opposite: #accessor Comment: Accesses to variables made by this behaviour.
-- Relation: #outgoingInvocations Type: #FamixTInvocation Opposite: #sender Comment: Outgoing invocations sent by this behaviour.
-- Relation: #outgoingReferences Type: #FamixTReference Opposite: #referencer Comment: References from this entity to other entities.
+| Relation | Type | Opposite | Comment |
+| `accesses` | `FamixTAccess` | `accessor` | Accesses to variables made by this behaviour.|
+| `outgoingInvocations` | `FamixTInvocation` | `sender` | Outgoing invocations sent by this behaviour.|
+| `outgoingReferences` | `FamixTReference` | `referencer` | References from this entity to other entities.|
+
 ### Incoming dependencies
-- Relation: #incomingInvocations Type: #FamixTInvocation Opposite: #candidates Comment: Incoming invocations from other behaviours computed by the candidate operator.
+| Relation | Type | Opposite | Comment |
+| `incomingInvocations` | `FamixTInvocation` | `candidates` | Incoming invocations from other behaviours computed by the candidate operator.|
+
 ### Other
-- Relation: #comments Type: #FamixTComment Opposite: #commentedEntity Comment: List of comments for the entity
-- Relation: #declaredSourceLanguage Type: #FamixTSourceLanguage Opposite: #sourcedEntities Comment: The declared SourceLanguage for the source code of this entity
-- Relation: #declaredType Type: #FamixTType Opposite: #typedEntities Comment: Type of the entity, if any
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
+| Relation | Type | Opposite | Comment |
+| `comments` | `FamixTComment` | `commentedEntity` | List of comments for the entity|
+| `declaredSourceLanguage` | `FamixTSourceLanguage` | `sourcedEntities` | The declared SourceLanguage for the source code of this entity|
+| `declaredType` | `FamixTType` | `typedEntities` | Type of the entity, if any|
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+
 
 ## Properties
 ======================
 
-- Named: #isClassSide Type: Boolean Comment: Entity can be declared class side i.e. static
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
-- Named: #kind Type: String Comment: Tag indicating a setter, getter, constant, constructor method
-- Named: #name Type: String Comment: Basic name of the entity, not full reference.
-- Named: #signature Type: String Comment: Signature of the message being sent
+| Name | Type | Comment |
+| `isClassSide` | Boolean | Entity can be declared class side i.e. static|
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
+| `kind` | String | Tag indicating a setter, getter, constant, constructor method|
+| `name` | String | Basic name of the entity, not full reference.|
+| `signature` | String | Signature of the message being sent|
 
 "
 Class {

--- a/src/Famix-Test1-Entities/FamixTest1Model.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1Model.class.st
@@ -4,7 +4,8 @@ This is a the comment of the model class
 ## Properties
 ======================
 
-- Named: #modelHasProperties Type: Object
+| Name | Type | Comment |
+| `modelHasProperties` | Object | |
 
 "
 Class {

--- a/src/Famix-Test1-Entities/FamixTest1MultipleFileAnchor.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1MultipleFileAnchor.class.st
@@ -3,12 +3,15 @@
 ======================
 
 ### Other
-- Relation: #element Type: #FamixTSourceEntity Opposite: #sourceAnchor Comment: Enable the accessibility to the famix entity that this class is a source pointer for
+| Relation | Type | Opposite | Comment |
+| `element` | `FamixTSourceEntity` | `sourceAnchor` | Enable the accessibility to the famix entity that this class is a source pointer for|
+
 
 ## Properties
 ======================
 
-- Named: #fileAnchors Type: FamixTFileAnchor Comment: All source code definition files
+| Name | Type | Comment |
+| `fileAnchors` | FamixTFileAnchor | All source code definition files|
 
 "
 Class {

--- a/src/Famix-Test1-Entities/FamixTest1NamedEntity.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1NamedEntity.class.st
@@ -2,7 +2,8 @@
 ## Properties
 ======================
 
-- Named: #name Type: String Comment: Basic name of the entity, not full reference.
+| Name | Type | Comment |
+| `name` | String | Basic name of the entity, not full reference.|
 
 "
 Class {

--- a/src/Famix-Test1-Entities/FamixTest1SourceAnchor.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1SourceAnchor.class.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Other
-- Relation: #element Type: #FamixTSourceEntity Opposite: #sourceAnchor Comment: Enable the accessibility to the famix entity that this class is a source pointer for
+| Relation | Type | Opposite | Comment |
+| `element` | `FamixTSourceEntity` | `sourceAnchor` | Enable the accessibility to the famix entity that this class is a source pointer for|
+
 
 
 "

--- a/src/Famix-Test1-Entities/FamixTest1SourceLanguage.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1SourceLanguage.class.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Other
-- Relation: #sourcedEntities Type: #FamixTWithSourceLanguages Opposite: #declaredSourceLanguage Comment: References to the entities saying explicitly that are written in this language.
+| Relation | Type | Opposite | Comment |
+| `sourcedEntities` | `FamixTWithSourceLanguages` | `declaredSourceLanguage` | References to the entities saying explicitly that are written in this language.|
+
 
 
 "

--- a/src/Famix-Test1-Entities/FamixTest1SourceTextAnchor.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1SourceTextAnchor.class.st
@@ -3,12 +3,15 @@
 ======================
 
 ### Other
-- Relation: #element Type: #FamixTSourceEntity Opposite: #sourceAnchor Comment: Enable the accessibility to the famix entity that this class is a source pointer for
+| Relation | Type | Opposite | Comment |
+| `element` | `FamixTSourceEntity` | `sourceAnchor` | Enable the accessibility to the famix entity that this class is a source pointer for|
+
 
 ## Properties
 ======================
 
-- Named: #source Type: String Comment: Actual source code of the source entity
+| Name | Type | Comment |
+| `source` | String | Actual source code of the source entity|
 
 "
 Class {

--- a/src/Famix-Test1-Entities/FamixTest1SourcedEntity.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1SourcedEntity.class.st
@@ -3,14 +3,17 @@
 ======================
 
 ### Other
-- Relation: #containerFiles Type: #FamixTFile Opposite: #entities Comment: List of files containing the entity
-- Relation: #declaredSourceLanguage Type: #FamixTSourceLanguage Opposite: #sourcedEntities Comment: The declared SourceLanguage for the source code of this entity
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
+| Relation | Type | Opposite | Comment |
+| `containerFiles` | `FamixTFile` | `entities` | List of files containing the entity|
+| `declaredSourceLanguage` | `FamixTSourceLanguage` | `sourcedEntities` | The declared SourceLanguage for the source code of this entity|
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
 
 "
 Class {

--- a/src/Famix-Test1-Entities/FamixTest1TCanBeClassSide.trait.st
+++ b/src/Famix-Test1-Entities/FamixTest1TCanBeClassSide.trait.st
@@ -2,7 +2,8 @@
 ## Properties
 ======================
 
-- Named: #isClassSide Type: Boolean Comment: Entity can be declared class side i.e. static
+| Name | Type | Comment |
+| `isClassSide` | Boolean | Entity can be declared class side i.e. static|
 
 "
 Trait {

--- a/src/Famix-Test1-Entities/FamixTest1UnknownSourceLanguage.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1UnknownSourceLanguage.class.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Other
-- Relation: #sourcedEntities Type: #FamixTWithSourceLanguages Opposite: #declaredSourceLanguage Comment: References to the entities saying explicitly that are written in this language.
+| Relation | Type | Opposite | Comment |
+| `sourcedEntities` | `FamixTWithSourceLanguages` | `declaredSourceLanguage` | References to the entities saying explicitly that are written in this language.|
+
 
 
 "

--- a/src/Famix-Test2-Entities/FamixTest2Class.class.st
+++ b/src/Famix-Test2-Entities/FamixTest2Class.class.st
@@ -3,26 +3,37 @@
 ======================
 
 ### Parents
-- Relation: #typeContainer Type: #FamixTWithTypes Opposite: #types Comment: Container entity to which this type belongs. Container is a namespace, not a package (Smalltalk).
+| Relation | Type | Opposite | Comment |
+| `typeContainer` | `FamixTWithTypes` | `types` | Container entity to which this type belongs. Container is a namespace, not a package (Smalltalk).|
+
 ### Children
-- Relation: #attributes Type: #FamixTAttribute Opposite: #parentType Comment: List of attributes declared by this type.
-- Relation: #methods Type: #FamixTMethod Opposite: #parentType Comment: Methods declared by this type.
+| Relation | Type | Opposite | Comment |
+| `attributes` | `FamixTAttribute` | `parentType` | List of attributes declared by this type.|
+| `methods` | `FamixTMethod` | `parentType` | Methods declared by this type.|
+
 ### Outgoing dependencies
-- Relation: #superInheritances Type: #FamixTInheritance Opposite: #subclass Comment: Superinheritance relationships, i.e. known superclasses of this type.
+| Relation | Type | Opposite | Comment |
+| `superInheritances` | `FamixTInheritance` | `subclass` | Superinheritance relationships, i.e. known superclasses of this type.|
+
 ### Incoming dependencies
-- Relation: #incomingReferences Type: #FamixTReference Opposite: #referredType Comment: References to this entity by other entities.
-- Relation: #subInheritances Type: #FamixTInheritance Opposite: #superclass Comment: Subinheritance relationships, i.e. known subclasses of this type.
+| Relation | Type | Opposite | Comment |
+| `incomingReferences` | `FamixTReference` | `referredType` | References to this entity by other entities.|
+| `subInheritances` | `FamixTInheritance` | `superclass` | Subinheritance relationships, i.e. known subclasses of this type.|
+
 ### Other
-- Relation: #comments Type: #FamixTComment Opposite: #commentedEntity Comment: List of comments for the entity
-- Relation: #receivingInvocations Type: #FamixTInvocation Opposite: #receiver Comment: List of invocations performed on this entity (considered as the receiver)
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
-- Relation: #typedEntities Type: #FamixTTypedEntity Opposite: #declaredType Comment: Entities that have this type as declaredType
+| Relation | Type | Opposite | Comment |
+| `comments` | `FamixTComment` | `commentedEntity` | List of comments for the entity|
+| `receivingInvocations` | `FamixTInvocation` | `receiver` | List of invocations performed on this entity (considered as the receiver)|
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+| `typedEntities` | `FamixTTypedEntity` | `declaredType` | Entities that have this type as declaredType|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
-- Named: #name Type: String Comment: Basic name of the entity, not full reference.
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
+| `name` | String | Basic name of the entity, not full reference.|
 
 "
 Class {

--- a/src/Famix-Test2-Entities/FamixTest2Comment.class.st
+++ b/src/Famix-Test2-Entities/FamixTest2Comment.class.st
@@ -3,12 +3,15 @@
 ======================
 
 ### Other
-- Relation: #commentedEntity Type: #FamixTWithComments Opposite: #comments Comment: Source code commented by the comment
+| Relation | Type | Opposite | Comment |
+| `commentedEntity` | `FamixTWithComments` | `comments` | Source code commented by the comment|
+
 
 ## Properties
 ======================
 
-- Named: #content Type: String Comment: Content of the comment as a String
+| Name | Type | Comment |
+| `content` | String | Content of the comment as a String|
 
 "
 Class {

--- a/src/Famix-Test2-Entities/FamixTest2Inheritance.class.st
+++ b/src/Famix-Test2-Entities/FamixTest2Inheritance.class.st
@@ -3,18 +3,25 @@
 ======================
 
 ### Association source
-- Relation: #subclass Type: #FamixTWithInheritances Opposite: #superInheritances Comment: Subclass linked to in this relationship. from-side of the association
+| Relation | Type | Opposite | Comment |
+| `subclass` | `FamixTWithInheritances` | `superInheritances` | Subclass linked to in this relationship. from-side of the association|
+
 ### Association target
-- Relation: #superclass Type: #FamixTWithInheritances Opposite: #subInheritances Comment: Superclass linked to in this relationship. to-side of the association
+| Relation | Type | Opposite | Comment |
+| `superclass` | `FamixTWithInheritances` | `subInheritances` | Superclass linked to in this relationship. to-side of the association|
+
 ### Other
-- Relation: #next Type: #FamixTAssociation Opposite: #previous Comment: Next association in an ordered collection of associations. Currently not supported by the Moose importer
-- Relation: #previous Type: #FamixTAssociation Opposite: #next Comment: Previous association in an ordered collection of associations. Currently not supported by the Moose importer
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
+| Relation | Type | Opposite | Comment |
+| `next` | `FamixTAssociation` | `previous` | Next association in an ordered collection of associations. Currently not supported by the Moose importer|
+| `previous` | `FamixTAssociation` | `next` | Previous association in an ordered collection of associations. Currently not supported by the Moose importer|
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
 
 "
 Class {

--- a/src/Famix-Test2-Entities/FamixTest2NamedEntity.class.st
+++ b/src/Famix-Test2-Entities/FamixTest2NamedEntity.class.st
@@ -2,7 +2,8 @@
 ## Properties
 ======================
 
-- Named: #name Type: String Comment: Basic name of the entity, not full reference.
+| Name | Type | Comment |
+| `name` | String | Basic name of the entity, not full reference.|
 
 "
 Class {

--- a/src/Famix-Test2-Entities/FamixTest2SourceAnchor.class.st
+++ b/src/Famix-Test2-Entities/FamixTest2SourceAnchor.class.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Other
-- Relation: #element Type: #FamixTSourceEntity Opposite: #sourceAnchor Comment: Enable the accessibility to the famix entity that this class is a source pointer for
+| Relation | Type | Opposite | Comment |
+| `element` | `FamixTSourceEntity` | `sourceAnchor` | Enable the accessibility to the famix entity that this class is a source pointer for|
+
 
 
 "

--- a/src/Famix-Test2-Entities/FamixTest2SourceLanguage.class.st
+++ b/src/Famix-Test2-Entities/FamixTest2SourceLanguage.class.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Other
-- Relation: #sourcedEntities Type: #FamixTWithSourceLanguages Opposite: #declaredSourceLanguage Comment: References to the entities saying explicitly that are written in this language.
+| Relation | Type | Opposite | Comment |
+| `sourcedEntities` | `FamixTWithSourceLanguages` | `declaredSourceLanguage` | References to the entities saying explicitly that are written in this language.|
+
 
 
 "

--- a/src/Famix-Test2-Entities/FamixTest2SourceTextAnchor.class.st
+++ b/src/Famix-Test2-Entities/FamixTest2SourceTextAnchor.class.st
@@ -3,12 +3,15 @@
 ======================
 
 ### Other
-- Relation: #element Type: #FamixTSourceEntity Opposite: #sourceAnchor Comment: Enable the accessibility to the famix entity that this class is a source pointer for
+| Relation | Type | Opposite | Comment |
+| `element` | `FamixTSourceEntity` | `sourceAnchor` | Enable the accessibility to the famix entity that this class is a source pointer for|
+
 
 ## Properties
 ======================
 
-- Named: #source Type: String Comment: Actual source code of the source entity
+| Name | Type | Comment |
+| `source` | String | Actual source code of the source entity|
 
 "
 Class {

--- a/src/Famix-Test2-Entities/FamixTest2SourcedEntity.class.st
+++ b/src/Famix-Test2-Entities/FamixTest2SourcedEntity.class.st
@@ -3,12 +3,15 @@
 ======================
 
 ### Other
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
+| Relation | Type | Opposite | Comment |
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
 
 "
 Class {

--- a/src/Famix-Test2-Entities/FamixTest2UnknownSourceLanguage.class.st
+++ b/src/Famix-Test2-Entities/FamixTest2UnknownSourceLanguage.class.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Other
-- Relation: #sourcedEntities Type: #FamixTWithSourceLanguages Opposite: #declaredSourceLanguage Comment: References to the entities saying explicitly that are written in this language.
+| Relation | Type | Opposite | Comment |
+| `sourcedEntities` | `FamixTWithSourceLanguages` | `declaredSourceLanguage` | References to the entities saying explicitly that are written in this language.|
+
 
 
 "

--- a/src/Famix-Test3-Entities/FamixTest3Access.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3Access.class.st
@@ -3,19 +3,26 @@
 ======================
 
 ### Association source
-- Relation: #accessor Type: #FamixTWithAccesses Opposite: #accesses Comment: Behavioural entity making the access to the variable. from-side of the association
+| Relation | Type | Opposite | Comment |
+| `accessor` | `FamixTWithAccesses` | `accesses` | Behavioural entity making the access to the variable. from-side of the association|
+
 ### Association target
-- Relation: #variable Type: #FamixTAccessible Opposite: #incomingAccesses Comment: Variable accessed. to-side of the association
+| Relation | Type | Opposite | Comment |
+| `variable` | `FamixTAccessible` | `incomingAccesses` | Variable accessed. to-side of the association|
+
 ### Other
-- Relation: #next Type: #FamixTAssociation Opposite: #previous Comment: Next association in an ordered collection of associations. Currently not supported by the Moose importer
-- Relation: #previous Type: #FamixTAssociation Opposite: #next Comment: Previous association in an ordered collection of associations. Currently not supported by the Moose importer
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
+| Relation | Type | Opposite | Comment |
+| `next` | `FamixTAssociation` | `previous` | Next association in an ordered collection of associations. Currently not supported by the Moose importer|
+| `previous` | `FamixTAssociation` | `next` | Previous association in an ordered collection of associations. Currently not supported by the Moose importer|
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
-- Named: #isWrite Type: Boolean Comment: Write access
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
+| `isWrite` | Boolean | Write access|
 
 "
 Class {

--- a/src/Famix-Test3-Entities/FamixTest3Attribute.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3Attribute.class.st
@@ -3,18 +3,25 @@
 ======================
 
 ### Parents
-- Relation: #parentType Type: #FamixTWithAttributes Opposite: #attributes Comment: Type declaring the attribute. belongsTo implementation
+| Relation | Type | Opposite | Comment |
+| `parentType` | `FamixTWithAttributes` | `attributes` | Type declaring the attribute. belongsTo implementation|
+
 ### Incoming dependencies
-- Relation: #incomingAccesses Type: #FamixTAccess Opposite: #variable Comment: All Famix accesses pointing to this structural entity
+| Relation | Type | Opposite | Comment |
+| `incomingAccesses` | `FamixTAccess` | `variable` | All Famix accesses pointing to this structural entity|
+
 ### Other
-- Relation: #declaredType Type: #FamixTType Opposite: #typedEntities Comment: Type of the entity, if any
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
+| Relation | Type | Opposite | Comment |
+| `declaredType` | `FamixTType` | `typedEntities` | Type of the entity, if any|
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
-- Named: #name Type: String Comment: Basic name of the entity, not full reference.
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
+| `name` | String | Basic name of the entity, not full reference.|
 
 "
 Class {

--- a/src/Famix-Test3-Entities/FamixTest3Class.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3Class.class.st
@@ -3,27 +3,38 @@
 ======================
 
 ### Parents
-- Relation: #parentPackage Type: #FamixTPackage Opposite: #childEntities Comment: Package containing the entity in the code structure (if applicable)
-- Relation: #typeContainer Type: #FamixTWithTypes Opposite: #types Comment: Container entity to which this type belongs. Container is a namespace, not a package (Smalltalk).
+| Relation | Type | Opposite | Comment |
+| `parentPackage` | `FamixTPackage` | `childEntities` | Package containing the entity in the code structure (if applicable)|
+| `typeContainer` | `FamixTWithTypes` | `types` | Container entity to which this type belongs. Container is a namespace, not a package (Smalltalk).|
+
 ### Children
-- Relation: #attributes Type: #FamixTAttribute Opposite: #parentType Comment: List of attributes declared by this type.
-- Relation: #methods Type: #FamixTMethod Opposite: #parentType Comment: Methods declared by this type.
+| Relation | Type | Opposite | Comment |
+| `attributes` | `FamixTAttribute` | `parentType` | List of attributes declared by this type.|
+| `methods` | `FamixTMethod` | `parentType` | Methods declared by this type.|
+
 ### Outgoing dependencies
-- Relation: #superInheritances Type: #FamixTInheritance Opposite: #subclass Comment: Superinheritance relationships, i.e. known superclasses of this type.
+| Relation | Type | Opposite | Comment |
+| `superInheritances` | `FamixTInheritance` | `subclass` | Superinheritance relationships, i.e. known superclasses of this type.|
+
 ### Incoming dependencies
-- Relation: #incomingReferences Type: #FamixTReference Opposite: #referredType Comment: References to this entity by other entities.
-- Relation: #subInheritances Type: #FamixTInheritance Opposite: #superclass Comment: Subinheritance relationships, i.e. known subclasses of this type.
+| Relation | Type | Opposite | Comment |
+| `incomingReferences` | `FamixTReference` | `referredType` | References to this entity by other entities.|
+| `subInheritances` | `FamixTInheritance` | `superclass` | Subinheritance relationships, i.e. known subclasses of this type.|
+
 ### Other
-- Relation: #comments Type: #FamixTComment Opposite: #commentedEntity Comment: List of comments for the entity
-- Relation: #receivingInvocations Type: #FamixTInvocation Opposite: #receiver Comment: List of invocations performed on this entity (considered as the receiver)
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
-- Relation: #typedEntities Type: #FamixTTypedEntity Opposite: #declaredType Comment: Entities that have this type as declaredType
+| Relation | Type | Opposite | Comment |
+| `comments` | `FamixTComment` | `commentedEntity` | List of comments for the entity|
+| `receivingInvocations` | `FamixTInvocation` | `receiver` | List of invocations performed on this entity (considered as the receiver)|
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+| `typedEntities` | `FamixTTypedEntity` | `declaredType` | Entities that have this type as declaredType|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
-- Named: #name Type: String Comment: Basic name of the entity, not full reference.
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
+| `name` | String | Basic name of the entity, not full reference.|
 
 "
 Class {

--- a/src/Famix-Test3-Entities/FamixTest3Comment.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3Comment.class.st
@@ -3,12 +3,15 @@
 ======================
 
 ### Other
-- Relation: #commentedEntity Type: #FamixTWithComments Opposite: #comments Comment: Source code commented by the comment
+| Relation | Type | Opposite | Comment |
+| `commentedEntity` | `FamixTWithComments` | `comments` | Source code commented by the comment|
+
 
 ## Properties
 ======================
 
-- Named: #content Type: String Comment: Content of the comment as a String
+| Name | Type | Comment |
+| `content` | String | Content of the comment as a String|
 
 "
 Class {

--- a/src/Famix-Test3-Entities/FamixTest3Invocation.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3Invocation.class.st
@@ -3,20 +3,27 @@
 ======================
 
 ### Association source
-- Relation: #sender Type: #FamixTWithInvocations Opposite: #outgoingInvocations Comment: Behavioural entity making the call. from-side of the association
+| Relation | Type | Opposite | Comment |
+| `sender` | `FamixTWithInvocations` | `outgoingInvocations` | Behavioural entity making the call. from-side of the association|
+
 ### Association target
-- Relation: #candidates Type: #FamixTInvocable Opposite: #incomingInvocations Comment: List of candidate behavioural entities for receiving the invocation
+| Relation | Type | Opposite | Comment |
+| `candidates` | `FamixTInvocable` | `incomingInvocations` | List of candidate behavioural entities for receiving the invocation|
+
 ### Other
-- Relation: #next Type: #FamixTAssociation Opposite: #previous Comment: Next association in an ordered collection of associations. Currently not supported by the Moose importer
-- Relation: #previous Type: #FamixTAssociation Opposite: #next Comment: Previous association in an ordered collection of associations. Currently not supported by the Moose importer
-- Relation: #receiver Type: #FamixTInvocationsReceiver Opposite: #receivingInvocations Comment: Named entity (variable, class...) receiving the invocation. to-side of the association
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
+| Relation | Type | Opposite | Comment |
+| `next` | `FamixTAssociation` | `previous` | Next association in an ordered collection of associations. Currently not supported by the Moose importer|
+| `previous` | `FamixTAssociation` | `next` | Previous association in an ordered collection of associations. Currently not supported by the Moose importer|
+| `receiver` | `FamixTInvocationsReceiver` | `receivingInvocations` | Named entity (variable, class...) receiving the invocation. to-side of the association|
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
-- Named: #signature Type: String Comment: Signature of the message being sent
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
+| `signature` | String | Signature of the message being sent|
 
 "
 Class {

--- a/src/Famix-Test3-Entities/FamixTest3Method.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3Method.class.st
@@ -3,27 +3,38 @@
 ======================
 
 ### Parents
-- Relation: #parentType Type: #FamixTWithMethods Opposite: #methods Comment: Type declaring the method. It provides the implementation for belongsTo.
+| Relation | Type | Opposite | Comment |
+| `parentType` | `FamixTWithMethods` | `methods` | Type declaring the method. It provides the implementation for belongsTo.|
+
 ### Children
-- Relation: #implicitVariables Type: #FamixTImplicitVariable Opposite: #parentBehaviouralEntity Comment: Implicit variables used locally by this behaviour.
-- Relation: #localVariables Type: #FamixTLocalVariable Opposite: #parentBehaviouralEntity Comment: Variables locally defined by this behaviour.
-- Relation: #parameters Type: #FamixTParameter Opposite: #parentBehaviouralEntity Comment: List of formal parameters declared by this behaviour.
+| Relation | Type | Opposite | Comment |
+| `implicitVariables` | `FamixTImplicitVariable` | `parentBehaviouralEntity` | Implicit variables used locally by this behaviour.|
+| `localVariables` | `FamixTLocalVariable` | `parentBehaviouralEntity` | Variables locally defined by this behaviour.|
+| `parameters` | `FamixTParameter` | `parentBehaviouralEntity` | List of formal parameters declared by this behaviour.|
+
 ### Outgoing dependencies
-- Relation: #accesses Type: #FamixTAccess Opposite: #accessor Comment: Accesses to variables made by this behaviour.
-- Relation: #outgoingInvocations Type: #FamixTInvocation Opposite: #sender Comment: Outgoing invocations sent by this behaviour.
-- Relation: #outgoingReferences Type: #FamixTReference Opposite: #referencer Comment: References from this entity to other entities.
+| Relation | Type | Opposite | Comment |
+| `accesses` | `FamixTAccess` | `accessor` | Accesses to variables made by this behaviour.|
+| `outgoingInvocations` | `FamixTInvocation` | `sender` | Outgoing invocations sent by this behaviour.|
+| `outgoingReferences` | `FamixTReference` | `referencer` | References from this entity to other entities.|
+
 ### Incoming dependencies
-- Relation: #incomingInvocations Type: #FamixTInvocation Opposite: #candidates Comment: Incoming invocations from other behaviours computed by the candidate operator.
+| Relation | Type | Opposite | Comment |
+| `incomingInvocations` | `FamixTInvocation` | `candidates` | Incoming invocations from other behaviours computed by the candidate operator.|
+
 ### Other
-- Relation: #declaredType Type: #FamixTType Opposite: #typedEntities Comment: Type of the entity, if any
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
+| Relation | Type | Opposite | Comment |
+| `declaredType` | `FamixTType` | `typedEntities` | Type of the entity, if any|
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
-- Named: #name Type: String Comment: Basic name of the entity, not full reference.
-- Named: #signature Type: String Comment: Signature of the message being sent
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
+| `name` | String | Basic name of the entity, not full reference.|
+| `signature` | String | Signature of the message being sent|
 
 "
 Class {

--- a/src/Famix-Test3-Entities/FamixTest3NamedEntity.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3NamedEntity.class.st
@@ -2,7 +2,8 @@
 ## Properties
 ======================
 
-- Named: #name Type: String Comment: Basic name of the entity, not full reference.
+| Name | Type | Comment |
+| `name` | String | Basic name of the entity, not full reference.|
 
 "
 Class {

--- a/src/Famix-Test3-Entities/FamixTest3Package.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3Package.class.st
@@ -3,15 +3,20 @@
 ======================
 
 ### Children
-- Relation: #childEntities Type: #FamixTPackageable Opposite: #parentPackage
+| Relation | Type | Opposite | Comment |
+| `childEntities` | `FamixTPackageable` | `parentPackage` | |
+
 ### Other
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
+| Relation | Type | Opposite | Comment |
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
-- Named: #name Type: String Comment: Basic name of the entity, not full reference.
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
+| `name` | String | Basic name of the entity, not full reference.|
 
 "
 Class {

--- a/src/Famix-Test3-Entities/FamixTest3PrimitiveType.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3PrimitiveType.class.st
@@ -3,10 +3,14 @@
 ======================
 
 ### Children
-- Relation: #types Type: #FamixTType Opposite: #typeContainer Comment: Types contained (declared) in this entity, if any.
-#types is declared in ContainerEntity because different kinds of container can embed types. Types are usually contained in a Famix.Namespace. But types can also be contained in a Famix.Class or Famix.Method (in Java with inner classes for example). Famix.Function can also contain some types such as structs.
+| Relation | Type | Opposite | Comment |
+| `types` | `FamixTType` | `typeContainer` | Types contained (declared) in this entity, if any.
+#types is declared in ContainerEntity because different kinds of container can embed types. Types are usually contained in a Famix.Namespace. But types can also be contained in a Famix.Class or Famix.Method (in Java with inner classes for example). Famix.Function can also contain some types such as structs.|
+
 ### Incoming dependencies
-- Relation: #incomingReferences Type: #FamixTReference Opposite: #referredType Comment: References to this entity by other entities.
+| Relation | Type | Opposite | Comment |
+| `incomingReferences` | `FamixTReference` | `referredType` | References to this entity by other entities.|
+
 
 
 "

--- a/src/Famix-Test3-Entities/FamixTest3Reference.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3Reference.class.st
@@ -3,18 +3,25 @@
 ======================
 
 ### Association source
-- Relation: #referencer Type: #FamixTWithReferences Opposite: #outgoingReferences Comment: Source entity making the reference. from-side of the association
+| Relation | Type | Opposite | Comment |
+| `referencer` | `FamixTWithReferences` | `outgoingReferences` | Source entity making the reference. from-side of the association|
+
 ### Association target
-- Relation: #referredType Type: #FamixTReferenceable Opposite: #incomingReferences Comment: Target entity referenced. to-side of the association
+| Relation | Type | Opposite | Comment |
+| `referredType` | `FamixTReferenceable` | `incomingReferences` | Target entity referenced. to-side of the association|
+
 ### Other
-- Relation: #next Type: #FamixTAssociation Opposite: #previous Comment: Next association in an ordered collection of associations. Currently not supported by the Moose importer
-- Relation: #previous Type: #FamixTAssociation Opposite: #next Comment: Previous association in an ordered collection of associations. Currently not supported by the Moose importer
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
+| Relation | Type | Opposite | Comment |
+| `next` | `FamixTAssociation` | `previous` | Next association in an ordered collection of associations. Currently not supported by the Moose importer|
+| `previous` | `FamixTAssociation` | `next` | Previous association in an ordered collection of associations. Currently not supported by the Moose importer|
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
 
 "
 Class {

--- a/src/Famix-Test3-Entities/FamixTest3SourceAnchor.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3SourceAnchor.class.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Other
-- Relation: #element Type: #FamixTSourceEntity Opposite: #sourceAnchor Comment: Enable the accessibility to the famix entity that this class is a source pointer for
+| Relation | Type | Opposite | Comment |
+| `element` | `FamixTSourceEntity` | `sourceAnchor` | Enable the accessibility to the famix entity that this class is a source pointer for|
+
 
 
 "

--- a/src/Famix-Test3-Entities/FamixTest3SourceLanguage.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3SourceLanguage.class.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Other
-- Relation: #sourcedEntities Type: #FamixTWithSourceLanguages Opposite: #declaredSourceLanguage Comment: References to the entities saying explicitly that are written in this language.
+| Relation | Type | Opposite | Comment |
+| `sourcedEntities` | `FamixTWithSourceLanguages` | `declaredSourceLanguage` | References to the entities saying explicitly that are written in this language.|
+
 
 
 "

--- a/src/Famix-Test3-Entities/FamixTest3SourceTextAnchor.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3SourceTextAnchor.class.st
@@ -3,12 +3,15 @@
 ======================
 
 ### Other
-- Relation: #element Type: #FamixTSourceEntity Opposite: #sourceAnchor Comment: Enable the accessibility to the famix entity that this class is a source pointer for
+| Relation | Type | Opposite | Comment |
+| `element` | `FamixTSourceEntity` | `sourceAnchor` | Enable the accessibility to the famix entity that this class is a source pointer for|
+
 
 ## Properties
 ======================
 
-- Named: #source Type: String Comment: Actual source code of the source entity
+| Name | Type | Comment |
+| `source` | String | Actual source code of the source entity|
 
 "
 Class {

--- a/src/Famix-Test3-Entities/FamixTest3SourcedEntity.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3SourcedEntity.class.st
@@ -3,12 +3,15 @@
 ======================
 
 ### Other
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
+| Relation | Type | Opposite | Comment |
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
 
 "
 Class {

--- a/src/Famix-Test3-Entities/FamixTest3Type.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3Type.class.st
@@ -3,18 +3,25 @@
 ======================
 
 ### Parents
-- Relation: #typeContainer Type: #FamixTWithTypes Opposite: #types Comment: Container entity to which this type belongs. Container is a namespace, not a package (Smalltalk).
+| Relation | Type | Opposite | Comment |
+| `typeContainer` | `FamixTWithTypes` | `types` | Container entity to which this type belongs. Container is a namespace, not a package (Smalltalk).|
+
 ### Incoming dependencies
-- Relation: #incomingReferences Type: #FamixTReference Opposite: #referredType Comment: References to this entity by other entities.
+| Relation | Type | Opposite | Comment |
+| `incomingReferences` | `FamixTReference` | `referredType` | References to this entity by other entities.|
+
 ### Other
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
-- Relation: #typedEntities Type: #FamixTTypedEntity Opposite: #declaredType Comment: Entities that have this type as declaredType
+| Relation | Type | Opposite | Comment |
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+| `typedEntities` | `FamixTTypedEntity` | `declaredType` | Entities that have this type as declaredType|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
-- Named: #name Type: String Comment: Basic name of the entity, not full reference.
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
+| `name` | String | Basic name of the entity, not full reference.|
 
 "
 Class {

--- a/src/Famix-Test3-Entities/FamixTest3UnknownSourceLanguage.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3UnknownSourceLanguage.class.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Other
-- Relation: #sourcedEntities Type: #FamixTWithSourceLanguages Opposite: #declaredSourceLanguage Comment: References to the entities saying explicitly that are written in this language.
+| Relation | Type | Opposite | Comment |
+| `sourcedEntities` | `FamixTWithSourceLanguages` | `declaredSourceLanguage` | References to the entities saying explicitly that are written in this language.|
+
 
 
 "

--- a/src/Famix-Test4-Entities/FamixTest4Book.class.st
+++ b/src/Famix-Test4-Entities/FamixTest4Book.class.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Parents
-- Relation: #person Type: #FamixTest4Person Opposite: #books
+| Relation | Type | Opposite | Comment |
+| `person` | `FamixTest4Person` | `books` | |
+
 
 
 "

--- a/src/Famix-Test4-Entities/FamixTest4Entity.class.st
+++ b/src/Famix-Test4-Entities/FamixTest4Entity.class.st
@@ -2,7 +2,8 @@
 ## Properties
 ======================
 
-- Named: #name Type: String
+| Name | Type | Comment |
+| `name` | String | |
 
 "
 Class {

--- a/src/Famix-Test4-Entities/FamixTest4Person.class.st
+++ b/src/Famix-Test4-Entities/FamixTest4Person.class.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Children
-- Relation: #books Type: #FamixTest4Book Opposite: #person
+| Relation | Type | Opposite | Comment |
+| `books` | `FamixTest4Book` | `person` | |
+
 
 
 "

--- a/src/Famix-Test4-Entities/FamixTest4Principal.class.st
+++ b/src/Famix-Test4-Entities/FamixTest4Principal.class.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Parents
-- Relation: #school Type: #FamixTest4School Opposite: #principal
+| Relation | Type | Opposite | Comment |
+| `school` | `FamixTest4School` | `principal` | |
+
 
 
 "

--- a/src/Famix-Test4-Entities/FamixTest4Room.class.st
+++ b/src/Famix-Test4-Entities/FamixTest4Room.class.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Parents
-- Relation: #school Type: #FamixTest4School Opposite: #rooms
+| Relation | Type | Opposite | Comment |
+| `school` | `FamixTest4School` | `rooms` | |
+
 
 
 "

--- a/src/Famix-Test4-Entities/FamixTest4School.class.st
+++ b/src/Famix-Test4-Entities/FamixTest4School.class.st
@@ -3,10 +3,12 @@
 ======================
 
 ### Children
-- Relation: #principal Type: #FamixTest4Principal Opposite: #school
-- Relation: #rooms Type: #FamixTest4Room Opposite: #school
-- Relation: #students Type: #FamixTest4Student Opposite: #school
-- Relation: #teachers Type: #FamixTest4Teacher Opposite: #school
+| Relation | Type | Opposite | Comment |
+| `principal` | `FamixTest4Principal` | `school` | |
+| `rooms` | `FamixTest4Room` | `school` | |
+| `students` | `FamixTest4Student` | `school` | |
+| `teachers` | `FamixTest4Teacher` | `school` | |
+
 
 
 "

--- a/src/Famix-Test4-Entities/FamixTest4Student.class.st
+++ b/src/Famix-Test4-Entities/FamixTest4Student.class.st
@@ -3,9 +3,13 @@
 ======================
 
 ### Parents
-- Relation: #school Type: #FamixTest4School Opposite: #students
+| Relation | Type | Opposite | Comment |
+| `school` | `FamixTest4School` | `students` | |
+
 ### Other
-- Relation: #teachers Type: #FamixTest4Teacher Opposite: #students
+| Relation | Type | Opposite | Comment |
+| `teachers` | `FamixTest4Teacher` | `students` | |
+
 
 
 "

--- a/src/Famix-Test4-Entities/FamixTest4Teacher.class.st
+++ b/src/Famix-Test4-Entities/FamixTest4Teacher.class.st
@@ -3,9 +3,13 @@
 ======================
 
 ### Parents
-- Relation: #school Type: #FamixTest4School Opposite: #teachers
+| Relation | Type | Opposite | Comment |
+| `school` | `FamixTest4School` | `teachers` | |
+
 ### Other
-- Relation: #students Type: #FamixTest4Student Opposite: #teachers
+| Relation | Type | Opposite | Comment |
+| `students` | `FamixTest4Student` | `teachers` | |
+
 
 
 "

--- a/src/Famix-Test5-Entities/FamixTest5AnnotationType1.class.st
+++ b/src/Famix-Test5-Entities/FamixTest5AnnotationType1.class.st
@@ -3,9 +3,13 @@
 ======================
 
 ### Parents
-- Relation: #annotationTypesContainer Type: #FamixTWithAnnotationTypes Opposite: #definedAnnotationTypes Comment: Container in which an AnnotationType may reside
+| Relation | Type | Opposite | Comment |
+| `annotationTypesContainer` | `FamixTWithAnnotationTypes` | `definedAnnotationTypes` | Container in which an AnnotationType may reside|
+
 ### Other
-- Relation: #instances Type: #FamixTTypedAnnotationInstance Opposite: #annotationType Comment: Annotations of this type
+| Relation | Type | Opposite | Comment |
+| `instances` | `FamixTTypedAnnotationInstance` | `annotationType` | Annotations of this type|
+
 
 
 "

--- a/src/Famix-Test5-Entities/FamixTest5AnnotationType2.class.st
+++ b/src/Famix-Test5-Entities/FamixTest5AnnotationType2.class.st
@@ -3,9 +3,13 @@
 ======================
 
 ### Parents
-- Relation: #annotationTypesContainer Type: #FamixTWithAnnotationTypes Opposite: #definedAnnotationTypes Comment: Container in which an AnnotationType may reside
+| Relation | Type | Opposite | Comment |
+| `annotationTypesContainer` | `FamixTWithAnnotationTypes` | `definedAnnotationTypes` | Container in which an AnnotationType may reside|
+
 ### Other
-- Relation: #instances Type: #FamixTTypedAnnotationInstance Opposite: #annotationType Comment: Annotations of this type
+| Relation | Type | Opposite | Comment |
+| `instances` | `FamixTTypedAnnotationInstance` | `annotationType` | Annotations of this type|
+
 
 
 "

--- a/src/Famix-Test5-Entities/FamixTest5WithAnnotationType1.class.st
+++ b/src/Famix-Test5-Entities/FamixTest5WithAnnotationType1.class.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Children
-- Relation: #definedAnnotationTypes Type: #FamixTAnnotationType Opposite: #annotationTypesContainer Comment: The container in which the AnnotationTypes may be declared
+| Relation | Type | Opposite | Comment |
+| `definedAnnotationTypes` | `FamixTAnnotationType` | `annotationTypesContainer` | The container in which the AnnotationTypes may be declared|
+
 
 
 "

--- a/src/Famix-Test5-Entities/FamixTest5WithAnnotationType2.class.st
+++ b/src/Famix-Test5-Entities/FamixTest5WithAnnotationType2.class.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Children
-- Relation: #definedAnnotationTypes Type: #FamixTAnnotationType Opposite: #annotationTypesContainer Comment: The container in which the AnnotationTypes may be declared
+| Relation | Type | Opposite | Comment |
+| `definedAnnotationTypes` | `FamixTAnnotationType` | `annotationTypesContainer` | The container in which the AnnotationTypes may be declared|
+
 
 
 "

--- a/src/Famix-Test6-Entities/FamixTest6Bacon.class.st
+++ b/src/Famix-Test6-Entities/FamixTest6Bacon.class.st
@@ -2,8 +2,9 @@
 ## Properties
 ======================
 
-- Named: #eggs Type: Number
-- Named: #isFood Type: Boolean
+| Name | Type | Comment |
+| `eggs` | Number | |
+| `isFood` | Boolean | |
 
 "
 Class {

--- a/src/Famix-Test6-Entities/FamixTest6Comment.class.st
+++ b/src/Famix-Test6-Entities/FamixTest6Comment.class.st
@@ -3,12 +3,15 @@
 ======================
 
 ### Other
-- Relation: #commentedEntity Type: #FamixTWithComments Opposite: #comments Comment: Source code commented by the comment
+| Relation | Type | Opposite | Comment |
+| `commentedEntity` | `FamixTWithComments` | `comments` | Source code commented by the comment|
+
 
 ## Properties
 ======================
 
-- Named: #content Type: String Comment: Content of the comment as a String
+| Name | Type | Comment |
+| `content` | String | Content of the comment as a String|
 
 "
 Class {

--- a/src/Famix-Test6-Entities/FamixTest6NamedEntity.class.st
+++ b/src/Famix-Test6-Entities/FamixTest6NamedEntity.class.st
@@ -2,7 +2,8 @@
 ## Properties
 ======================
 
-- Named: #name Type: String Comment: Basic name of the entity, not full reference.
+| Name | Type | Comment |
+| `name` | String | Basic name of the entity, not full reference.|
 
 "
 Class {

--- a/src/Famix-Test6-Entities/FamixTest6SourceAnchor.class.st
+++ b/src/Famix-Test6-Entities/FamixTest6SourceAnchor.class.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Other
-- Relation: #element Type: #FamixTSourceEntity Opposite: #sourceAnchor Comment: Enable the accessibility to the famix entity that this class is a source pointer for
+| Relation | Type | Opposite | Comment |
+| `element` | `FamixTSourceEntity` | `sourceAnchor` | Enable the accessibility to the famix entity that this class is a source pointer for|
+
 
 
 "

--- a/src/Famix-Test6-Entities/FamixTest6SourceLanguage.class.st
+++ b/src/Famix-Test6-Entities/FamixTest6SourceLanguage.class.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Other
-- Relation: #sourcedEntities Type: #FamixTWithSourceLanguages Opposite: #declaredSourceLanguage Comment: References to the entities saying explicitly that are written in this language.
+| Relation | Type | Opposite | Comment |
+| `sourcedEntities` | `FamixTWithSourceLanguages` | `declaredSourceLanguage` | References to the entities saying explicitly that are written in this language.|
+
 
 
 "

--- a/src/Famix-Test6-Entities/FamixTest6SourceTextAnchor.class.st
+++ b/src/Famix-Test6-Entities/FamixTest6SourceTextAnchor.class.st
@@ -3,12 +3,15 @@
 ======================
 
 ### Other
-- Relation: #element Type: #FamixTSourceEntity Opposite: #sourceAnchor Comment: Enable the accessibility to the famix entity that this class is a source pointer for
+| Relation | Type | Opposite | Comment |
+| `element` | `FamixTSourceEntity` | `sourceAnchor` | Enable the accessibility to the famix entity that this class is a source pointer for|
+
 
 ## Properties
 ======================
 
-- Named: #source Type: String Comment: Actual source code of the source entity
+| Name | Type | Comment |
+| `source` | String | Actual source code of the source entity|
 
 "
 Class {

--- a/src/Famix-Test6-Entities/FamixTest6SourcedEntity.class.st
+++ b/src/Famix-Test6-Entities/FamixTest6SourcedEntity.class.st
@@ -3,12 +3,15 @@
 ======================
 
 ### Other
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
+| Relation | Type | Opposite | Comment |
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
 
 "
 Class {

--- a/src/Famix-Test6-Entities/FamixTest6Spam.class.st
+++ b/src/Famix-Test6-Entities/FamixTest6Spam.class.st
@@ -2,7 +2,8 @@
 ## Properties
 ======================
 
-- Named: #isSomething Type: Boolean
+| Name | Type | Comment |
+| `isSomething` | Boolean | |
 
 "
 Class {

--- a/src/Famix-Test6-Entities/FamixTest6UnknownSourceLanguage.class.st
+++ b/src/Famix-Test6-Entities/FamixTest6UnknownSourceLanguage.class.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Other
-- Relation: #sourcedEntities Type: #FamixTWithSourceLanguages Opposite: #declaredSourceLanguage Comment: References to the entities saying explicitly that are written in this language.
+| Relation | Type | Opposite | Comment |
+| `sourcedEntities` | `FamixTWithSourceLanguages` | `declaredSourceLanguage` | References to the entities saying explicitly that are written in this language.|
+
 
 
 "

--- a/src/Famix-Test7-Entities/FamixTest7Class.class.st
+++ b/src/Famix-Test7-Entities/FamixTest7Class.class.st
@@ -3,26 +3,37 @@
 ======================
 
 ### Parents
-- Relation: #typeContainer Type: #FamixTWithTypes Opposite: #types Comment: Container entity to which this type belongs. Container is a namespace, not a package (Smalltalk).
+| Relation | Type | Opposite | Comment |
+| `typeContainer` | `FamixTWithTypes` | `types` | Container entity to which this type belongs. Container is a namespace, not a package (Smalltalk).|
+
 ### Children
-- Relation: #attributes Type: #FamixTAttribute Opposite: #parentType Comment: List of attributes declared by this type.
-- Relation: #methods Type: #FamixTMethod Opposite: #parentType Comment: Methods declared by this type.
+| Relation | Type | Opposite | Comment |
+| `attributes` | `FamixTAttribute` | `parentType` | List of attributes declared by this type.|
+| `methods` | `FamixTMethod` | `parentType` | Methods declared by this type.|
+
 ### Outgoing dependencies
-- Relation: #superInheritances Type: #FamixTInheritance Opposite: #subclass Comment: Superinheritance relationships, i.e. known superclasses of this type.
+| Relation | Type | Opposite | Comment |
+| `superInheritances` | `FamixTInheritance` | `subclass` | Superinheritance relationships, i.e. known superclasses of this type.|
+
 ### Incoming dependencies
-- Relation: #incomingReferences Type: #FamixTReference Opposite: #referredType Comment: References to this entity by other entities.
-- Relation: #subInheritances Type: #FamixTInheritance Opposite: #superclass Comment: Subinheritance relationships, i.e. known subclasses of this type.
+| Relation | Type | Opposite | Comment |
+| `incomingReferences` | `FamixTReference` | `referredType` | References to this entity by other entities.|
+| `subInheritances` | `FamixTInheritance` | `superclass` | Subinheritance relationships, i.e. known subclasses of this type.|
+
 ### Other
-- Relation: #comments Type: #FamixTComment Opposite: #commentedEntity Comment: List of comments for the entity
-- Relation: #receivingInvocations Type: #FamixTInvocation Opposite: #receiver Comment: List of invocations performed on this entity (considered as the receiver)
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
-- Relation: #typedEntities Type: #FamixTTypedEntity Opposite: #declaredType Comment: Entities that have this type as declaredType
+| Relation | Type | Opposite | Comment |
+| `comments` | `FamixTComment` | `commentedEntity` | List of comments for the entity|
+| `receivingInvocations` | `FamixTInvocation` | `receiver` | List of invocations performed on this entity (considered as the receiver)|
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+| `typedEntities` | `FamixTTypedEntity` | `declaredType` | Entities that have this type as declaredType|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
-- Named: #name Type: String Comment: Basic name of the entity, not full reference.
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
+| `name` | String | Basic name of the entity, not full reference.|
 
 "
 Class {

--- a/src/Famix-Test7-Entities/FamixTest7Comment.class.st
+++ b/src/Famix-Test7-Entities/FamixTest7Comment.class.st
@@ -3,12 +3,15 @@
 ======================
 
 ### Other
-- Relation: #commentedEntity Type: #FamixTWithComments Opposite: #comments Comment: Source code commented by the comment
+| Relation | Type | Opposite | Comment |
+| `commentedEntity` | `FamixTWithComments` | `comments` | Source code commented by the comment|
+
 
 ## Properties
 ======================
 
-- Named: #content Type: String Comment: Content of the comment as a String
+| Name | Type | Comment |
+| `content` | String | Content of the comment as a String|
 
 "
 Class {

--- a/src/Famix-Test7-Entities/FamixTest7Inheritance.class.st
+++ b/src/Famix-Test7-Entities/FamixTest7Inheritance.class.st
@@ -3,18 +3,25 @@
 ======================
 
 ### Association source
-- Relation: #subclass Type: #FamixTWithInheritances Opposite: #superInheritances Comment: Subclass linked to in this relationship. from-side of the association
+| Relation | Type | Opposite | Comment |
+| `subclass` | `FamixTWithInheritances` | `superInheritances` | Subclass linked to in this relationship. from-side of the association|
+
 ### Association target
-- Relation: #superclass Type: #FamixTWithInheritances Opposite: #subInheritances Comment: Superclass linked to in this relationship. to-side of the association
+| Relation | Type | Opposite | Comment |
+| `superclass` | `FamixTWithInheritances` | `subInheritances` | Superclass linked to in this relationship. to-side of the association|
+
 ### Other
-- Relation: #next Type: #FamixTAssociation Opposite: #previous Comment: Next association in an ordered collection of associations. Currently not supported by the Moose importer
-- Relation: #previous Type: #FamixTAssociation Opposite: #next Comment: Previous association in an ordered collection of associations. Currently not supported by the Moose importer
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
+| Relation | Type | Opposite | Comment |
+| `next` | `FamixTAssociation` | `previous` | Next association in an ordered collection of associations. Currently not supported by the Moose importer|
+| `previous` | `FamixTAssociation` | `next` | Previous association in an ordered collection of associations. Currently not supported by the Moose importer|
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
 
 "
 Class {

--- a/src/Famix-Test7-Entities/FamixTest7Method.class.st
+++ b/src/Famix-Test7-Entities/FamixTest7Method.class.st
@@ -3,27 +3,38 @@
 ======================
 
 ### Parents
-- Relation: #parentType Type: #FamixTWithMethods Opposite: #methods Comment: Type declaring the method. It provides the implementation for belongsTo.
+| Relation | Type | Opposite | Comment |
+| `parentType` | `FamixTWithMethods` | `methods` | Type declaring the method. It provides the implementation for belongsTo.|
+
 ### Children
-- Relation: #implicitVariables Type: #FamixTImplicitVariable Opposite: #parentBehaviouralEntity Comment: Implicit variables used locally by this behaviour.
-- Relation: #localVariables Type: #FamixTLocalVariable Opposite: #parentBehaviouralEntity Comment: Variables locally defined by this behaviour.
-- Relation: #parameters Type: #FamixTParameter Opposite: #parentBehaviouralEntity Comment: List of formal parameters declared by this behaviour.
+| Relation | Type | Opposite | Comment |
+| `implicitVariables` | `FamixTImplicitVariable` | `parentBehaviouralEntity` | Implicit variables used locally by this behaviour.|
+| `localVariables` | `FamixTLocalVariable` | `parentBehaviouralEntity` | Variables locally defined by this behaviour.|
+| `parameters` | `FamixTParameter` | `parentBehaviouralEntity` | List of formal parameters declared by this behaviour.|
+
 ### Outgoing dependencies
-- Relation: #accesses Type: #FamixTAccess Opposite: #accessor Comment: Accesses to variables made by this behaviour.
-- Relation: #outgoingInvocations Type: #FamixTInvocation Opposite: #sender Comment: Outgoing invocations sent by this behaviour.
-- Relation: #outgoingReferences Type: #FamixTReference Opposite: #referencer Comment: References from this entity to other entities.
+| Relation | Type | Opposite | Comment |
+| `accesses` | `FamixTAccess` | `accessor` | Accesses to variables made by this behaviour.|
+| `outgoingInvocations` | `FamixTInvocation` | `sender` | Outgoing invocations sent by this behaviour.|
+| `outgoingReferences` | `FamixTReference` | `referencer` | References from this entity to other entities.|
+
 ### Incoming dependencies
-- Relation: #incomingInvocations Type: #FamixTInvocation Opposite: #candidates Comment: Incoming invocations from other behaviours computed by the candidate operator.
+| Relation | Type | Opposite | Comment |
+| `incomingInvocations` | `FamixTInvocation` | `candidates` | Incoming invocations from other behaviours computed by the candidate operator.|
+
 ### Other
-- Relation: #declaredType Type: #FamixTType Opposite: #typedEntities Comment: Type of the entity, if any
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
+| Relation | Type | Opposite | Comment |
+| `declaredType` | `FamixTType` | `typedEntities` | Type of the entity, if any|
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
-- Named: #name Type: String Comment: Basic name of the entity, not full reference.
-- Named: #signature Type: String Comment: Signature of the message being sent
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
+| `name` | String | Basic name of the entity, not full reference.|
+| `signature` | String | Signature of the message being sent|
 
 "
 Class {

--- a/src/Famix-Test7-Entities/FamixTest7NamedEntity.class.st
+++ b/src/Famix-Test7-Entities/FamixTest7NamedEntity.class.st
@@ -2,7 +2,8 @@
 ## Properties
 ======================
 
-- Named: #name Type: String Comment: Basic name of the entity, not full reference.
+| Name | Type | Comment |
+| `name` | String | Basic name of the entity, not full reference.|
 
 "
 Class {

--- a/src/Famix-Test7-Entities/FamixTest7SourceAnchor.class.st
+++ b/src/Famix-Test7-Entities/FamixTest7SourceAnchor.class.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Other
-- Relation: #element Type: #FamixTSourceEntity Opposite: #sourceAnchor Comment: Enable the accessibility to the famix entity that this class is a source pointer for
+| Relation | Type | Opposite | Comment |
+| `element` | `FamixTSourceEntity` | `sourceAnchor` | Enable the accessibility to the famix entity that this class is a source pointer for|
+
 
 
 "

--- a/src/Famix-Test7-Entities/FamixTest7SourceLanguage.class.st
+++ b/src/Famix-Test7-Entities/FamixTest7SourceLanguage.class.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Other
-- Relation: #sourcedEntities Type: #FamixTWithSourceLanguages Opposite: #declaredSourceLanguage Comment: References to the entities saying explicitly that are written in this language.
+| Relation | Type | Opposite | Comment |
+| `sourcedEntities` | `FamixTWithSourceLanguages` | `declaredSourceLanguage` | References to the entities saying explicitly that are written in this language.|
+
 
 
 "

--- a/src/Famix-Test7-Entities/FamixTest7SourceTextAnchor.class.st
+++ b/src/Famix-Test7-Entities/FamixTest7SourceTextAnchor.class.st
@@ -3,12 +3,15 @@
 ======================
 
 ### Other
-- Relation: #element Type: #FamixTSourceEntity Opposite: #sourceAnchor Comment: Enable the accessibility to the famix entity that this class is a source pointer for
+| Relation | Type | Opposite | Comment |
+| `element` | `FamixTSourceEntity` | `sourceAnchor` | Enable the accessibility to the famix entity that this class is a source pointer for|
+
 
 ## Properties
 ======================
 
-- Named: #source Type: String Comment: Actual source code of the source entity
+| Name | Type | Comment |
+| `source` | String | Actual source code of the source entity|
 
 "
 Class {

--- a/src/Famix-Test7-Entities/FamixTest7SourcedEntity.class.st
+++ b/src/Famix-Test7-Entities/FamixTest7SourcedEntity.class.st
@@ -3,12 +3,15 @@
 ======================
 
 ### Other
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
+| Relation | Type | Opposite | Comment |
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
 
 "
 Class {

--- a/src/Famix-Test7-Entities/FamixTest7UnknownSourceLanguage.class.st
+++ b/src/Famix-Test7-Entities/FamixTest7UnknownSourceLanguage.class.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Other
-- Relation: #sourcedEntities Type: #FamixTWithSourceLanguages Opposite: #declaredSourceLanguage Comment: References to the entities saying explicitly that are written in this language.
+| Relation | Type | Opposite | Comment |
+| `sourcedEntities` | `FamixTWithSourceLanguages` | `declaredSourceLanguage` | References to the entities saying explicitly that are written in this language.|
+
 
 
 "

--- a/src/Famix-Test8-Entities/FamixTest8Animal.class.st
+++ b/src/Famix-Test8-Entities/FamixTest8Animal.class.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Incoming dependencies
-- Relation: #incomingInfections Type: #FamixTest8Infection Opposite: #infectious
+| Relation | Type | Opposite | Comment |
+| `incomingInfections` | `FamixTest8Infection` | `infectious` | |
+
 
 
 "

--- a/src/Famix-Test8-Entities/FamixTest8Bacteria.class.st
+++ b/src/Famix-Test8-Entities/FamixTest8Bacteria.class.st
@@ -3,12 +3,15 @@
 ======================
 
 ### Outgoing dependencies
-- Relation: #outgoingInfections Type: #FamixTest8Infection Opposite: #infectable
+| Relation | Type | Opposite | Comment |
+| `outgoingInfections` | `FamixTest8Infection` | `infectable` | |
+
 
 ## Properties
 ======================
 
-- Named: #pathogenicity Type: Number
+| Name | Type | Comment |
+| `pathogenicity` | Number | |
 
 "
 Class {

--- a/src/Famix-Test8-Entities/FamixTest8Biotope.class.st
+++ b/src/Famix-Test8-Entities/FamixTest8Biotope.class.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Incoming dependencies
-- Relation: #incomingResidences Type: #FamixTest8Residence Opposite: #biotope
+| Relation | Type | Opposite | Comment |
+| `incomingResidences` | `FamixTest8Residence` | `biotope` | |
+
 
 
 "

--- a/src/Famix-Test8-Entities/FamixTest8Infection.class.st
+++ b/src/Famix-Test8-Entities/FamixTest8Infection.class.st
@@ -3,19 +3,26 @@
 ======================
 
 ### Association source
-- Relation: #infectable Type: #FamixTest8TInfectable Opposite: #outgoingInfections
+| Relation | Type | Opposite | Comment |
+| `infectable` | `FamixTest8TInfectable` | `outgoingInfections` | |
+
 ### Association target
-- Relation: #infectious Type: #FamixTest8TInfectious Opposite: #incomingInfections
+| Relation | Type | Opposite | Comment |
+| `infectious` | `FamixTest8TInfectious` | `incomingInfections` | |
+
 ### Other
-- Relation: #next Type: #FamixTAssociation Opposite: #previous Comment: Next association in an ordered collection of associations. Currently not supported by the Moose importer
-- Relation: #previous Type: #FamixTAssociation Opposite: #next Comment: Previous association in an ordered collection of associations. Currently not supported by the Moose importer
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
+| Relation | Type | Opposite | Comment |
+| `next` | `FamixTAssociation` | `previous` | Next association in an ordered collection of associations. Currently not supported by the Moose importer|
+| `previous` | `FamixTAssociation` | `next` | Previous association in an ordered collection of associations. Currently not supported by the Moose importer|
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+
 
 ## Properties
 ======================
 
-- Named: #isInvasive Type: Boolean
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
+| Name | Type | Comment |
+| `isInvasive` | Boolean | |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
 
 "
 Class {

--- a/src/Famix-Test8-Entities/FamixTest8LivingBeing.class.st
+++ b/src/Famix-Test8-Entities/FamixTest8LivingBeing.class.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Outgoing dependencies
-- Relation: #outgoingResidences Type: #FamixTest8Residence Opposite: #resident
+| Relation | Type | Opposite | Comment |
+| `outgoingResidences` | `FamixTest8Residence` | `resident` | |
+
 
 
 "

--- a/src/Famix-Test8-Entities/FamixTest8Plant.class.st
+++ b/src/Famix-Test8-Entities/FamixTest8Plant.class.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Incoming dependencies
-- Relation: #incomingInfections Type: #FamixTest8Infection Opposite: #infectious
+| Relation | Type | Opposite | Comment |
+| `incomingInfections` | `FamixTest8Infection` | `infectious` | |
+
 
 
 "

--- a/src/Famix-Test8-Entities/FamixTest8Residence.class.st
+++ b/src/Famix-Test8-Entities/FamixTest8Residence.class.st
@@ -3,18 +3,25 @@
 ======================
 
 ### Association source
-- Relation: #resident Type: #FamixTest8TResident Opposite: #outgoingResidences
+| Relation | Type | Opposite | Comment |
+| `resident` | `FamixTest8TResident` | `outgoingResidences` | |
+
 ### Association target
-- Relation: #biotope Type: #FamixTest8TBiotope Opposite: #incomingResidences
+| Relation | Type | Opposite | Comment |
+| `biotope` | `FamixTest8TBiotope` | `incomingResidences` | |
+
 ### Other
-- Relation: #next Type: #FamixTAssociation Opposite: #previous Comment: Next association in an ordered collection of associations. Currently not supported by the Moose importer
-- Relation: #previous Type: #FamixTAssociation Opposite: #next Comment: Previous association in an ordered collection of associations. Currently not supported by the Moose importer
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
+| Relation | Type | Opposite | Comment |
+| `next` | `FamixTAssociation` | `previous` | Next association in an ordered collection of associations. Currently not supported by the Moose importer|
+| `previous` | `FamixTAssociation` | `next` | Previous association in an ordered collection of associations. Currently not supported by the Moose importer|
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
 
 "
 Class {

--- a/src/Famix-Test8-Entities/FamixTest8TBiotope.trait.st
+++ b/src/Famix-Test8-Entities/FamixTest8TBiotope.trait.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Incoming dependencies
-- Relation: #incomingResidences Type: #FamixTest8Residence Opposite: #biotope
+| Relation | Type | Opposite | Comment |
+| `incomingResidences` | `FamixTest8Residence` | `biotope` | |
+
 
 
 "

--- a/src/Famix-Test8-Entities/FamixTest8TInfectable.trait.st
+++ b/src/Famix-Test8-Entities/FamixTest8TInfectable.trait.st
@@ -3,12 +3,15 @@
 ======================
 
 ### Outgoing dependencies
-- Relation: #outgoingInfections Type: #FamixTest8Infection Opposite: #infectable
+| Relation | Type | Opposite | Comment |
+| `outgoingInfections` | `FamixTest8Infection` | `infectable` | |
+
 
 ## Properties
 ======================
 
-- Named: #pathogenicity Type: Number
+| Name | Type | Comment |
+| `pathogenicity` | Number | |
 
 "
 Trait {

--- a/src/Famix-Test8-Entities/FamixTest8TInfectious.trait.st
+++ b/src/Famix-Test8-Entities/FamixTest8TInfectious.trait.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Incoming dependencies
-- Relation: #incomingInfections Type: #FamixTest8Infection Opposite: #infectious
+| Relation | Type | Opposite | Comment |
+| `incomingInfections` | `FamixTest8Infection` | `infectious` | |
+
 
 
 "

--- a/src/Famix-Test8-Entities/FamixTest8TResident.trait.st
+++ b/src/Famix-Test8-Entities/FamixTest8TResident.trait.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Outgoing dependencies
-- Relation: #outgoingResidences Type: #FamixTest8Residence Opposite: #resident
+| Relation | Type | Opposite | Comment |
+| `outgoingResidences` | `FamixTest8Residence` | `resident` | |
+
 
 
 "

--- a/src/Famix-Test8-Entities/FamixTest8Virus.class.st
+++ b/src/Famix-Test8-Entities/FamixTest8Virus.class.st
@@ -3,12 +3,15 @@
 ======================
 
 ### Outgoing dependencies
-- Relation: #outgoingInfections Type: #FamixTest8Infection Opposite: #infectable
+| Relation | Type | Opposite | Comment |
+| `outgoingInfections` | `FamixTest8Infection` | `infectable` | |
+
 
 ## Properties
 ======================
 
-- Named: #pathogenicity Type: Number
+| Name | Type | Comment |
+| `pathogenicity` | Number | |
 
 "
 Class {

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedAssociation.class.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedAssociation.class.st
@@ -3,18 +3,25 @@
 ======================
 
 ### Association source
-- Relation: #c25 Type: #FamixTestComposed2CustomEntity5 Opposite: #associations
+| Relation | Type | Opposite | Comment |
+| `c25` | `FamixTestComposed2CustomEntity5` | `associations` | |
+
 ### Association target
-- Relation: #c15 Type: #FamixTestComposed1CustomEntity5 Opposite: #associations
+| Relation | Type | Opposite | Comment |
+| `c15` | `FamixTestComposed1CustomEntity5` | `associations` | |
+
 ### Other
-- Relation: #next Type: #FamixTAssociation Opposite: #previous Comment: Next association in an ordered collection of associations. Currently not supported by the Moose importer
-- Relation: #previous Type: #FamixTAssociation Opposite: #next Comment: Previous association in an ordered collection of associations. Currently not supported by the Moose importer
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
+| Relation | Type | Opposite | Comment |
+| `next` | `FamixTAssociation` | `previous` | Next association in an ordered collection of associations. Currently not supported by the Moose importer|
+| `previous` | `FamixTAssociation` | `next` | Previous association in an ordered collection of associations. Currently not supported by the Moose importer|
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
 
 "
 Class {

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedCustomEntity1.class.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedCustomEntity1.class.st
@@ -3,9 +3,13 @@
 ======================
 
 ### Children
-- Relation: #customEntity1 Type: #FamixTestComposed1CustomEntity1 Opposite: #customEntity1
+| Relation | Type | Opposite | Comment |
+| `customEntity1` | `FamixTestComposed1CustomEntity1` | `customEntity1` | |
+
 ### Other
-- Relation: #c21 Type: #FamixTestComposed2CustomEntity1 Opposite: #c1
+| Relation | Type | Opposite | Comment |
+| `c21` | `FamixTestComposed2CustomEntity1` | `c1` | |
+
 
 
 "

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedCustomEntity2.class.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedCustomEntity2.class.st
@@ -3,8 +3,10 @@
 ======================
 
 ### Other
-- Relation: #c22s Type: #FamixTestComposed2CustomEntity2 Opposite: #c2
-- Relation: #customEntities2 Type: #FamixTestComposed1CustomEntity2 Opposite: #customEntity2
+| Relation | Type | Opposite | Comment |
+| `c22s` | `FamixTestComposed2CustomEntity2` | `c2` | |
+| `customEntities2` | `FamixTestComposed1CustomEntity2` | `customEntity2` | |
+
 
 
 "

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedCustomEntity3.class.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedCustomEntity3.class.st
@@ -3,8 +3,10 @@
 ======================
 
 ### Other
-- Relation: #c23 Type: #FamixTestComposed2CustomEntity3 Opposite: #c3s
-- Relation: #customEntity3 Type: #FamixTestComposed1CustomEntity3 Opposite: #customEntities3
+| Relation | Type | Opposite | Comment |
+| `c23` | `FamixTestComposed2CustomEntity3` | `c3s` | |
+| `customEntity3` | `FamixTestComposed1CustomEntity3` | `customEntities3` | |
+
 
 
 "

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedCustomEntity4.class.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedCustomEntity4.class.st
@@ -3,8 +3,10 @@
 ======================
 
 ### Other
-- Relation: #c24s Type: #FamixTestComposed2CustomEntity4 Opposite: #c4s
-- Relation: #customEntities4 Type: #FamixTestComposed1CustomEntity4 Opposite: #customEntities4
+| Relation | Type | Opposite | Comment |
+| `c24s` | `FamixTestComposed2CustomEntity4` | `c4s` | |
+| `customEntities4` | `FamixTestComposed1CustomEntity4` | `customEntities4` | |
+
 
 
 "

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedStandardEntity.class.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedStandardEntity.class.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Other
-- Relation: #method Type: #FamixTestComposed1Method Opposite: #standardEntity
+| Relation | Type | Opposite | Comment |
+| `method` | `FamixTestComposed1Method` | `standardEntity` | |
+
 
 
 "

--- a/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1Class.class.st
+++ b/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1Class.class.st
@@ -3,26 +3,37 @@
 ======================
 
 ### Parents
-- Relation: #typeContainer Type: #FamixTWithTypes Opposite: #types Comment: Container entity to which this type belongs. Container is a namespace, not a package (Smalltalk).
+| Relation | Type | Opposite | Comment |
+| `typeContainer` | `FamixTWithTypes` | `types` | Container entity to which this type belongs. Container is a namespace, not a package (Smalltalk).|
+
 ### Children
-- Relation: #attributes Type: #FamixTAttribute Opposite: #parentType Comment: List of attributes declared by this type.
-- Relation: #methods Type: #FamixTMethod Opposite: #parentType Comment: Methods declared by this type.
+| Relation | Type | Opposite | Comment |
+| `attributes` | `FamixTAttribute` | `parentType` | List of attributes declared by this type.|
+| `methods` | `FamixTMethod` | `parentType` | Methods declared by this type.|
+
 ### Outgoing dependencies
-- Relation: #superInheritances Type: #FamixTInheritance Opposite: #subclass Comment: Superinheritance relationships, i.e. known superclasses of this type.
+| Relation | Type | Opposite | Comment |
+| `superInheritances` | `FamixTInheritance` | `subclass` | Superinheritance relationships, i.e. known superclasses of this type.|
+
 ### Incoming dependencies
-- Relation: #incomingReferences Type: #FamixTReference Opposite: #referredType Comment: References to this entity by other entities.
-- Relation: #subInheritances Type: #FamixTInheritance Opposite: #superclass Comment: Subinheritance relationships, i.e. known subclasses of this type.
+| Relation | Type | Opposite | Comment |
+| `incomingReferences` | `FamixTReference` | `referredType` | References to this entity by other entities.|
+| `subInheritances` | `FamixTInheritance` | `superclass` | Subinheritance relationships, i.e. known subclasses of this type.|
+
 ### Other
-- Relation: #comments Type: #FamixTComment Opposite: #commentedEntity Comment: List of comments for the entity
-- Relation: #receivingInvocations Type: #FamixTInvocation Opposite: #receiver Comment: List of invocations performed on this entity (considered as the receiver)
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
-- Relation: #typedEntities Type: #FamixTTypedEntity Opposite: #declaredType Comment: Entities that have this type as declaredType
+| Relation | Type | Opposite | Comment |
+| `comments` | `FamixTComment` | `commentedEntity` | List of comments for the entity|
+| `receivingInvocations` | `FamixTInvocation` | `receiver` | List of invocations performed on this entity (considered as the receiver)|
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+| `typedEntities` | `FamixTTypedEntity` | `declaredType` | Entities that have this type as declaredType|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
-- Named: #name Type: String Comment: Basic name of the entity, not full reference.
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
+| `name` | String | Basic name of the entity, not full reference.|
 
 "
 Class {

--- a/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1Comment.class.st
+++ b/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1Comment.class.st
@@ -3,12 +3,15 @@
 ======================
 
 ### Other
-- Relation: #commentedEntity Type: #FamixTWithComments Opposite: #comments Comment: Source code commented by the comment
+| Relation | Type | Opposite | Comment |
+| `commentedEntity` | `FamixTWithComments` | `comments` | Source code commented by the comment|
+
 
 ## Properties
 ======================
 
-- Named: #content Type: String Comment: Content of the comment as a String
+| Name | Type | Comment |
+| `content` | String | Content of the comment as a String|
 
 "
 Class {

--- a/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1Method.class.st
+++ b/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1Method.class.st
@@ -3,27 +3,38 @@
 ======================
 
 ### Parents
-- Relation: #parentType Type: #FamixTWithMethods Opposite: #methods Comment: Type declaring the method. It provides the implementation for belongsTo.
+| Relation | Type | Opposite | Comment |
+| `parentType` | `FamixTWithMethods` | `methods` | Type declaring the method. It provides the implementation for belongsTo.|
+
 ### Children
-- Relation: #implicitVariables Type: #FamixTImplicitVariable Opposite: #parentBehaviouralEntity Comment: Implicit variables used locally by this behaviour.
-- Relation: #localVariables Type: #FamixTLocalVariable Opposite: #parentBehaviouralEntity Comment: Variables locally defined by this behaviour.
-- Relation: #parameters Type: #FamixTParameter Opposite: #parentBehaviouralEntity Comment: List of formal parameters declared by this behaviour.
+| Relation | Type | Opposite | Comment |
+| `implicitVariables` | `FamixTImplicitVariable` | `parentBehaviouralEntity` | Implicit variables used locally by this behaviour.|
+| `localVariables` | `FamixTLocalVariable` | `parentBehaviouralEntity` | Variables locally defined by this behaviour.|
+| `parameters` | `FamixTParameter` | `parentBehaviouralEntity` | List of formal parameters declared by this behaviour.|
+
 ### Outgoing dependencies
-- Relation: #accesses Type: #FamixTAccess Opposite: #accessor Comment: Accesses to variables made by this behaviour.
-- Relation: #outgoingInvocations Type: #FamixTInvocation Opposite: #sender Comment: Outgoing invocations sent by this behaviour.
-- Relation: #outgoingReferences Type: #FamixTReference Opposite: #referencer Comment: References from this entity to other entities.
+| Relation | Type | Opposite | Comment |
+| `accesses` | `FamixTAccess` | `accessor` | Accesses to variables made by this behaviour.|
+| `outgoingInvocations` | `FamixTInvocation` | `sender` | Outgoing invocations sent by this behaviour.|
+| `outgoingReferences` | `FamixTReference` | `referencer` | References from this entity to other entities.|
+
 ### Incoming dependencies
-- Relation: #incomingInvocations Type: #FamixTInvocation Opposite: #candidates Comment: Incoming invocations from other behaviours computed by the candidate operator.
+| Relation | Type | Opposite | Comment |
+| `incomingInvocations` | `FamixTInvocation` | `candidates` | Incoming invocations from other behaviours computed by the candidate operator.|
+
 ### Other
-- Relation: #declaredType Type: #FamixTType Opposite: #typedEntities Comment: Type of the entity, if any
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
+| Relation | Type | Opposite | Comment |
+| `declaredType` | `FamixTType` | `typedEntities` | Type of the entity, if any|
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
-- Named: #name Type: String Comment: Basic name of the entity, not full reference.
-- Named: #signature Type: String Comment: Signature of the message being sent
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
+| `name` | String | Basic name of the entity, not full reference.|
+| `signature` | String | Signature of the message being sent|
 
 "
 Class {

--- a/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1NamedEntity.class.st
+++ b/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1NamedEntity.class.st
@@ -2,7 +2,8 @@
 ## Properties
 ======================
 
-- Named: #name Type: String Comment: Basic name of the entity, not full reference.
+| Name | Type | Comment |
+| `name` | String | Basic name of the entity, not full reference.|
 
 "
 Class {

--- a/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1SourceAnchor.class.st
+++ b/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1SourceAnchor.class.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Other
-- Relation: #element Type: #FamixTSourceEntity Opposite: #sourceAnchor Comment: Enable the accessibility to the famix entity that this class is a source pointer for
+| Relation | Type | Opposite | Comment |
+| `element` | `FamixTSourceEntity` | `sourceAnchor` | Enable the accessibility to the famix entity that this class is a source pointer for|
+
 
 
 "

--- a/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1SourceLanguage.class.st
+++ b/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1SourceLanguage.class.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Other
-- Relation: #sourcedEntities Type: #FamixTWithSourceLanguages Opposite: #declaredSourceLanguage Comment: References to the entities saying explicitly that are written in this language.
+| Relation | Type | Opposite | Comment |
+| `sourcedEntities` | `FamixTWithSourceLanguages` | `declaredSourceLanguage` | References to the entities saying explicitly that are written in this language.|
+
 
 
 "

--- a/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1SourceTextAnchor.class.st
+++ b/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1SourceTextAnchor.class.st
@@ -3,12 +3,15 @@
 ======================
 
 ### Other
-- Relation: #element Type: #FamixTSourceEntity Opposite: #sourceAnchor Comment: Enable the accessibility to the famix entity that this class is a source pointer for
+| Relation | Type | Opposite | Comment |
+| `element` | `FamixTSourceEntity` | `sourceAnchor` | Enable the accessibility to the famix entity that this class is a source pointer for|
+
 
 ## Properties
 ======================
 
-- Named: #source Type: String Comment: Actual source code of the source entity
+| Name | Type | Comment |
+| `source` | String | Actual source code of the source entity|
 
 "
 Class {

--- a/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1SourcedEntity.class.st
+++ b/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1SourcedEntity.class.st
@@ -3,12 +3,15 @@
 ======================
 
 ### Other
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
+| Relation | Type | Opposite | Comment |
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
 
 "
 Class {

--- a/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1UnknownSourceLanguage.class.st
+++ b/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1UnknownSourceLanguage.class.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Other
-- Relation: #sourcedEntities Type: #FamixTWithSourceLanguages Opposite: #declaredSourceLanguage Comment: References to the entities saying explicitly that are written in this language.
+| Relation | Type | Opposite | Comment |
+| `sourcedEntities` | `FamixTWithSourceLanguages` | `declaredSourceLanguage` | References to the entities saying explicitly that are written in this language.|
+
 
 
 "

--- a/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2Class.class.st
+++ b/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2Class.class.st
@@ -3,26 +3,37 @@
 ======================
 
 ### Parents
-- Relation: #typeContainer Type: #FamixTWithTypes Opposite: #types Comment: Container entity to which this type belongs. Container is a namespace, not a package (Smalltalk).
+| Relation | Type | Opposite | Comment |
+| `typeContainer` | `FamixTWithTypes` | `types` | Container entity to which this type belongs. Container is a namespace, not a package (Smalltalk).|
+
 ### Children
-- Relation: #attributes Type: #FamixTAttribute Opposite: #parentType Comment: List of attributes declared by this type.
-- Relation: #methods Type: #FamixTMethod Opposite: #parentType Comment: Methods declared by this type.
+| Relation | Type | Opposite | Comment |
+| `attributes` | `FamixTAttribute` | `parentType` | List of attributes declared by this type.|
+| `methods` | `FamixTMethod` | `parentType` | Methods declared by this type.|
+
 ### Outgoing dependencies
-- Relation: #superInheritances Type: #FamixTInheritance Opposite: #subclass Comment: Superinheritance relationships, i.e. known superclasses of this type.
+| Relation | Type | Opposite | Comment |
+| `superInheritances` | `FamixTInheritance` | `subclass` | Superinheritance relationships, i.e. known superclasses of this type.|
+
 ### Incoming dependencies
-- Relation: #incomingReferences Type: #FamixTReference Opposite: #referredType Comment: References to this entity by other entities.
-- Relation: #subInheritances Type: #FamixTInheritance Opposite: #superclass Comment: Subinheritance relationships, i.e. known subclasses of this type.
+| Relation | Type | Opposite | Comment |
+| `incomingReferences` | `FamixTReference` | `referredType` | References to this entity by other entities.|
+| `subInheritances` | `FamixTInheritance` | `superclass` | Subinheritance relationships, i.e. known subclasses of this type.|
+
 ### Other
-- Relation: #comments Type: #FamixTComment Opposite: #commentedEntity Comment: List of comments for the entity
-- Relation: #receivingInvocations Type: #FamixTInvocation Opposite: #receiver Comment: List of invocations performed on this entity (considered as the receiver)
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
-- Relation: #typedEntities Type: #FamixTTypedEntity Opposite: #declaredType Comment: Entities that have this type as declaredType
+| Relation | Type | Opposite | Comment |
+| `comments` | `FamixTComment` | `commentedEntity` | List of comments for the entity|
+| `receivingInvocations` | `FamixTInvocation` | `receiver` | List of invocations performed on this entity (considered as the receiver)|
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+| `typedEntities` | `FamixTTypedEntity` | `declaredType` | Entities that have this type as declaredType|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
-- Named: #name Type: String Comment: Basic name of the entity, not full reference.
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
+| `name` | String | Basic name of the entity, not full reference.|
 
 "
 Class {

--- a/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2Comment.class.st
+++ b/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2Comment.class.st
@@ -3,12 +3,15 @@
 ======================
 
 ### Other
-- Relation: #commentedEntity Type: #FamixTWithComments Opposite: #comments Comment: Source code commented by the comment
+| Relation | Type | Opposite | Comment |
+| `commentedEntity` | `FamixTWithComments` | `comments` | Source code commented by the comment|
+
 
 ## Properties
 ======================
 
-- Named: #content Type: String Comment: Content of the comment as a String
+| Name | Type | Comment |
+| `content` | String | Content of the comment as a String|
 
 "
 Class {

--- a/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2Method.class.st
+++ b/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2Method.class.st
@@ -3,27 +3,38 @@
 ======================
 
 ### Parents
-- Relation: #parentType Type: #FamixTWithMethods Opposite: #methods Comment: Type declaring the method. It provides the implementation for belongsTo.
+| Relation | Type | Opposite | Comment |
+| `parentType` | `FamixTWithMethods` | `methods` | Type declaring the method. It provides the implementation for belongsTo.|
+
 ### Children
-- Relation: #implicitVariables Type: #FamixTImplicitVariable Opposite: #parentBehaviouralEntity Comment: Implicit variables used locally by this behaviour.
-- Relation: #localVariables Type: #FamixTLocalVariable Opposite: #parentBehaviouralEntity Comment: Variables locally defined by this behaviour.
-- Relation: #parameters Type: #FamixTParameter Opposite: #parentBehaviouralEntity Comment: List of formal parameters declared by this behaviour.
+| Relation | Type | Opposite | Comment |
+| `implicitVariables` | `FamixTImplicitVariable` | `parentBehaviouralEntity` | Implicit variables used locally by this behaviour.|
+| `localVariables` | `FamixTLocalVariable` | `parentBehaviouralEntity` | Variables locally defined by this behaviour.|
+| `parameters` | `FamixTParameter` | `parentBehaviouralEntity` | List of formal parameters declared by this behaviour.|
+
 ### Outgoing dependencies
-- Relation: #accesses Type: #FamixTAccess Opposite: #accessor Comment: Accesses to variables made by this behaviour.
-- Relation: #outgoingInvocations Type: #FamixTInvocation Opposite: #sender Comment: Outgoing invocations sent by this behaviour.
-- Relation: #outgoingReferences Type: #FamixTReference Opposite: #referencer Comment: References from this entity to other entities.
+| Relation | Type | Opposite | Comment |
+| `accesses` | `FamixTAccess` | `accessor` | Accesses to variables made by this behaviour.|
+| `outgoingInvocations` | `FamixTInvocation` | `sender` | Outgoing invocations sent by this behaviour.|
+| `outgoingReferences` | `FamixTReference` | `referencer` | References from this entity to other entities.|
+
 ### Incoming dependencies
-- Relation: #incomingInvocations Type: #FamixTInvocation Opposite: #candidates Comment: Incoming invocations from other behaviours computed by the candidate operator.
+| Relation | Type | Opposite | Comment |
+| `incomingInvocations` | `FamixTInvocation` | `candidates` | Incoming invocations from other behaviours computed by the candidate operator.|
+
 ### Other
-- Relation: #declaredType Type: #FamixTType Opposite: #typedEntities Comment: Type of the entity, if any
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
+| Relation | Type | Opposite | Comment |
+| `declaredType` | `FamixTType` | `typedEntities` | Type of the entity, if any|
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
-- Named: #name Type: String Comment: Basic name of the entity, not full reference.
-- Named: #signature Type: String Comment: Signature of the message being sent
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
+| `name` | String | Basic name of the entity, not full reference.|
+| `signature` | String | Signature of the message being sent|
 
 "
 Class {

--- a/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2NamedEntity.class.st
+++ b/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2NamedEntity.class.st
@@ -2,7 +2,8 @@
 ## Properties
 ======================
 
-- Named: #name Type: String Comment: Basic name of the entity, not full reference.
+| Name | Type | Comment |
+| `name` | String | Basic name of the entity, not full reference.|
 
 "
 Class {

--- a/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2SourceAnchor.class.st
+++ b/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2SourceAnchor.class.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Other
-- Relation: #element Type: #FamixTSourceEntity Opposite: #sourceAnchor Comment: Enable the accessibility to the famix entity that this class is a source pointer for
+| Relation | Type | Opposite | Comment |
+| `element` | `FamixTSourceEntity` | `sourceAnchor` | Enable the accessibility to the famix entity that this class is a source pointer for|
+
 
 
 "

--- a/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2SourceLanguage.class.st
+++ b/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2SourceLanguage.class.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Other
-- Relation: #sourcedEntities Type: #FamixTWithSourceLanguages Opposite: #declaredSourceLanguage Comment: References to the entities saying explicitly that are written in this language.
+| Relation | Type | Opposite | Comment |
+| `sourcedEntities` | `FamixTWithSourceLanguages` | `declaredSourceLanguage` | References to the entities saying explicitly that are written in this language.|
+
 
 
 "

--- a/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2SourceTextAnchor.class.st
+++ b/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2SourceTextAnchor.class.st
@@ -3,12 +3,15 @@
 ======================
 
 ### Other
-- Relation: #element Type: #FamixTSourceEntity Opposite: #sourceAnchor Comment: Enable the accessibility to the famix entity that this class is a source pointer for
+| Relation | Type | Opposite | Comment |
+| `element` | `FamixTSourceEntity` | `sourceAnchor` | Enable the accessibility to the famix entity that this class is a source pointer for|
+
 
 ## Properties
 ======================
 
-- Named: #source Type: String Comment: Actual source code of the source entity
+| Name | Type | Comment |
+| `source` | String | Actual source code of the source entity|
 
 "
 Class {

--- a/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2SourcedEntity.class.st
+++ b/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2SourcedEntity.class.st
@@ -3,12 +3,15 @@
 ======================
 
 ### Other
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
+| Relation | Type | Opposite | Comment |
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
 
 "
 Class {

--- a/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2UnknownSourceLanguage.class.st
+++ b/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2UnknownSourceLanguage.class.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Other
-- Relation: #sourcedEntities Type: #FamixTWithSourceLanguages Opposite: #declaredSourceLanguage Comment: References to the entities saying explicitly that are written in this language.
+| Relation | Type | Opposite | Comment |
+| `sourcedEntities` | `FamixTWithSourceLanguages` | `declaredSourceLanguage` | References to the entities saying explicitly that are written in this language.|
+
 
 
 "

--- a/src/Famix-Traits/FamixTAccess.trait.st
+++ b/src/Famix-Traits/FamixTAccess.trait.st
@@ -16,19 +16,26 @@ For each access in the source code, there is one famix access created even if it
 ======================
 
 ### Association source
-- Relation: #accessor Type: #FamixTWithAccesses Opposite: #accesses Comment: Behavioural entity making the access to the variable. from-side of the association
+| Relation | Type | Opposite | Comment |
+| `accessor` | `FamixTWithAccesses` | `accesses` | Behavioural entity making the access to the variable. from-side of the association|
+
 ### Association target
-- Relation: #variable Type: #FamixTAccessible Opposite: #incomingAccesses Comment: Variable accessed. to-side of the association
+| Relation | Type | Opposite | Comment |
+| `variable` | `FamixTAccessible` | `incomingAccesses` | Variable accessed. to-side of the association|
+
 ### Other
-- Relation: #next Type: #FamixTAssociation Opposite: #previous Comment: Next association in an ordered collection of associations. Currently not supported by the Moose importer
-- Relation: #previous Type: #FamixTAssociation Opposite: #next Comment: Previous association in an ordered collection of associations. Currently not supported by the Moose importer
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
+| Relation | Type | Opposite | Comment |
+| `next` | `FamixTAssociation` | `previous` | Next association in an ordered collection of associations. Currently not supported by the Moose importer|
+| `previous` | `FamixTAssociation` | `next` | Previous association in an ordered collection of associations. Currently not supported by the Moose importer|
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
-- Named: #isWrite Type: Boolean Comment: Write access
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
+| `isWrite` | Boolean | Write access|
 
 "
 Trait {

--- a/src/Famix-Traits/FamixTAccessible.trait.st
+++ b/src/Famix-Traits/FamixTAccessible.trait.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Incoming dependencies
-- Relation: #incomingAccesses Type: #FamixTAccess Opposite: #variable Comment: All Famix accesses pointing to this structural entity
+| Relation | Type | Opposite | Comment |
+| `incomingAccesses` | `FamixTAccess` | `variable` | All Famix accesses pointing to this structural entity|
+
 
 
 "

--- a/src/Famix-Traits/FamixTAnnotationInstance.trait.st
+++ b/src/Famix-Traits/FamixTAnnotationInstance.trait.st
@@ -15,7 +15,9 @@ Instance Variables:
 ======================
 
 ### Other
-- Relation: #annotatedEntity Type: #FamixTWithAnnotationInstances Opposite: #annotationInstances Comment: The NamedEntity on which the annotation occurs.
+| Relation | Type | Opposite | Comment |
+| `annotatedEntity` | `FamixTWithAnnotationInstances` | `annotationInstances` | The NamedEntity on which the annotation occurs.|
+
 
 
 "

--- a/src/Famix-Traits/FamixTAnnotationInstanceAttribute.trait.st
+++ b/src/Famix-Traits/FamixTAnnotationInstanceAttribute.trait.st
@@ -13,12 +13,15 @@ Instance Variables:
 ======================
 
 ### Parents
-- Relation: #parentAnnotationInstance Type: #FamixTWithAnnotationInstanceAttributes Opposite: #attributes Comment: The instance of the annotation in which the attribute is used.
+| Relation | Type | Opposite | Comment |
+| `parentAnnotationInstance` | `FamixTWithAnnotationInstanceAttributes` | `attributes` | The instance of the annotation in which the attribute is used.|
+
 
 ## Properties
 ======================
 
-- Named: #value Type: String Comment: Actual value of the attribute used in an annotation
+| Name | Type | Comment |
+| `value` | String | Actual value of the attribute used in an annotation|
 
 "
 Trait {

--- a/src/Famix-Traits/FamixTAnnotationType.trait.st
+++ b/src/Famix-Traits/FamixTAnnotationType.trait.st
@@ -9,9 +9,13 @@ Instance Variables:
 ======================
 
 ### Parents
-- Relation: #annotationTypesContainer Type: #FamixTWithAnnotationTypes Opposite: #definedAnnotationTypes Comment: Container in which an AnnotationType may reside
+| Relation | Type | Opposite | Comment |
+| `annotationTypesContainer` | `FamixTWithAnnotationTypes` | `definedAnnotationTypes` | Container in which an AnnotationType may reside|
+
 ### Other
-- Relation: #instances Type: #FamixTTypedAnnotationInstance Opposite: #annotationType Comment: Annotations of this type
+| Relation | Type | Opposite | Comment |
+| `instances` | `FamixTTypedAnnotationInstance` | `annotationType` | Annotations of this type|
+
 
 
 "

--- a/src/Famix-Traits/FamixTAnnotationTypeAttribute.trait.st
+++ b/src/Famix-Traits/FamixTAnnotationTypeAttribute.trait.st
@@ -20,19 +20,26 @@ Instance Variables:
 ======================
 
 ### Parents
-- Relation: #parentType Type: #FamixTWithAttributes Opposite: #attributes Comment: Type declaring the attribute. belongsTo implementation
+| Relation | Type | Opposite | Comment |
+| `parentType` | `FamixTWithAttributes` | `attributes` | Type declaring the attribute. belongsTo implementation|
+
 ### Incoming dependencies
-- Relation: #incomingAccesses Type: #FamixTAccess Opposite: #variable Comment: All Famix accesses pointing to this structural entity
+| Relation | Type | Opposite | Comment |
+| `incomingAccesses` | `FamixTAccess` | `variable` | All Famix accesses pointing to this structural entity|
+
 ### Other
-- Relation: #annotationAttributeInstances Type: #FamixTTypedAnnotationInstanceAttribute Opposite: #annotationTypeAttribute Comment: A collection of AnnotationInstanceAttribute which hold the usages of this attribute in actual AnnotationInstances
-- Relation: #declaredType Type: #FamixTType Opposite: #typedEntities Comment: Type of the entity, if any
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
+| Relation | Type | Opposite | Comment |
+| `annotationAttributeInstances` | `FamixTTypedAnnotationInstanceAttribute` | `annotationTypeAttribute` | A collection of AnnotationInstanceAttribute which hold the usages of this attribute in actual AnnotationInstances|
+| `declaredType` | `FamixTType` | `typedEntities` | Type of the entity, if any|
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
-- Named: #name Type: String Comment: Basic name of the entity, not full reference.
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
+| `name` | String | Basic name of the entity, not full reference.|
 
 "
 Trait {

--- a/src/Famix-Traits/FamixTAssociation.trait.st
+++ b/src/Famix-Traits/FamixTAssociation.trait.st
@@ -21,14 +21,17 @@ will produce two invocation associations first from method a to method b, and se
 ======================
 
 ### Other
-- Relation: #next Type: #FamixTAssociation Opposite: #previous Comment: Next association in an ordered collection of associations. Currently not supported by the Moose importer
-- Relation: #previous Type: #FamixTAssociation Opposite: #next Comment: Previous association in an ordered collection of associations. Currently not supported by the Moose importer
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
+| Relation | Type | Opposite | Comment |
+| `next` | `FamixTAssociation` | `previous` | Next association in an ordered collection of associations. Currently not supported by the Moose importer|
+| `previous` | `FamixTAssociation` | `next` | Previous association in an ordered collection of associations. Currently not supported by the Moose importer|
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
 
 "
 Trait {

--- a/src/Famix-Traits/FamixTAttribute.trait.st
+++ b/src/Famix-Traits/FamixTAttribute.trait.st
@@ -6,18 +6,25 @@ FamixTAttribute represents a field of a class. It is an attribute of the parent 
 ======================
 
 ### Parents
-- Relation: #parentType Type: #FamixTWithAttributes Opposite: #attributes Comment: Type declaring the attribute. belongsTo implementation
+| Relation | Type | Opposite | Comment |
+| `parentType` | `FamixTWithAttributes` | `attributes` | Type declaring the attribute. belongsTo implementation|
+
 ### Incoming dependencies
-- Relation: #incomingAccesses Type: #FamixTAccess Opposite: #variable Comment: All Famix accesses pointing to this structural entity
+| Relation | Type | Opposite | Comment |
+| `incomingAccesses` | `FamixTAccess` | `variable` | All Famix accesses pointing to this structural entity|
+
 ### Other
-- Relation: #declaredType Type: #FamixTType Opposite: #typedEntities Comment: Type of the entity, if any
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
+| Relation | Type | Opposite | Comment |
+| `declaredType` | `FamixTType` | `typedEntities` | Type of the entity, if any|
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
-- Named: #name Type: String Comment: Basic name of the entity, not full reference.
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
+| `name` | String | Basic name of the entity, not full reference.|
 
 "
 Trait {

--- a/src/Famix-Traits/FamixTCanBeAbstract.trait.st
+++ b/src/Famix-Traits/FamixTCanBeAbstract.trait.st
@@ -2,7 +2,8 @@
 ## Properties
 ======================
 
-- Named: #isAbstract Type: Boolean Comment: Entity can be declared abstract
+| Name | Type | Comment |
+| `isAbstract` | Boolean | Entity can be declared abstract|
 
 "
 Trait {

--- a/src/Famix-Traits/FamixTCanBeClassSide.trait.st
+++ b/src/Famix-Traits/FamixTCanBeClassSide.trait.st
@@ -2,7 +2,8 @@
 ## Properties
 ======================
 
-- Named: #isClassSide Type: Boolean Comment: Entity can be declared class side i.e. static
+| Name | Type | Comment |
+| `isClassSide` | Boolean | Entity can be declared class side i.e. static|
 
 "
 Trait {

--- a/src/Famix-Traits/FamixTCanBeFinal.trait.st
+++ b/src/Famix-Traits/FamixTCanBeFinal.trait.st
@@ -2,7 +2,8 @@
 ## Properties
 ======================
 
-- Named: #isFinal Type: Boolean Comment: Entity can be declared final
+| Name | Type | Comment |
+| `isFinal` | Boolean | Entity can be declared final|
 
 "
 Trait {

--- a/src/Famix-Traits/FamixTCanImplement.trait.st
+++ b/src/Famix-Traits/FamixTCanImplement.trait.st
@@ -5,7 +5,9 @@ I can be the source of an implementation (cf a class implementing an Interface)
 ======================
 
 ### Outgoing dependencies
-- Relation: #interfaceImplementations Type: #FamixTImplementation Opposite: #implementingClass Comment: Implementation relationships
+| Relation | Type | Opposite | Comment |
+| `interfaceImplementations` | `FamixTImplementation` | `implementingClass` | Implementation relationships|
+
 
 
 "

--- a/src/Famix-Traits/FamixTClass.trait.st
+++ b/src/Famix-Traits/FamixTClass.trait.st
@@ -9,26 +9,37 @@ A class is typically scoped in a namespace. To model nested or anonymous classes
 ======================
 
 ### Parents
-- Relation: #typeContainer Type: #FamixTWithTypes Opposite: #types Comment: Container entity to which this type belongs. Container is a namespace, not a package (Smalltalk).
+| Relation | Type | Opposite | Comment |
+| `typeContainer` | `FamixTWithTypes` | `types` | Container entity to which this type belongs. Container is a namespace, not a package (Smalltalk).|
+
 ### Children
-- Relation: #attributes Type: #FamixTAttribute Opposite: #parentType Comment: List of attributes declared by this type.
-- Relation: #methods Type: #FamixTMethod Opposite: #parentType Comment: Methods declared by this type.
+| Relation | Type | Opposite | Comment |
+| `attributes` | `FamixTAttribute` | `parentType` | List of attributes declared by this type.|
+| `methods` | `FamixTMethod` | `parentType` | Methods declared by this type.|
+
 ### Outgoing dependencies
-- Relation: #superInheritances Type: #FamixTInheritance Opposite: #subclass Comment: Superinheritance relationships, i.e. known superclasses of this type.
+| Relation | Type | Opposite | Comment |
+| `superInheritances` | `FamixTInheritance` | `subclass` | Superinheritance relationships, i.e. known superclasses of this type.|
+
 ### Incoming dependencies
-- Relation: #incomingReferences Type: #FamixTReference Opposite: #referredType Comment: References to this entity by other entities.
-- Relation: #subInheritances Type: #FamixTInheritance Opposite: #superclass Comment: Subinheritance relationships, i.e. known subclasses of this type.
+| Relation | Type | Opposite | Comment |
+| `incomingReferences` | `FamixTReference` | `referredType` | References to this entity by other entities.|
+| `subInheritances` | `FamixTInheritance` | `superclass` | Subinheritance relationships, i.e. known subclasses of this type.|
+
 ### Other
-- Relation: #comments Type: #FamixTComment Opposite: #commentedEntity Comment: List of comments for the entity
-- Relation: #receivingInvocations Type: #FamixTInvocation Opposite: #receiver Comment: List of invocations performed on this entity (considered as the receiver)
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
-- Relation: #typedEntities Type: #FamixTTypedEntity Opposite: #declaredType Comment: Entities that have this type as declaredType
+| Relation | Type | Opposite | Comment |
+| `comments` | `FamixTComment` | `commentedEntity` | List of comments for the entity|
+| `receivingInvocations` | `FamixTInvocation` | `receiver` | List of invocations performed on this entity (considered as the receiver)|
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+| `typedEntities` | `FamixTTypedEntity` | `declaredType` | Entities that have this type as declaredType|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
-- Named: #name Type: String Comment: Basic name of the entity, not full reference.
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
+| `name` | String | Basic name of the entity, not full reference.|
 
 "
 Trait {

--- a/src/Famix-Traits/FamixTClassWithVisibility.trait.st
+++ b/src/Famix-Traits/FamixTClassWithVisibility.trait.st
@@ -3,27 +3,38 @@
 ======================
 
 ### Parents
-- Relation: #typeContainer Type: #FamixTWithTypes Opposite: #types Comment: Container entity to which this type belongs. Container is a namespace, not a package (Smalltalk).
+| Relation | Type | Opposite | Comment |
+| `typeContainer` | `FamixTWithTypes` | `types` | Container entity to which this type belongs. Container is a namespace, not a package (Smalltalk).|
+
 ### Children
-- Relation: #attributes Type: #FamixTAttribute Opposite: #parentType Comment: List of attributes declared by this type.
-- Relation: #methods Type: #FamixTMethod Opposite: #parentType Comment: Methods declared by this type.
+| Relation | Type | Opposite | Comment |
+| `attributes` | `FamixTAttribute` | `parentType` | List of attributes declared by this type.|
+| `methods` | `FamixTMethod` | `parentType` | Methods declared by this type.|
+
 ### Outgoing dependencies
-- Relation: #superInheritances Type: #FamixTInheritance Opposite: #subclass Comment: Superinheritance relationships, i.e. known superclasses of this type.
+| Relation | Type | Opposite | Comment |
+| `superInheritances` | `FamixTInheritance` | `subclass` | Superinheritance relationships, i.e. known superclasses of this type.|
+
 ### Incoming dependencies
-- Relation: #incomingReferences Type: #FamixTReference Opposite: #referredType Comment: References to this entity by other entities.
-- Relation: #subInheritances Type: #FamixTInheritance Opposite: #superclass Comment: Subinheritance relationships, i.e. known subclasses of this type.
+| Relation | Type | Opposite | Comment |
+| `incomingReferences` | `FamixTReference` | `referredType` | References to this entity by other entities.|
+| `subInheritances` | `FamixTInheritance` | `superclass` | Subinheritance relationships, i.e. known subclasses of this type.|
+
 ### Other
-- Relation: #comments Type: #FamixTComment Opposite: #commentedEntity Comment: List of comments for the entity
-- Relation: #receivingInvocations Type: #FamixTInvocation Opposite: #receiver Comment: List of invocations performed on this entity (considered as the receiver)
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
-- Relation: #typedEntities Type: #FamixTTypedEntity Opposite: #declaredType Comment: Entities that have this type as declaredType
+| Relation | Type | Opposite | Comment |
+| `comments` | `FamixTComment` | `commentedEntity` | List of comments for the entity|
+| `receivingInvocations` | `FamixTInvocation` | `receiver` | List of invocations performed on this entity (considered as the receiver)|
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+| `typedEntities` | `FamixTTypedEntity` | `declaredType` | Entities that have this type as declaredType|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
-- Named: #name Type: String Comment: Basic name of the entity, not full reference.
-- Named: #visibility Type: String Comment: Visibility of the entity
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
+| `name` | String | Basic name of the entity, not full reference.|
+| `visibility` | String | Visibility of the entity|
 
 "
 Trait {

--- a/src/Famix-Traits/FamixTCohesionCouplingMetrics.trait.st
+++ b/src/Famix-Traits/FamixTCohesionCouplingMetrics.trait.st
@@ -3,15 +3,20 @@
 ======================
 
 ### Children
-- Relation: #childEntities Type: #FamixTPackageable Opposite: #parentPackage
+| Relation | Type | Opposite | Comment |
+| `childEntities` | `FamixTPackageable` | `parentPackage` | |
+
 ### Other
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
+| Relation | Type | Opposite | Comment |
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
-- Named: #name Type: String Comment: Basic name of the entity, not full reference.
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
+| `name` | String | Basic name of the entity, not full reference.|
 
 "
 Trait {

--- a/src/Famix-Traits/FamixTComment.trait.st
+++ b/src/Famix-Traits/FamixTComment.trait.st
@@ -5,12 +5,15 @@ FamixTComment represents one instance of a comment (in the sense of programming 
 ======================
 
 ### Other
-- Relation: #commentedEntity Type: #FamixTWithComments Opposite: #comments Comment: Source code commented by the comment
+| Relation | Type | Opposite | Comment |
+| `commentedEntity` | `FamixTWithComments` | `comments` | Source code commented by the comment|
+
 
 ## Properties
 ======================
 
-- Named: #content Type: String Comment: Content of the comment as a String
+| Name | Type | Comment |
+| `content` | String | Content of the comment as a String|
 
 "
 Trait {

--- a/src/Famix-Traits/FamixTCompilationUnit.trait.st
+++ b/src/Famix-Traits/FamixTCompilationUnit.trait.st
@@ -5,10 +5,14 @@ I represent a compilation unit file. Typically a .c or .cpp file
 ======================
 
 ### Parents
-- Relation: #compilationUnitOwner Type: #FamixTWithCompilationUnits Opposite: #compilationUnit Comment: The compilation unit that defines this module
-- Relation: #parentFolder Type: #FamixTFolder Opposite: #childrenFileSystemEntities Comment: Folder entity containing this file.
+| Relation | Type | Opposite | Comment |
+| `compilationUnitOwner` | `FamixTWithCompilationUnits` | `compilationUnit` | The compilation unit that defines this module|
+| `parentFolder` | `FamixTFolder` | `childrenFileSystemEntities` | Folder entity containing this file.|
+
 ### Other
-- Relation: #entities Type: #FamixTWithFiles Opposite: #containerFiles Comment: List of entities defined in the file
+| Relation | Type | Opposite | Comment |
+| `entities` | `FamixTWithFiles` | `containerFiles` | List of entities defined in the file|
+
 
 
 "

--- a/src/Famix-Traits/FamixTDefinedInModule.trait.st
+++ b/src/Famix-Traits/FamixTDefinedInModule.trait.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Parents
-- Relation: #parentModule Type: #FamixTModule Opposite: #moduleEntities Comment: Module that contains the definition of this entity
+| Relation | Type | Opposite | Comment |
+| `parentModule` | `FamixTModule` | `moduleEntities` | Module that contains the definition of this entity|
+
 
 
 "

--- a/src/Famix-Traits/FamixTDereferencedInvocation.trait.st
+++ b/src/Famix-Traits/FamixTDereferencedInvocation.trait.st
@@ -9,21 +9,28 @@ It has a referencer which is the pointer variable
 ======================
 
 ### Association source
-- Relation: #sender Type: #FamixTWithInvocations Opposite: #outgoingInvocations Comment: Behavioural entity making the call. from-side of the association
+| Relation | Type | Opposite | Comment |
+| `sender` | `FamixTWithInvocations` | `outgoingInvocations` | Behavioural entity making the call. from-side of the association|
+
 ### Association target
-- Relation: #candidates Type: #FamixTInvocable Opposite: #incomingInvocations Comment: List of candidate behavioural entities for receiving the invocation
+| Relation | Type | Opposite | Comment |
+| `candidates` | `FamixTInvocable` | `incomingInvocations` | List of candidate behavioural entities for receiving the invocation|
+
 ### Other
-- Relation: #next Type: #FamixTAssociation Opposite: #previous Comment: Next association in an ordered collection of associations. Currently not supported by the Moose importer
-- Relation: #previous Type: #FamixTAssociation Opposite: #next Comment: Previous association in an ordered collection of associations. Currently not supported by the Moose importer
-- Relation: #receiver Type: #FamixTInvocationsReceiver Opposite: #receivingInvocations Comment: Named entity (variable, class...) receiving the invocation. to-side of the association
-- Relation: #referencer Type: #FamixTWithDereferencedInvocations Opposite: #dereferencedInvocations Comment: Structural entity that references the BehaviouralEntity invoked
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
+| Relation | Type | Opposite | Comment |
+| `next` | `FamixTAssociation` | `previous` | Next association in an ordered collection of associations. Currently not supported by the Moose importer|
+| `previous` | `FamixTAssociation` | `next` | Previous association in an ordered collection of associations. Currently not supported by the Moose importer|
+| `receiver` | `FamixTInvocationsReceiver` | `receivingInvocations` | Named entity (variable, class...) receiving the invocation. to-side of the association|
+| `referencer` | `FamixTWithDereferencedInvocations` | `dereferencedInvocations` | Structural entity that references the BehaviouralEntity invoked|
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
-- Named: #signature Type: String Comment: Signature of the message being sent
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
+| `signature` | String | Signature of the message being sent|
 
 "
 Trait {

--- a/src/Famix-Traits/FamixTEnum.trait.st
+++ b/src/Famix-Traits/FamixTEnum.trait.st
@@ -15,20 +15,29 @@ Instance Variables:
 ======================
 
 ### Parents
-- Relation: #typeContainer Type: #FamixTWithTypes Opposite: #types Comment: Container entity to which this type belongs. Container is a namespace, not a package (Smalltalk).
+| Relation | Type | Opposite | Comment |
+| `typeContainer` | `FamixTWithTypes` | `types` | Container entity to which this type belongs. Container is a namespace, not a package (Smalltalk).|
+
 ### Children
-- Relation: #enumValues Type: #FamixTEnumValue Opposite: #parentEnum
+| Relation | Type | Opposite | Comment |
+| `enumValues` | `FamixTEnumValue` | `parentEnum` | |
+
 ### Incoming dependencies
-- Relation: #incomingReferences Type: #FamixTReference Opposite: #referredType Comment: References to this entity by other entities.
+| Relation | Type | Opposite | Comment |
+| `incomingReferences` | `FamixTReference` | `referredType` | References to this entity by other entities.|
+
 ### Other
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
-- Relation: #typedEntities Type: #FamixTTypedEntity Opposite: #declaredType Comment: Entities that have this type as declaredType
+| Relation | Type | Opposite | Comment |
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+| `typedEntities` | `FamixTTypedEntity` | `declaredType` | Entities that have this type as declaredType|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
-- Named: #name Type: String Comment: Basic name of the entity, not full reference.
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
+| `name` | String | Basic name of the entity, not full reference.|
 
 "
 Trait {

--- a/src/Famix-Traits/FamixTEnumValue.trait.st
+++ b/src/Famix-Traits/FamixTEnumValue.trait.st
@@ -15,18 +15,25 @@ Instance Variables:
 ======================
 
 ### Parents
-- Relation: #parentEnum Type: #FamixTWithEnumValues Opposite: #enumValues Comment: The Enum declaring this value. It offers the implementation of belongsTo
+| Relation | Type | Opposite | Comment |
+| `parentEnum` | `FamixTWithEnumValues` | `enumValues` | The Enum declaring this value. It offers the implementation of belongsTo|
+
 ### Incoming dependencies
-- Relation: #incomingAccesses Type: #FamixTAccess Opposite: #variable Comment: All Famix accesses pointing to this structural entity
+| Relation | Type | Opposite | Comment |
+| `incomingAccesses` | `FamixTAccess` | `variable` | All Famix accesses pointing to this structural entity|
+
 ### Other
-- Relation: #declaredType Type: #FamixTType Opposite: #typedEntities Comment: Type of the entity, if any
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
+| Relation | Type | Opposite | Comment |
+| `declaredType` | `FamixTType` | `typedEntities` | Type of the entity, if any|
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
-- Named: #name Type: String Comment: Basic name of the entity, not full reference.
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
+| `name` | String | Basic name of the entity, not full reference.|
 
 "
 Trait {

--- a/src/Famix-Traits/FamixTException.trait.st
+++ b/src/Famix-Traits/FamixTException.trait.st
@@ -5,29 +5,40 @@ This is the abstract representation of an Exception. It is specific to Java. It 
 ======================
 
 ### Parents
-- Relation: #typeContainer Type: #FamixTWithTypes Opposite: #types Comment: Container entity to which this type belongs. Container is a namespace, not a package (Smalltalk).
+| Relation | Type | Opposite | Comment |
+| `typeContainer` | `FamixTWithTypes` | `types` | Container entity to which this type belongs. Container is a namespace, not a package (Smalltalk).|
+
 ### Children
-- Relation: #attributes Type: #FamixTAttribute Opposite: #parentType Comment: List of attributes declared by this type.
-- Relation: #methods Type: #FamixTMethod Opposite: #parentType Comment: Methods declared by this type.
+| Relation | Type | Opposite | Comment |
+| `attributes` | `FamixTAttribute` | `parentType` | List of attributes declared by this type.|
+| `methods` | `FamixTMethod` | `parentType` | Methods declared by this type.|
+
 ### Outgoing dependencies
-- Relation: #superInheritances Type: #FamixTInheritance Opposite: #subclass Comment: Superinheritance relationships, i.e. known superclasses of this type.
+| Relation | Type | Opposite | Comment |
+| `superInheritances` | `FamixTInheritance` | `subclass` | Superinheritance relationships, i.e. known superclasses of this type.|
+
 ### Incoming dependencies
-- Relation: #incomingReferences Type: #FamixTReference Opposite: #referredType Comment: References to this entity by other entities.
-- Relation: #subInheritances Type: #FamixTInheritance Opposite: #superclass Comment: Subinheritance relationships, i.e. known subclasses of this type.
+| Relation | Type | Opposite | Comment |
+| `incomingReferences` | `FamixTReference` | `referredType` | References to this entity by other entities.|
+| `subInheritances` | `FamixTInheritance` | `superclass` | Subinheritance relationships, i.e. known subclasses of this type.|
+
 ### Other
-- Relation: #catchingEntities Type: #FamixTWithExceptions Opposite: #caughtExceptions
-- Relation: #comments Type: #FamixTComment Opposite: #commentedEntity Comment: List of comments for the entity
-- Relation: #declaringEntities Type: #FamixTWithExceptions Opposite: #declaredExceptions
-- Relation: #receivingInvocations Type: #FamixTInvocation Opposite: #receiver Comment: List of invocations performed on this entity (considered as the receiver)
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
-- Relation: #throwingEntities Type: #FamixTWithExceptions Opposite: #thrownExceptions
-- Relation: #typedEntities Type: #FamixTTypedEntity Opposite: #declaredType Comment: Entities that have this type as declaredType
+| Relation | Type | Opposite | Comment |
+| `catchingEntities` | `FamixTWithExceptions` | `caughtExceptions` | |
+| `comments` | `FamixTComment` | `commentedEntity` | List of comments for the entity|
+| `declaringEntities` | `FamixTWithExceptions` | `declaredExceptions` | |
+| `receivingInvocations` | `FamixTInvocation` | `receiver` | List of invocations performed on this entity (considered as the receiver)|
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+| `throwingEntities` | `FamixTWithExceptions` | `thrownExceptions` | |
+| `typedEntities` | `FamixTTypedEntity` | `declaredType` | Entities that have this type as declaredType|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
-- Named: #name Type: String Comment: Basic name of the entity, not full reference.
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
+| `name` | String | Basic name of the entity, not full reference.|
 
 "
 Trait {

--- a/src/Famix-Traits/FamixTFile.trait.st
+++ b/src/Famix-Traits/FamixTFile.trait.st
@@ -5,9 +5,13 @@ It represents a file in the file system.
 ======================
 
 ### Parents
-- Relation: #parentFolder Type: #FamixTFolder Opposite: #childrenFileSystemEntities Comment: Folder entity containing this file.
+| Relation | Type | Opposite | Comment |
+| `parentFolder` | `FamixTFolder` | `childrenFileSystemEntities` | Folder entity containing this file.|
+
 ### Other
-- Relation: #entities Type: #FamixTWithFiles Opposite: #containerFiles Comment: List of entities defined in the file
+| Relation | Type | Opposite | Comment |
+| `entities` | `FamixTWithFiles` | `containerFiles` | List of entities defined in the file|
+
 
 
 "

--- a/src/Famix-Traits/FamixTFileAnchor.trait.st
+++ b/src/Famix-Traits/FamixTFileAnchor.trait.st
@@ -4,9 +4,10 @@ This offers a source anchor that connects a sourced entity to a file through a r
 ## Properties
 ======================
 
-- Named: #correspondingFile Type: FamixTFile Comment: File associated to this source anchor
-- Named: #encoding Type: String Comment: A string representing the encoding of a file
-- Named: #fileName Type: String Comment: Name of the source file
+| Name | Type | Comment |
+| `correspondingFile` | FamixTFile | File associated to this source anchor|
+| `encoding` | String | A string representing the encoding of a file|
+| `fileName` | String | Name of the source file|
 
 "
 Trait {

--- a/src/Famix-Traits/FamixTFileInclude.trait.st
+++ b/src/Famix-Traits/FamixTFileInclude.trait.st
@@ -3,16 +3,19 @@
 ======================
 
 ### Other
-- Relation: #next Type: #FamixTAssociation Opposite: #previous Comment: Next association in an ordered collection of associations. Currently not supported by the Moose importer
-- Relation: #previous Type: #FamixTAssociation Opposite: #next Comment: Previous association in an ordered collection of associations. Currently not supported by the Moose importer
-- Relation: #source Type: #FamixTWithFileIncludes Opposite: #outgoingIncludeRelations Comment: The file that is including
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
-- Relation: #target Type: #FamixTWithFileIncludes Opposite: #incomingIncludeRelations Comment: The file that is included
+| Relation | Type | Opposite | Comment |
+| `next` | `FamixTAssociation` | `previous` | Next association in an ordered collection of associations. Currently not supported by the Moose importer|
+| `previous` | `FamixTAssociation` | `next` | Previous association in an ordered collection of associations. Currently not supported by the Moose importer|
+| `source` | `FamixTWithFileIncludes` | `outgoingIncludeRelations` | The file that is including|
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+| `target` | `FamixTWithFileIncludes` | `incomingIncludeRelations` | The file that is included|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
 
 "
 Trait {

--- a/src/Famix-Traits/FamixTFileNavigation.trait.st
+++ b/src/Famix-Traits/FamixTFileNavigation.trait.st
@@ -2,13 +2,14 @@
 ## Properties
 ======================
 
-- Named: #correspondingFile Type: FamixTFile Comment: File associated to this source anchor
-- Named: #encoding Type: String Comment: A string representing the encoding of a file
-- Named: #endColumn Type: Number Comment: Number of the end column
-- Named: #endLine Type: Number Comment: Number of the end line
-- Named: #fileName Type: String Comment: Name of the source file
-- Named: #startColumn Type: Number Comment: Number of the start column
-- Named: #startLine Type: Number Comment: Number of the start line
+| Name | Type | Comment |
+| `correspondingFile` | FamixTFile | File associated to this source anchor|
+| `encoding` | String | A string representing the encoding of a file|
+| `endColumn` | Number | Number of the end column|
+| `endLine` | Number | Number of the end line|
+| `fileName` | String | Name of the source file|
+| `startColumn` | Number | Number of the start column|
+| `startLine` | Number | Number of the start line|
 
 "
 Trait {

--- a/src/Famix-Traits/FamixTFileSystemEntity.trait.st
+++ b/src/Famix-Traits/FamixTFileSystemEntity.trait.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Parents
-- Relation: #parentFolder Type: #FamixTFolder Opposite: #childrenFileSystemEntities Comment: Folder entity containing this file.
+| Relation | Type | Opposite | Comment |
+| `parentFolder` | `FamixTFolder` | `childrenFileSystemEntities` | Folder entity containing this file.|
+
 
 
 "

--- a/src/Famix-Traits/FamixTFolder.trait.st
+++ b/src/Famix-Traits/FamixTFolder.trait.st
@@ -5,9 +5,13 @@ It represents a folder in the file system. It can contain other files or folders
 ======================
 
 ### Parents
-- Relation: #parentFolder Type: #FamixTFolder Opposite: #childrenFileSystemEntities Comment: Folder entity containing this file.
+| Relation | Type | Opposite | Comment |
+| `parentFolder` | `FamixTFolder` | `childrenFileSystemEntities` | Folder entity containing this file.|
+
 ### Children
-- Relation: #childrenFileSystemEntities Type: #FamixTFileSystemEntity Opposite: #parentFolder Comment: List of entities contained in this folder.
+| Relation | Type | Opposite | Comment |
+| `childrenFileSystemEntities` | `FamixTFileSystemEntity` | `parentFolder` | List of entities contained in this folder.|
+
 
 
 "

--- a/src/Famix-Traits/FamixTFunction.trait.st
+++ b/src/Famix-Traits/FamixTFunction.trait.st
@@ -5,24 +5,33 @@ FamixTFunction represents a behavioural entity in a procedural language.
 ======================
 
 ### Parents
-- Relation: #functionOwner Type: #FamixTWithFunctions Opposite: #functions Comment: The container defining the function. The function is placed in a container, because certain languages can nest functions in functions.
+| Relation | Type | Opposite | Comment |
+| `functionOwner` | `FamixTWithFunctions` | `functions` | The container defining the function. The function is placed in a container, because certain languages can nest functions in functions.|
+
 ### Children
-- Relation: #localVariables Type: #FamixTLocalVariable Opposite: #parentBehaviouralEntity Comment: Variables locally defined by this behaviour.
-- Relation: #parameters Type: #FamixTParameter Opposite: #parentBehaviouralEntity Comment: List of formal parameters declared by this behaviour.
+| Relation | Type | Opposite | Comment |
+| `localVariables` | `FamixTLocalVariable` | `parentBehaviouralEntity` | Variables locally defined by this behaviour.|
+| `parameters` | `FamixTParameter` | `parentBehaviouralEntity` | List of formal parameters declared by this behaviour.|
+
 ### Outgoing dependencies
-- Relation: #accesses Type: #FamixTAccess Opposite: #accessor Comment: Accesses to variables made by this behaviour.
-- Relation: #outgoingInvocations Type: #FamixTInvocation Opposite: #sender Comment: Outgoing invocations sent by this behaviour.
-- Relation: #outgoingReferences Type: #FamixTReference Opposite: #referencer Comment: References from this entity to other entities.
+| Relation | Type | Opposite | Comment |
+| `accesses` | `FamixTAccess` | `accessor` | Accesses to variables made by this behaviour.|
+| `outgoingInvocations` | `FamixTInvocation` | `sender` | Outgoing invocations sent by this behaviour.|
+| `outgoingReferences` | `FamixTReference` | `referencer` | References from this entity to other entities.|
+
 ### Other
-- Relation: #declaredType Type: #FamixTType Opposite: #typedEntities Comment: Type of the entity, if any
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
+| Relation | Type | Opposite | Comment |
+| `declaredType` | `FamixTType` | `typedEntities` | Type of the entity, if any|
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
-- Named: #name Type: String Comment: Basic name of the entity, not full reference.
-- Named: #signature Type: String Comment: Signature of the message being sent
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
+| `name` | String | Basic name of the entity, not full reference.|
+| `signature` | String | Signature of the message being sent|
 
 "
 Trait {

--- a/src/Famix-Traits/FamixTGlobalVariable.trait.st
+++ b/src/Famix-Traits/FamixTGlobalVariable.trait.st
@@ -6,18 +6,25 @@ FamixTGlobalVariable represents a global variable in the source code.
 ======================
 
 ### Parents
-- Relation: #parentScope Type: #FamixTWithGlobalVariables Opposite: #globalVariables Comment: Scope declaring the global variable. belongsTo implementation
+| Relation | Type | Opposite | Comment |
+| `parentScope` | `FamixTWithGlobalVariables` | `globalVariables` | Scope declaring the global variable. belongsTo implementation|
+
 ### Incoming dependencies
-- Relation: #incomingAccesses Type: #FamixTAccess Opposite: #variable Comment: All Famix accesses pointing to this structural entity
+| Relation | Type | Opposite | Comment |
+| `incomingAccesses` | `FamixTAccess` | `variable` | All Famix accesses pointing to this structural entity|
+
 ### Other
-- Relation: #declaredType Type: #FamixTType Opposite: #typedEntities Comment: Type of the entity, if any
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
+| Relation | Type | Opposite | Comment |
+| `declaredType` | `FamixTType` | `typedEntities` | Type of the entity, if any|
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
-- Named: #name Type: String Comment: Basic name of the entity, not full reference.
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
+| `name` | String | Basic name of the entity, not full reference.|
 
 "
 Trait {

--- a/src/Famix-Traits/FamixTHasImmediateSource.trait.st
+++ b/src/Famix-Traits/FamixTHasImmediateSource.trait.st
@@ -5,12 +5,15 @@ An immediate source is the source code of the entity stored directly into its so
 ======================
 
 ### Other
-- Relation: #element Type: #FamixTSourceEntity Opposite: #sourceAnchor Comment: Enable the accessibility to the famix entity that this class is a source pointer for
+| Relation | Type | Opposite | Comment |
+| `element` | `FamixTSourceEntity` | `sourceAnchor` | Enable the accessibility to the famix entity that this class is a source pointer for|
+
 
 ## Properties
 ======================
 
-- Named: #source Type: String Comment: Actual source code of the source entity
+| Name | Type | Comment |
+| `source` | String | Actual source code of the source entity|
 
 "
 Trait {

--- a/src/Famix-Traits/FamixTHasKind.trait.st
+++ b/src/Famix-Traits/FamixTHasKind.trait.st
@@ -4,7 +4,8 @@ This is an indicator that a method is a setter, getter, constant, or constructor
 ## Properties
 ======================
 
-- Named: #kind Type: String Comment: Tag indicating a setter, getter, constant, constructor method
+| Name | Type | Comment |
+| `kind` | String | Tag indicating a setter, getter, constant, constructor method|
 
 "
 Trait {

--- a/src/Famix-Traits/FamixTHasSignature.trait.st
+++ b/src/Famix-Traits/FamixTHasSignature.trait.st
@@ -4,7 +4,8 @@ The signature of any behavioural entity
 ## Properties
 ======================
 
-- Named: #signature Type: String Comment: Signature of the message being sent
+| Name | Type | Comment |
+| `signature` | String | Signature of the message being sent|
 
 "
 Trait {

--- a/src/Famix-Traits/FamixTHasVisibility.trait.st
+++ b/src/Famix-Traits/FamixTHasVisibility.trait.st
@@ -2,7 +2,8 @@
 ## Properties
 ======================
 
-- Named: #visibility Type: String Comment: Visibility of the entity
+| Name | Type | Comment |
+| `visibility` | String | Visibility of the entity|
 
 "
 Trait {

--- a/src/Famix-Traits/FamixTHeader.trait.st
+++ b/src/Famix-Traits/FamixTHeader.trait.st
@@ -5,10 +5,14 @@ I represent a header file. Typically a .h or .hpp
 ======================
 
 ### Parents
-- Relation: #headerOwner Type: #FamixTWithHeaders Opposite: #header
-- Relation: #parentFolder Type: #FamixTFolder Opposite: #childrenFileSystemEntities Comment: Folder entity containing this file.
+| Relation | Type | Opposite | Comment |
+| `headerOwner` | `FamixTWithHeaders` | `header` | |
+| `parentFolder` | `FamixTFolder` | `childrenFileSystemEntities` | Folder entity containing this file.|
+
 ### Other
-- Relation: #entities Type: #FamixTWithFiles Opposite: #containerFiles Comment: List of entities defined in the file
+| Relation | Type | Opposite | Comment |
+| `entities` | `FamixTWithFiles` | `containerFiles` | List of entities defined in the file|
+
 
 
 "

--- a/src/Famix-Traits/FamixTImplementable.trait.st
+++ b/src/Famix-Traits/FamixTImplementable.trait.st
@@ -5,7 +5,9 @@ I can be the target of an implementation cf Interface
 ======================
 
 ### Incoming dependencies
-- Relation: #implementations Type: #FamixTImplementation Opposite: #interface Comment: Implementation relationships.
+| Relation | Type | Opposite | Comment |
+| `implementations` | `FamixTImplementation` | `interface` | Implementation relationships.|
+
 
 
 "

--- a/src/Famix-Traits/FamixTImplementation.trait.st
+++ b/src/Famix-Traits/FamixTImplementation.trait.st
@@ -3,18 +3,25 @@
 ======================
 
 ### Association source
-- Relation: #implementingClass Type: #FamixTCanImplement Opposite: #interfaceImplementations Comment: Class linked to in this relationship. from-side of the association
+| Relation | Type | Opposite | Comment |
+| `implementingClass` | `FamixTCanImplement` | `interfaceImplementations` | Class linked to in this relationship. from-side of the association|
+
 ### Association target
-- Relation: #interface Type: #FamixTImplementable Opposite: #implementations Comment: Interface linked to in this relationship. to-side of the association
+| Relation | Type | Opposite | Comment |
+| `interface` | `FamixTImplementable` | `implementations` | Interface linked to in this relationship. to-side of the association|
+
 ### Other
-- Relation: #next Type: #FamixTAssociation Opposite: #previous Comment: Next association in an ordered collection of associations. Currently not supported by the Moose importer
-- Relation: #previous Type: #FamixTAssociation Opposite: #next Comment: Previous association in an ordered collection of associations. Currently not supported by the Moose importer
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
+| Relation | Type | Opposite | Comment |
+| `next` | `FamixTAssociation` | `previous` | Next association in an ordered collection of associations. Currently not supported by the Moose importer|
+| `previous` | `FamixTAssociation` | `next` | Previous association in an ordered collection of associations. Currently not supported by the Moose importer|
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
 
 "
 Trait {

--- a/src/Famix-Traits/FamixTImplicitVariable.trait.st
+++ b/src/Famix-Traits/FamixTImplicitVariable.trait.st
@@ -5,18 +5,25 @@ FamixTImplicitVariable represents a variable defined by the compiler in a contex
 ======================
 
 ### Parents
-- Relation: #parentBehaviouralEntity Type: #FamixTWithImplicitVariables Opposite: #implicitVariables Comment: The behaviour containing this implicit variable. belongsTo implementation
+| Relation | Type | Opposite | Comment |
+| `parentBehaviouralEntity` | `FamixTWithImplicitVariables` | `implicitVariables` | The behaviour containing this implicit variable. belongsTo implementation|
+
 ### Incoming dependencies
-- Relation: #incomingAccesses Type: #FamixTAccess Opposite: #variable Comment: All Famix accesses pointing to this structural entity
+| Relation | Type | Opposite | Comment |
+| `incomingAccesses` | `FamixTAccess` | `variable` | All Famix accesses pointing to this structural entity|
+
 ### Other
-- Relation: #declaredType Type: #FamixTType Opposite: #typedEntities Comment: Type of the entity, if any
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
+| Relation | Type | Opposite | Comment |
+| `declaredType` | `FamixTType` | `typedEntities` | Type of the entity, if any|
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
-- Named: #name Type: String Comment: Basic name of the entity, not full reference.
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
+| `name` | String | Basic name of the entity, not full reference.|
 
 "
 Trait {

--- a/src/Famix-Traits/FamixTImport.trait.st
+++ b/src/Famix-Traits/FamixTImport.trait.st
@@ -3,18 +3,25 @@
 ======================
 
 ### Association source
-- Relation: #importingEntity Type: #FamixTWithImports Opposite: #outgoingImports Comment: Importing entity
+| Relation | Type | Opposite | Comment |
+| `importingEntity` | `FamixTWithImports` | `outgoingImports` | Importing entity|
+
 ### Association target
-- Relation: #importedEntity Type: #FamixTImportable Opposite: #incomingImports Comment: Imported entity
+| Relation | Type | Opposite | Comment |
+| `importedEntity` | `FamixTImportable` | `incomingImports` | Imported entity|
+
 ### Other
-- Relation: #next Type: #FamixTAssociation Opposite: #previous Comment: Next association in an ordered collection of associations. Currently not supported by the Moose importer
-- Relation: #previous Type: #FamixTAssociation Opposite: #next Comment: Previous association in an ordered collection of associations. Currently not supported by the Moose importer
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
+| Relation | Type | Opposite | Comment |
+| `next` | `FamixTAssociation` | `previous` | Next association in an ordered collection of associations. Currently not supported by the Moose importer|
+| `previous` | `FamixTAssociation` | `next` | Previous association in an ordered collection of associations. Currently not supported by the Moose importer|
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
 
 "
 Trait {

--- a/src/Famix-Traits/FamixTImportable.trait.st
+++ b/src/Famix-Traits/FamixTImportable.trait.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Incoming dependencies
-- Relation: #incomingImports Type: #FamixTImport Opposite: #importedEntity Comment: List of imports of this entity
+| Relation | Type | Opposite | Comment |
+| `incomingImports` | `FamixTImport` | `importedEntity` | List of imports of this entity|
+
 
 
 "

--- a/src/Famix-Traits/FamixTIndexedFileNavigation.trait.st
+++ b/src/Famix-Traits/FamixTIndexedFileNavigation.trait.st
@@ -2,11 +2,12 @@
 ## Properties
 ======================
 
-- Named: #correspondingFile Type: FamixTFile Comment: File associated to this source anchor
-- Named: #encoding Type: String Comment: A string representing the encoding of a file
-- Named: #endPos Type: Number Comment: Stop position in the source
-- Named: #fileName Type: String Comment: Name of the source file
-- Named: #startPos Type: Number Comment: Start position in the source
+| Name | Type | Comment |
+| `correspondingFile` | FamixTFile | File associated to this source anchor|
+| `encoding` | String | A string representing the encoding of a file|
+| `endPos` | Number | Stop position in the source|
+| `fileName` | String | Name of the source file|
+| `startPos` | Number | Start position in the source|
 
 "
 Trait {

--- a/src/Famix-Traits/FamixTInheritance.trait.st
+++ b/src/Famix-Traits/FamixTInheritance.trait.st
@@ -3,18 +3,25 @@
 ======================
 
 ### Association source
-- Relation: #subclass Type: #FamixTWithInheritances Opposite: #superInheritances Comment: Subclass linked to in this relationship. from-side of the association
+| Relation | Type | Opposite | Comment |
+| `subclass` | `FamixTWithInheritances` | `superInheritances` | Subclass linked to in this relationship. from-side of the association|
+
 ### Association target
-- Relation: #superclass Type: #FamixTWithInheritances Opposite: #subInheritances Comment: Superclass linked to in this relationship. to-side of the association
+| Relation | Type | Opposite | Comment |
+| `superclass` | `FamixTWithInheritances` | `subInheritances` | Superclass linked to in this relationship. to-side of the association|
+
 ### Other
-- Relation: #next Type: #FamixTAssociation Opposite: #previous Comment: Next association in an ordered collection of associations. Currently not supported by the Moose importer
-- Relation: #previous Type: #FamixTAssociation Opposite: #next Comment: Previous association in an ordered collection of associations. Currently not supported by the Moose importer
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
+| Relation | Type | Opposite | Comment |
+| `next` | `FamixTAssociation` | `previous` | Next association in an ordered collection of associations. Currently not supported by the Moose importer|
+| `previous` | `FamixTAssociation` | `next` | Previous association in an ordered collection of associations. Currently not supported by the Moose importer|
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
 
 "
 Trait {

--- a/src/Famix-Traits/FamixTInvocable.trait.st
+++ b/src/Famix-Traits/FamixTInvocable.trait.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Incoming dependencies
-- Relation: #incomingInvocations Type: #FamixTInvocation Opposite: #candidates Comment: Incoming invocations from other behaviours computed by the candidate operator.
+| Relation | Type | Opposite | Comment |
+| `incomingInvocations` | `FamixTInvocation` | `candidates` | Incoming invocations from other behaviours computed by the candidate operator.|
+
 
 
 "

--- a/src/Famix-Traits/FamixTInvocation.trait.st
+++ b/src/Famix-Traits/FamixTInvocation.trait.st
@@ -14,20 +14,27 @@ will produce one invocation association from current method to a variable anObje
 ======================
 
 ### Association source
-- Relation: #sender Type: #FamixTWithInvocations Opposite: #outgoingInvocations Comment: Behavioural entity making the call. from-side of the association
+| Relation | Type | Opposite | Comment |
+| `sender` | `FamixTWithInvocations` | `outgoingInvocations` | Behavioural entity making the call. from-side of the association|
+
 ### Association target
-- Relation: #candidates Type: #FamixTInvocable Opposite: #incomingInvocations Comment: List of candidate behavioural entities for receiving the invocation
+| Relation | Type | Opposite | Comment |
+| `candidates` | `FamixTInvocable` | `incomingInvocations` | List of candidate behavioural entities for receiving the invocation|
+
 ### Other
-- Relation: #next Type: #FamixTAssociation Opposite: #previous Comment: Next association in an ordered collection of associations. Currently not supported by the Moose importer
-- Relation: #previous Type: #FamixTAssociation Opposite: #next Comment: Previous association in an ordered collection of associations. Currently not supported by the Moose importer
-- Relation: #receiver Type: #FamixTInvocationsReceiver Opposite: #receivingInvocations Comment: Named entity (variable, class...) receiving the invocation. to-side of the association
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
+| Relation | Type | Opposite | Comment |
+| `next` | `FamixTAssociation` | `previous` | Next association in an ordered collection of associations. Currently not supported by the Moose importer|
+| `previous` | `FamixTAssociation` | `next` | Previous association in an ordered collection of associations. Currently not supported by the Moose importer|
+| `receiver` | `FamixTInvocationsReceiver` | `receivingInvocations` | Named entity (variable, class...) receiving the invocation. to-side of the association|
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
-- Named: #signature Type: String Comment: Signature of the message being sent
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
+| `signature` | String | Signature of the message being sent|
 
 "
 Trait {

--- a/src/Famix-Traits/FamixTInvocationsReceiver.trait.st
+++ b/src/Famix-Traits/FamixTInvocationsReceiver.trait.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Other
-- Relation: #receivingInvocations Type: #FamixTInvocation Opposite: #receiver Comment: List of invocations performed on this entity (considered as the receiver)
+| Relation | Type | Opposite | Comment |
+| `receivingInvocations` | `FamixTInvocation` | `receiver` | List of invocations performed on this entity (considered as the receiver)|
+
 
 
 "

--- a/src/Famix-Traits/FamixTLocalVariable.trait.st
+++ b/src/Famix-Traits/FamixTLocalVariable.trait.st
@@ -5,18 +5,25 @@ FamixTLocalVariable represents a local variable in the scope of a behavioural en
 ======================
 
 ### Parents
-- Relation: #parentBehaviouralEntity Type: #FamixTWithLocalVariables Opposite: #localVariables Comment: Behavioural entity declaring this local variable. belongsTo implementation
+| Relation | Type | Opposite | Comment |
+| `parentBehaviouralEntity` | `FamixTWithLocalVariables` | `localVariables` | Behavioural entity declaring this local variable. belongsTo implementation|
+
 ### Incoming dependencies
-- Relation: #incomingAccesses Type: #FamixTAccess Opposite: #variable Comment: All Famix accesses pointing to this structural entity
+| Relation | Type | Opposite | Comment |
+| `incomingAccesses` | `FamixTAccess` | `variable` | All Famix accesses pointing to this structural entity|
+
 ### Other
-- Relation: #declaredType Type: #FamixTType Opposite: #typedEntities Comment: Type of the entity, if any
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
+| Relation | Type | Opposite | Comment |
+| `declaredType` | `FamixTType` | `typedEntities` | Type of the entity, if any|
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
-- Named: #name Type: String Comment: Basic name of the entity, not full reference.
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
+| `name` | String | Basic name of the entity, not full reference.|
 
 "
 Trait {

--- a/src/Famix-Traits/FamixTMethod.trait.st
+++ b/src/Famix-Traits/FamixTMethod.trait.st
@@ -7,27 +7,38 @@ A FamixTMethod is always contained in a parentType.
 ======================
 
 ### Parents
-- Relation: #parentType Type: #FamixTWithMethods Opposite: #methods Comment: Type declaring the method. It provides the implementation for belongsTo.
+| Relation | Type | Opposite | Comment |
+| `parentType` | `FamixTWithMethods` | `methods` | Type declaring the method. It provides the implementation for belongsTo.|
+
 ### Children
-- Relation: #implicitVariables Type: #FamixTImplicitVariable Opposite: #parentBehaviouralEntity Comment: Implicit variables used locally by this behaviour.
-- Relation: #localVariables Type: #FamixTLocalVariable Opposite: #parentBehaviouralEntity Comment: Variables locally defined by this behaviour.
-- Relation: #parameters Type: #FamixTParameter Opposite: #parentBehaviouralEntity Comment: List of formal parameters declared by this behaviour.
+| Relation | Type | Opposite | Comment |
+| `implicitVariables` | `FamixTImplicitVariable` | `parentBehaviouralEntity` | Implicit variables used locally by this behaviour.|
+| `localVariables` | `FamixTLocalVariable` | `parentBehaviouralEntity` | Variables locally defined by this behaviour.|
+| `parameters` | `FamixTParameter` | `parentBehaviouralEntity` | List of formal parameters declared by this behaviour.|
+
 ### Outgoing dependencies
-- Relation: #accesses Type: #FamixTAccess Opposite: #accessor Comment: Accesses to variables made by this behaviour.
-- Relation: #outgoingInvocations Type: #FamixTInvocation Opposite: #sender Comment: Outgoing invocations sent by this behaviour.
-- Relation: #outgoingReferences Type: #FamixTReference Opposite: #referencer Comment: References from this entity to other entities.
+| Relation | Type | Opposite | Comment |
+| `accesses` | `FamixTAccess` | `accessor` | Accesses to variables made by this behaviour.|
+| `outgoingInvocations` | `FamixTInvocation` | `sender` | Outgoing invocations sent by this behaviour.|
+| `outgoingReferences` | `FamixTReference` | `referencer` | References from this entity to other entities.|
+
 ### Incoming dependencies
-- Relation: #incomingInvocations Type: #FamixTInvocation Opposite: #candidates Comment: Incoming invocations from other behaviours computed by the candidate operator.
+| Relation | Type | Opposite | Comment |
+| `incomingInvocations` | `FamixTInvocation` | `candidates` | Incoming invocations from other behaviours computed by the candidate operator.|
+
 ### Other
-- Relation: #declaredType Type: #FamixTType Opposite: #typedEntities Comment: Type of the entity, if any
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
+| Relation | Type | Opposite | Comment |
+| `declaredType` | `FamixTType` | `typedEntities` | Type of the entity, if any|
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
-- Named: #name Type: String Comment: Basic name of the entity, not full reference.
-- Named: #signature Type: String Comment: Signature of the message being sent
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
+| `name` | String | Basic name of the entity, not full reference.|
+| `signature` | String | Signature of the message being sent|
 
 "
 Trait {

--- a/src/Famix-Traits/FamixTModule.trait.st
+++ b/src/Famix-Traits/FamixTModule.trait.st
@@ -6,7 +6,9 @@ FamixTModule represents a that basically provides a simple scoping abstraction f
 ======================
 
 ### Children
-- Relation: #moduleEntities Type: #FamixTDefinedInModule Opposite: #parentModule
+| Relation | Type | Opposite | Comment |
+| `moduleEntities` | `FamixTDefinedInModule` | `parentModule` | |
+
 
 
 "

--- a/src/Famix-Traits/FamixTMultipleFileAnchor.trait.st
+++ b/src/Famix-Traits/FamixTMultipleFileAnchor.trait.st
@@ -3,12 +3,15 @@
 ======================
 
 ### Other
-- Relation: #element Type: #FamixTSourceEntity Opposite: #sourceAnchor Comment: Enable the accessibility to the famix entity that this class is a source pointer for
+| Relation | Type | Opposite | Comment |
+| `element` | `FamixTSourceEntity` | `sourceAnchor` | Enable the accessibility to the famix entity that this class is a source pointer for|
+
 
 ## Properties
 ======================
 
-- Named: #fileAnchors Type: FamixTFileAnchor Comment: All source code definition files
+| Name | Type | Comment |
+| `fileAnchors` | FamixTFileAnchor | All source code definition files|
 
 "
 Trait {

--- a/src/Famix-Traits/FamixTNamedEntity.trait.st
+++ b/src/Famix-Traits/FamixTNamedEntity.trait.st
@@ -2,7 +2,8 @@
 ## Properties
 ======================
 
-- Named: #name Type: String Comment: Basic name of the entity, not full reference.
+| Name | Type | Comment |
+| `name` | String | Basic name of the entity, not full reference.|
 
 "
 Trait {

--- a/src/Famix-Traits/FamixTNamespace.trait.st
+++ b/src/Famix-Traits/FamixTNamespace.trait.st
@@ -9,13 +9,16 @@ When an entity is placed inside a namespace, the fully qualified name (mooseName
 ======================
 
 ### Other
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
+| Relation | Type | Opposite | Comment |
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
-- Named: #name Type: String Comment: Basic name of the entity, not full reference.
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
+| `name` | String | Basic name of the entity, not full reference.|
 
 "
 Trait {

--- a/src/Famix-Traits/FamixTPackage.trait.st
+++ b/src/Famix-Traits/FamixTPackage.trait.st
@@ -7,15 +7,20 @@ Java extractors map Java packages to FamixTNamespaces. They can also mirror the 
 ======================
 
 ### Children
-- Relation: #childEntities Type: #FamixTPackageable Opposite: #parentPackage
+| Relation | Type | Opposite | Comment |
+| `childEntities` | `FamixTPackageable` | `parentPackage` | |
+
 ### Other
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
+| Relation | Type | Opposite | Comment |
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
-- Named: #name Type: String Comment: Basic name of the entity, not full reference.
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
+| `name` | String | Basic name of the entity, not full reference.|
 
 "
 Trait {

--- a/src/Famix-Traits/FamixTPackageable.trait.st
+++ b/src/Famix-Traits/FamixTPackageable.trait.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Parents
-- Relation: #parentPackage Type: #FamixTPackage Opposite: #childEntities Comment: Package containing the entity in the code structure (if applicable)
+| Relation | Type | Opposite | Comment |
+| `parentPackage` | `FamixTPackage` | `childEntities` | Package containing the entity in the code structure (if applicable)|
+
 
 
 "

--- a/src/Famix-Traits/FamixTParameter.trait.st
+++ b/src/Famix-Traits/FamixTParameter.trait.st
@@ -15,18 +15,25 @@ int addNumbers(int a, int b) {
 ======================
 
 ### Parents
-- Relation: #parentBehaviouralEntity Type: #FamixTWithParameters Opposite: #parameters Comment: Behavioural entity containing this parameter. belongsTo implementation
+| Relation | Type | Opposite | Comment |
+| `parentBehaviouralEntity` | `FamixTWithParameters` | `parameters` | Behavioural entity containing this parameter. belongsTo implementation|
+
 ### Incoming dependencies
-- Relation: #incomingAccesses Type: #FamixTAccess Opposite: #variable Comment: All Famix accesses pointing to this structural entity
+| Relation | Type | Opposite | Comment |
+| `incomingAccesses` | `FamixTAccess` | `variable` | All Famix accesses pointing to this structural entity|
+
 ### Other
-- Relation: #declaredType Type: #FamixTType Opposite: #typedEntities Comment: Type of the entity, if any
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
+| Relation | Type | Opposite | Comment |
+| `declaredType` | `FamixTType` | `typedEntities` | Type of the entity, if any|
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
-- Named: #name Type: String Comment: Basic name of the entity, not full reference.
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
+| `name` | String | Basic name of the entity, not full reference.|
 
 "
 Trait {

--- a/src/Famix-Traits/FamixTParameterizedType.trait.st
+++ b/src/Famix-Traits/FamixTParameterizedType.trait.st
@@ -12,7 +12,9 @@ Where Map<String,Collection> is the FamixTParameterizedType of anAttribute. Stri
 ======================
 
 ### Other
-- Relation: #parameterizableClass Type: #FamixTWithParameterizedTypes Opposite: #parameterizedTypes Comment: Base type of this parameterized type.
+| Relation | Type | Opposite | Comment |
+| `parameterizableClass` | `FamixTWithParameterizedTypes` | `parameterizedTypes` | Base type of this parameterized type.|
+
 
 
 "

--- a/src/Famix-Traits/FamixTParameterizedTypeUser.trait.st
+++ b/src/Famix-Traits/FamixTParameterizedTypeUser.trait.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Other
-- Relation: #argumentsInParameterizedTypes Type: #FamixTWithParameterizedTypeUsers Opposite: #arguments
+| Relation | Type | Opposite | Comment |
+| `argumentsInParameterizedTypes` | `FamixTWithParameterizedTypeUsers` | `arguments` | |
+
 
 
 "

--- a/src/Famix-Traits/FamixTPrimitiveType.trait.st
+++ b/src/Famix-Traits/FamixTPrimitiveType.trait.st
@@ -3,18 +3,25 @@
 ======================
 
 ### Parents
-- Relation: #typeContainer Type: #FamixTWithTypes Opposite: #types Comment: Container entity to which this type belongs. Container is a namespace, not a package (Smalltalk).
+| Relation | Type | Opposite | Comment |
+| `typeContainer` | `FamixTWithTypes` | `types` | Container entity to which this type belongs. Container is a namespace, not a package (Smalltalk).|
+
 ### Incoming dependencies
-- Relation: #incomingReferences Type: #FamixTReference Opposite: #referredType Comment: References to this entity by other entities.
+| Relation | Type | Opposite | Comment |
+| `incomingReferences` | `FamixTReference` | `referredType` | References to this entity by other entities.|
+
 ### Other
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
-- Relation: #typedEntities Type: #FamixTTypedEntity Opposite: #declaredType Comment: Entities that have this type as declaredType
+| Relation | Type | Opposite | Comment |
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+| `typedEntities` | `FamixTTypedEntity` | `declaredType` | Entities that have this type as declaredType|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
-- Named: #name Type: String Comment: Basic name of the entity, not full reference.
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
+| `name` | String | Basic name of the entity, not full reference.|
 
 "
 Trait {

--- a/src/Famix-Traits/FamixTReference.trait.st
+++ b/src/Famix-Traits/FamixTReference.trait.st
@@ -15,18 +15,25 @@ Note that FamixTReference was defined between two FamixTContainerEntity entities
 ======================
 
 ### Association source
-- Relation: #referencer Type: #FamixTWithReferences Opposite: #outgoingReferences Comment: Source entity making the reference. from-side of the association
+| Relation | Type | Opposite | Comment |
+| `referencer` | `FamixTWithReferences` | `outgoingReferences` | Source entity making the reference. from-side of the association|
+
 ### Association target
-- Relation: #referredType Type: #FamixTReferenceable Opposite: #incomingReferences Comment: Target entity referenced. to-side of the association
+| Relation | Type | Opposite | Comment |
+| `referredType` | `FamixTReferenceable` | `incomingReferences` | Target entity referenced. to-side of the association|
+
 ### Other
-- Relation: #next Type: #FamixTAssociation Opposite: #previous Comment: Next association in an ordered collection of associations. Currently not supported by the Moose importer
-- Relation: #previous Type: #FamixTAssociation Opposite: #next Comment: Previous association in an ordered collection of associations. Currently not supported by the Moose importer
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
+| Relation | Type | Opposite | Comment |
+| `next` | `FamixTAssociation` | `previous` | Next association in an ordered collection of associations. Currently not supported by the Moose importer|
+| `previous` | `FamixTAssociation` | `next` | Previous association in an ordered collection of associations. Currently not supported by the Moose importer|
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
 
 "
 Trait {

--- a/src/Famix-Traits/FamixTReferenceable.trait.st
+++ b/src/Famix-Traits/FamixTReferenceable.trait.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Incoming dependencies
-- Relation: #incomingReferences Type: #FamixTReference Opposite: #referredType Comment: References to this entity by other entities.
+| Relation | Type | Opposite | Comment |
+| `incomingReferences` | `FamixTReference` | `referredType` | References to this entity by other entities.|
+
 
 
 "

--- a/src/Famix-Traits/FamixTRelativeSourceAnchor.trait.st
+++ b/src/Famix-Traits/FamixTRelativeSourceAnchor.trait.st
@@ -19,14 +19,17 @@ Internal Representation and Key Implementation Points.
 ======================
 
 ### Other
-- Relation: #element Type: #FamixTSourceEntity Opposite: #sourceAnchor Comment: Enable the accessibility to the famix entity that this class is a source pointer for
+| Relation | Type | Opposite | Comment |
+| `element` | `FamixTSourceEntity` | `sourceAnchor` | Enable the accessibility to the famix entity that this class is a source pointer for|
+
 
 ## Properties
 ======================
 
-- Named: #endPos Type: Number Comment: Stop position in the source
-- Named: #relatedAnchor Type: FamixTSourceAnchor Comment: Source anchor to which I am relative.
-- Named: #startPos Type: Number Comment: Start position in the source
+| Name | Type | Comment |
+| `endPos` | Number | Stop position in the source|
+| `relatedAnchor` | FamixTSourceAnchor | Source anchor to which I am relative.|
+| `startPos` | Number | Start position in the source|
 
 "
 Trait {

--- a/src/Famix-Traits/FamixTSourceAnchor.trait.st
+++ b/src/Famix-Traits/FamixTSourceAnchor.trait.st
@@ -5,7 +5,9 @@ FamixTSourceAnchor is an abstract class representing a pointer to a source. The 
 ======================
 
 ### Other
-- Relation: #element Type: #FamixTSourceEntity Opposite: #sourceAnchor Comment: Enable the accessibility to the famix entity that this class is a source pointer for
+| Relation | Type | Opposite | Comment |
+| `element` | `FamixTSourceEntity` | `sourceAnchor` | Enable the accessibility to the famix entity that this class is a source pointer for|
+
 
 
 "

--- a/src/Famix-Traits/FamixTSourceEntity.trait.st
+++ b/src/Famix-Traits/FamixTSourceEntity.trait.st
@@ -5,12 +5,15 @@ FamixTSourcedEntity models any fact in a program source and it is the superclass
 ======================
 
 ### Other
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
+| Relation | Type | Opposite | Comment |
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
 
 "
 Trait {

--- a/src/Famix-Traits/FamixTSourceLanguage.trait.st
+++ b/src/Famix-Traits/FamixTSourceLanguage.trait.st
@@ -8,7 +8,9 @@ One can create a default source language for a project by not associating any en
 ======================
 
 ### Other
-- Relation: #sourcedEntities Type: #FamixTWithSourceLanguages Opposite: #declaredSourceLanguage Comment: References to the entities saying explicitly that are written in this language.
+| Relation | Type | Opposite | Comment |
+| `sourcedEntities` | `FamixTWithSourceLanguages` | `declaredSourceLanguage` | References to the entities saying explicitly that are written in this language.|
+
 
 
 "

--- a/src/Famix-Traits/FamixTStructuralEntity.trait.st
+++ b/src/Famix-Traits/FamixTStructuralEntity.trait.st
@@ -5,16 +5,21 @@ FamixTStructuralEntity is the abstract superclass for basic data structure in th
 ======================
 
 ### Incoming dependencies
-- Relation: #incomingAccesses Type: #FamixTAccess Opposite: #variable Comment: All Famix accesses pointing to this structural entity
+| Relation | Type | Opposite | Comment |
+| `incomingAccesses` | `FamixTAccess` | `variable` | All Famix accesses pointing to this structural entity|
+
 ### Other
-- Relation: #declaredType Type: #FamixTType Opposite: #typedEntities Comment: Type of the entity, if any
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
+| Relation | Type | Opposite | Comment |
+| `declaredType` | `FamixTType` | `typedEntities` | Type of the entity, if any|
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
-- Named: #name Type: String Comment: Basic name of the entity, not full reference.
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
+| `name` | String | Basic name of the entity, not full reference.|
 
 "
 Trait {

--- a/src/Famix-Traits/FamixTTemplate.trait.st
+++ b/src/Famix-Traits/FamixTTemplate.trait.st
@@ -3,9 +3,13 @@
 ======================
 
 ### Parents
-- Relation: #templateOwner Type: #FamixTWithTemplates Opposite: #templates
+| Relation | Type | Opposite | Comment |
+| `templateOwner` | `FamixTWithTemplates` | `templates` | |
+
 ### Other
-- Relation: #templateUsers Type: #FamixTTemplateUser Opposite: #template
+| Relation | Type | Opposite | Comment |
+| `templateUsers` | `FamixTTemplateUser` | `template` | |
+
 
 
 "

--- a/src/Famix-Traits/FamixTTemplateUser.trait.st
+++ b/src/Famix-Traits/FamixTTemplateUser.trait.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Other
-- Relation: #template Type: #FamixTTemplate Opposite: #templateUsers
+| Relation | Type | Opposite | Comment |
+| `template` | `FamixTTemplate` | `templateUsers` | |
+
 
 
 "

--- a/src/Famix-Traits/FamixTTrait.trait.st
+++ b/src/Famix-Traits/FamixTTrait.trait.st
@@ -5,9 +5,13 @@ FamixTTrait models a trait as it can be found in Pharo or PHP.
 ======================
 
 ### Parents
-- Relation: #traitOwner Type: #FamixTWithTraits Opposite: #traits
+| Relation | Type | Opposite | Comment |
+| `traitOwner` | `FamixTWithTraits` | `traits` | |
+
 ### Outgoing dependencies
-- Relation: #incomingTraitUsages Type: #FamixTTraitUsage Opposite: #trait
+| Relation | Type | Opposite | Comment |
+| `incomingTraitUsages` | `FamixTTraitUsage` | `trait` | |
+
 
 
 "

--- a/src/Famix-Traits/FamixTTraitUsage.trait.st
+++ b/src/Famix-Traits/FamixTTraitUsage.trait.st
@@ -3,18 +3,25 @@
 ======================
 
 ### Association source
-- Relation: #trait Type: #FamixTTrait Opposite: #incomingTraitUsages
+| Relation | Type | Opposite | Comment |
+| `trait` | `FamixTTrait` | `incomingTraitUsages` | |
+
 ### Association target
-- Relation: #user Type: #FamixTTraitUser Opposite: #outgoingTraitUsages
+| Relation | Type | Opposite | Comment |
+| `user` | `FamixTTraitUser` | `outgoingTraitUsages` | |
+
 ### Other
-- Relation: #next Type: #FamixTAssociation Opposite: #previous Comment: Next association in an ordered collection of associations. Currently not supported by the Moose importer
-- Relation: #previous Type: #FamixTAssociation Opposite: #next Comment: Previous association in an ordered collection of associations. Currently not supported by the Moose importer
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
+| Relation | Type | Opposite | Comment |
+| `next` | `FamixTAssociation` | `previous` | Next association in an ordered collection of associations. Currently not supported by the Moose importer|
+| `previous` | `FamixTAssociation` | `next` | Previous association in an ordered collection of associations. Currently not supported by the Moose importer|
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
 
 "
 Trait {

--- a/src/Famix-Traits/FamixTTraitUser.trait.st
+++ b/src/Famix-Traits/FamixTTraitUser.trait.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Incoming dependencies
-- Relation: #outgoingTraitUsages Type: #FamixTTraitUsage Opposite: #user
+| Relation | Type | Opposite | Comment |
+| `outgoingTraitUsages` | `FamixTTraitUsage` | `user` | |
+
 
 
 "

--- a/src/Famix-Traits/FamixTType.trait.st
+++ b/src/Famix-Traits/FamixTType.trait.st
@@ -9,18 +9,25 @@ A type can have multiple subtypes or supertypes. These are modelled by means of 
 ======================
 
 ### Parents
-- Relation: #typeContainer Type: #FamixTWithTypes Opposite: #types Comment: Container entity to which this type belongs. Container is a namespace, not a package (Smalltalk).
+| Relation | Type | Opposite | Comment |
+| `typeContainer` | `FamixTWithTypes` | `types` | Container entity to which this type belongs. Container is a namespace, not a package (Smalltalk).|
+
 ### Incoming dependencies
-- Relation: #incomingReferences Type: #FamixTReference Opposite: #referredType Comment: References to this entity by other entities.
+| Relation | Type | Opposite | Comment |
+| `incomingReferences` | `FamixTReference` | `referredType` | References to this entity by other entities.|
+
 ### Other
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
-- Relation: #typedEntities Type: #FamixTTypedEntity Opposite: #declaredType Comment: Entities that have this type as declaredType
+| Relation | Type | Opposite | Comment |
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+| `typedEntities` | `FamixTTypedEntity` | `declaredType` | Entities that have this type as declaredType|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
-- Named: #name Type: String Comment: Basic name of the entity, not full reference.
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
+| `name` | String | Basic name of the entity, not full reference.|
 
 "
 Trait {

--- a/src/Famix-Traits/FamixTTypeAlias.trait.st
+++ b/src/Famix-Traits/FamixTTypeAlias.trait.st
@@ -8,7 +8,9 @@ Instance Variables:
 ======================
 
 ### Other
-- Relation: #aliasedType Type: #FamixTWithTypeAliases Opposite: #typeAliases Comment: Points to the actual type.
+| Relation | Type | Opposite | Comment |
+| `aliasedType` | `FamixTWithTypeAliases` | `typeAliases` | Points to the actual type.|
+
 
 
 "

--- a/src/Famix-Traits/FamixTTypedAnnotationInstance.trait.st
+++ b/src/Famix-Traits/FamixTTypedAnnotationInstance.trait.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Other
-- Relation: #annotationType Type: #FamixTAnnotationType Opposite: #instances Comment: Refers to the type of an annotation. (In some languages, Java and C#, an annotation as an explicit type). 
+| Relation | Type | Opposite | Comment |
+| `annotationType` | `FamixTAnnotationType` | `instances` | Refers to the type of an annotation. (In some languages, Java and C#, an annotation as an explicit type). |
+
 
 
 "

--- a/src/Famix-Traits/FamixTTypedAnnotationInstanceAttribute.trait.st
+++ b/src/Famix-Traits/FamixTTypedAnnotationInstanceAttribute.trait.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Other
-- Relation: #annotationTypeAttribute Type: #FamixTAnnotationTypeAttribute Opposite: #annotationAttributeInstances Comment: This corresponds to the type of the attribute in an AnnotationInstance
+| Relation | Type | Opposite | Comment |
+| `annotationTypeAttribute` | `FamixTAnnotationTypeAttribute` | `annotationAttributeInstances` | This corresponds to the type of the attribute in an AnnotationInstance|
+
 
 
 "

--- a/src/Famix-Traits/FamixTTypedEntity.trait.st
+++ b/src/Famix-Traits/FamixTTypedEntity.trait.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Other
-- Relation: #declaredType Type: #FamixTType Opposite: #typedEntities Comment: Type of the entity, if any
+| Relation | Type | Opposite | Comment |
+| `declaredType` | `FamixTType` | `typedEntities` | Type of the entity, if any|
+
 
 
 "

--- a/src/Famix-Traits/FamixTUnknownSourceLanguage.trait.st
+++ b/src/Famix-Traits/FamixTUnknownSourceLanguage.trait.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Other
-- Relation: #sourcedEntities Type: #FamixTWithSourceLanguages Opposite: #declaredSourceLanguage Comment: References to the entities saying explicitly that are written in this language.
+| Relation | Type | Opposite | Comment |
+| `sourcedEntities` | `FamixTWithSourceLanguages` | `declaredSourceLanguage` | References to the entities saying explicitly that are written in this language.|
+
 
 
 "

--- a/src/Famix-Traits/FamixTUnknownVariable.trait.st
+++ b/src/Famix-Traits/FamixTUnknownVariable.trait.st
@@ -3,16 +3,21 @@
 ======================
 
 ### Incoming dependencies
-- Relation: #incomingAccesses Type: #FamixTAccess Opposite: #variable Comment: All Famix accesses pointing to this structural entity
+| Relation | Type | Opposite | Comment |
+| `incomingAccesses` | `FamixTAccess` | `variable` | All Famix accesses pointing to this structural entity|
+
 ### Other
-- Relation: #declaredType Type: #FamixTType Opposite: #typedEntities Comment: Type of the entity, if any
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
+| Relation | Type | Opposite | Comment |
+| `declaredType` | `FamixTType` | `typedEntities` | Type of the entity, if any|
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
-- Named: #name Type: String Comment: Basic name of the entity, not full reference.
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
+| `name` | String | Basic name of the entity, not full reference.|
 
 "
 Trait {

--- a/src/Famix-Traits/FamixTWithAccesses.trait.st
+++ b/src/Famix-Traits/FamixTWithAccesses.trait.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Outgoing dependencies
-- Relation: #accesses Type: #FamixTAccess Opposite: #accessor Comment: Accesses to variables made by this behaviour.
+| Relation | Type | Opposite | Comment |
+| `accesses` | `FamixTAccess` | `accessor` | Accesses to variables made by this behaviour.|
+
 
 
 "

--- a/src/Famix-Traits/FamixTWithAnnotationInstanceAttributes.trait.st
+++ b/src/Famix-Traits/FamixTWithAnnotationInstanceAttributes.trait.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Children
-- Relation: #attributes Type: #FamixTAnnotationInstanceAttribute Opposite: #parentAnnotationInstance Comment: This corresponds to the actual values of the attributes in an AnnotationInstance
+| Relation | Type | Opposite | Comment |
+| `attributes` | `FamixTAnnotationInstanceAttribute` | `parentAnnotationInstance` | This corresponds to the actual values of the attributes in an AnnotationInstance|
+
 
 
 "

--- a/src/Famix-Traits/FamixTWithAnnotationInstances.trait.st
+++ b/src/Famix-Traits/FamixTWithAnnotationInstances.trait.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Other
-- Relation: #annotationInstances Type: #FamixTAnnotationInstance Opposite: #annotatedEntity Comment: This property corresponds to the set of annotations associated to the entity
+| Relation | Type | Opposite | Comment |
+| `annotationInstances` | `FamixTAnnotationInstance` | `annotatedEntity` | This property corresponds to the set of annotations associated to the entity|
+
 
 
 "

--- a/src/Famix-Traits/FamixTWithAnnotationTypes.trait.st
+++ b/src/Famix-Traits/FamixTWithAnnotationTypes.trait.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Children
-- Relation: #definedAnnotationTypes Type: #FamixTAnnotationType Opposite: #annotationTypesContainer Comment: The container in which the AnnotationTypes may be declared
+| Relation | Type | Opposite | Comment |
+| `definedAnnotationTypes` | `FamixTAnnotationType` | `annotationTypesContainer` | The container in which the AnnotationTypes may be declared|
+
 
 
 "

--- a/src/Famix-Traits/FamixTWithAttributes.trait.st
+++ b/src/Famix-Traits/FamixTWithAttributes.trait.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Children
-- Relation: #attributes Type: #FamixTAttribute Opposite: #parentType Comment: List of attributes declared by this type.
+| Relation | Type | Opposite | Comment |
+| `attributes` | `FamixTAttribute` | `parentType` | List of attributes declared by this type.|
+
 
 
 "

--- a/src/Famix-Traits/FamixTWithClasses.trait.st
+++ b/src/Famix-Traits/FamixTWithClasses.trait.st
@@ -3,8 +3,10 @@
 ======================
 
 ### Children
-- Relation: #types Type: #FamixTType Opposite: #typeContainer Comment: Types contained (declared) in this entity, if any.
-#types is declared in ContainerEntity because different kinds of container can embed types. Types are usually contained in a Famix.Namespace. But types can also be contained in a Famix.Class or Famix.Method (in Java with inner classes for example). Famix.Function can also contain some types such as structs.
+| Relation | Type | Opposite | Comment |
+| `types` | `FamixTType` | `typeContainer` | Types contained (declared) in this entity, if any.
+#types is declared in ContainerEntity because different kinds of container can embed types. Types are usually contained in a Famix.Namespace. But types can also be contained in a Famix.Class or Famix.Method (in Java with inner classes for example). Famix.Function can also contain some types such as structs.|
+
 
 
 "

--- a/src/Famix-Traits/FamixTWithComments.trait.st
+++ b/src/Famix-Traits/FamixTWithComments.trait.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Other
-- Relation: #comments Type: #FamixTComment Opposite: #commentedEntity Comment: List of comments for the entity
+| Relation | Type | Opposite | Comment |
+| `comments` | `FamixTComment` | `commentedEntity` | List of comments for the entity|
+
 
 
 "

--- a/src/Famix-Traits/FamixTWithCompilationUnits.trait.st
+++ b/src/Famix-Traits/FamixTWithCompilationUnits.trait.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Children
-- Relation: #compilationUnit Type: #FamixTCompilationUnit Opposite: #compilationUnitOwner
+| Relation | Type | Opposite | Comment |
+| `compilationUnit` | `FamixTCompilationUnit` | `compilationUnitOwner` | |
+
 
 
 "

--- a/src/Famix-Traits/FamixTWithDereferencedInvocations.trait.st
+++ b/src/Famix-Traits/FamixTWithDereferencedInvocations.trait.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Other
-- Relation: #dereferencedInvocations Type: #FamixTDereferencedInvocation Opposite: #referencer Comment: List of invocations performed on BehaviouralEntities referenced by this entity
+| Relation | Type | Opposite | Comment |
+| `dereferencedInvocations` | `FamixTDereferencedInvocation` | `referencer` | List of invocations performed on BehaviouralEntities referenced by this entity|
+
 
 
 "

--- a/src/Famix-Traits/FamixTWithEnumValues.trait.st
+++ b/src/Famix-Traits/FamixTWithEnumValues.trait.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Children
-- Relation: #enumValues Type: #FamixTEnumValue Opposite: #parentEnum
+| Relation | Type | Opposite | Comment |
+| `enumValues` | `FamixTEnumValue` | `parentEnum` | |
+
 
 
 "

--- a/src/Famix-Traits/FamixTWithExceptions.trait.st
+++ b/src/Famix-Traits/FamixTWithExceptions.trait.st
@@ -3,9 +3,11 @@
 ======================
 
 ### Other
-- Relation: #caughtExceptions Type: #FamixTException Opposite: #catchingEntities Comment: The exceptions caught by the method
-- Relation: #declaredExceptions Type: #FamixTException Opposite: #declaringEntities Comment: The exceptions declared by the method
-- Relation: #thrownExceptions Type: #FamixTException Opposite: #throwingEntities Comment: The exceptions thrown by the method
+| Relation | Type | Opposite | Comment |
+| `caughtExceptions` | `FamixTException` | `catchingEntities` | The exceptions caught by the method|
+| `declaredExceptions` | `FamixTException` | `declaringEntities` | The exceptions declared by the method|
+| `thrownExceptions` | `FamixTException` | `throwingEntities` | The exceptions thrown by the method|
+
 
 
 "

--- a/src/Famix-Traits/FamixTWithFileIncludes.trait.st
+++ b/src/Famix-Traits/FamixTWithFileIncludes.trait.st
@@ -3,8 +3,10 @@
 ======================
 
 ### Other
-- Relation: #incomingIncludeRelations Type: #FamixTFileInclude Opposite: #target Comment: The include entities that have this file as a target.
-- Relation: #outgoingIncludeRelations Type: #FamixTFileInclude Opposite: #source Comment: The include entities that have this file as a source.
+| Relation | Type | Opposite | Comment |
+| `incomingIncludeRelations` | `FamixTFileInclude` | `target` | The include entities that have this file as a target.|
+| `outgoingIncludeRelations` | `FamixTFileInclude` | `source` | The include entities that have this file as a source.|
+
 
 
 "

--- a/src/Famix-Traits/FamixTWithFiles.trait.st
+++ b/src/Famix-Traits/FamixTWithFiles.trait.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Other
-- Relation: #containerFiles Type: #FamixTFile Opposite: #entities Comment: List of files containing the entity
+| Relation | Type | Opposite | Comment |
+| `containerFiles` | `FamixTFile` | `entities` | List of files containing the entity|
+
 
 
 "

--- a/src/Famix-Traits/FamixTWithFunctions.trait.st
+++ b/src/Famix-Traits/FamixTWithFunctions.trait.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Children
-- Relation: #functions Type: #FamixTFunction Opposite: #functionOwner Comment: Functions defined in the container, if any.
+| Relation | Type | Opposite | Comment |
+| `functions` | `FamixTFunction` | `functionOwner` | Functions defined in the container, if any.|
+
 
 
 "

--- a/src/Famix-Traits/FamixTWithGlobalVariables.trait.st
+++ b/src/Famix-Traits/FamixTWithGlobalVariables.trait.st
@@ -5,7 +5,9 @@ A container having Global variables
 ======================
 
 ### Children
-- Relation: #globalVariables Type: #FamixTGlobalVariable Opposite: #parentScope Comment: Global variables defined in the scope, if any.
+| Relation | Type | Opposite | Comment |
+| `globalVariables` | `FamixTGlobalVariable` | `parentScope` | Global variables defined in the scope, if any.|
+
 
 
 "

--- a/src/Famix-Traits/FamixTWithHeaders.trait.st
+++ b/src/Famix-Traits/FamixTWithHeaders.trait.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Children
-- Relation: #header Type: #FamixTHeader Opposite: #headerOwner Comment: The header file that defines this module
+| Relation | Type | Opposite | Comment |
+| `header` | `FamixTHeader` | `headerOwner` | The header file that defines this module|
+
 
 
 "

--- a/src/Famix-Traits/FamixTWithImplicitVariables.trait.st
+++ b/src/Famix-Traits/FamixTWithImplicitVariables.trait.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Children
-- Relation: #implicitVariables Type: #FamixTImplicitVariable Opposite: #parentBehaviouralEntity Comment: Implicit variables used locally by this behaviour.
+| Relation | Type | Opposite | Comment |
+| `implicitVariables` | `FamixTImplicitVariable` | `parentBehaviouralEntity` | Implicit variables used locally by this behaviour.|
+
 
 
 "

--- a/src/Famix-Traits/FamixTWithImports.trait.st
+++ b/src/Famix-Traits/FamixTWithImports.trait.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Outgoing dependencies
-- Relation: #outgoingImports Type: #FamixTImport Opposite: #importingEntity
+| Relation | Type | Opposite | Comment |
+| `outgoingImports` | `FamixTImport` | `importingEntity` | |
+
 
 
 "

--- a/src/Famix-Traits/FamixTWithInheritances.trait.st
+++ b/src/Famix-Traits/FamixTWithInheritances.trait.st
@@ -3,9 +3,13 @@
 ======================
 
 ### Outgoing dependencies
-- Relation: #superInheritances Type: #FamixTInheritance Opposite: #subclass Comment: Superinheritance relationships, i.e. known superclasses of this type.
+| Relation | Type | Opposite | Comment |
+| `superInheritances` | `FamixTInheritance` | `subclass` | Superinheritance relationships, i.e. known superclasses of this type.|
+
 ### Incoming dependencies
-- Relation: #subInheritances Type: #FamixTInheritance Opposite: #superclass Comment: Subinheritance relationships, i.e. known subclasses of this type.
+| Relation | Type | Opposite | Comment |
+| `subInheritances` | `FamixTInheritance` | `superclass` | Subinheritance relationships, i.e. known subclasses of this type.|
+
 
 
 "

--- a/src/Famix-Traits/FamixTWithInvocations.trait.st
+++ b/src/Famix-Traits/FamixTWithInvocations.trait.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Outgoing dependencies
-- Relation: #outgoingInvocations Type: #FamixTInvocation Opposite: #sender Comment: Outgoing invocations sent by this behaviour.
+| Relation | Type | Opposite | Comment |
+| `outgoingInvocations` | `FamixTInvocation` | `sender` | Outgoing invocations sent by this behaviour.|
+
 
 
 "

--- a/src/Famix-Traits/FamixTWithLocalVariables.trait.st
+++ b/src/Famix-Traits/FamixTWithLocalVariables.trait.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Children
-- Relation: #localVariables Type: #FamixTLocalVariable Opposite: #parentBehaviouralEntity Comment: Variables locally defined by this behaviour.
+| Relation | Type | Opposite | Comment |
+| `localVariables` | `FamixTLocalVariable` | `parentBehaviouralEntity` | Variables locally defined by this behaviour.|
+
 
 
 "

--- a/src/Famix-Traits/FamixTWithMethods.trait.st
+++ b/src/Famix-Traits/FamixTWithMethods.trait.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Children
-- Relation: #methods Type: #FamixTMethod Opposite: #parentType Comment: Methods declared by this type.
+| Relation | Type | Opposite | Comment |
+| `methods` | `FamixTMethod` | `parentType` | Methods declared by this type.|
+
 
 
 "

--- a/src/Famix-Traits/FamixTWithParameterizedTypeUsers.trait.st
+++ b/src/Famix-Traits/FamixTWithParameterizedTypeUsers.trait.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Other
-- Relation: #arguments Type: #FamixTParameterizedTypeUser Opposite: #argumentsInParameterizedTypes
+| Relation | Type | Opposite | Comment |
+| `arguments` | `FamixTParameterizedTypeUser` | `argumentsInParameterizedTypes` | |
+
 
 
 "

--- a/src/Famix-Traits/FamixTWithParameterizedTypes.trait.st
+++ b/src/Famix-Traits/FamixTWithParameterizedTypes.trait.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Other
-- Relation: #parameterizedTypes Type: #FamixTParameterizedType Opposite: #parameterizableClass
+| Relation | Type | Opposite | Comment |
+| `parameterizedTypes` | `FamixTParameterizedType` | `parameterizableClass` | |
+
 
 
 "

--- a/src/Famix-Traits/FamixTWithParameters.trait.st
+++ b/src/Famix-Traits/FamixTWithParameters.trait.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Children
-- Relation: #parameters Type: #FamixTParameter Opposite: #parentBehaviouralEntity Comment: List of formal parameters declared by this behaviour.
+| Relation | Type | Opposite | Comment |
+| `parameters` | `FamixTParameter` | `parentBehaviouralEntity` | List of formal parameters declared by this behaviour.|
+
 
 
 "

--- a/src/Famix-Traits/FamixTWithReferences.trait.st
+++ b/src/Famix-Traits/FamixTWithReferences.trait.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Outgoing dependencies
-- Relation: #outgoingReferences Type: #FamixTReference Opposite: #referencer Comment: References from this entity to other entities.
+| Relation | Type | Opposite | Comment |
+| `outgoingReferences` | `FamixTReference` | `referencer` | References from this entity to other entities.|
+
 
 
 "

--- a/src/Famix-Traits/FamixTWithSourceLanguages.trait.st
+++ b/src/Famix-Traits/FamixTWithSourceLanguages.trait.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Other
-- Relation: #declaredSourceLanguage Type: #FamixTSourceLanguage Opposite: #sourcedEntities Comment: The declared SourceLanguage for the source code of this entity
+| Relation | Type | Opposite | Comment |
+| `declaredSourceLanguage` | `FamixTSourceLanguage` | `sourcedEntities` | The declared SourceLanguage for the source code of this entity|
+
 
 
 "

--- a/src/Famix-Traits/FamixTWithStatements.trait.st
+++ b/src/Famix-Traits/FamixTWithStatements.trait.st
@@ -3,16 +3,21 @@
 ======================
 
 ### Outgoing dependencies
-- Relation: #accesses Type: #FamixTAccess Opposite: #accessor Comment: Accesses to variables made by this behaviour.
-- Relation: #outgoingInvocations Type: #FamixTInvocation Opposite: #sender Comment: Outgoing invocations sent by this behaviour.
-- Relation: #outgoingReferences Type: #FamixTReference Opposite: #referencer Comment: References from this entity to other entities.
+| Relation | Type | Opposite | Comment |
+| `accesses` | `FamixTAccess` | `accessor` | Accesses to variables made by this behaviour.|
+| `outgoingInvocations` | `FamixTInvocation` | `sender` | Outgoing invocations sent by this behaviour.|
+| `outgoingReferences` | `FamixTReference` | `referencer` | References from this entity to other entities.|
+
 ### Other
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
+| Relation | Type | Opposite | Comment |
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
 
 "
 Trait {

--- a/src/Famix-Traits/FamixTWithTemplates.trait.st
+++ b/src/Famix-Traits/FamixTWithTemplates.trait.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Children
-- Relation: #templates Type: #FamixTTemplate Opposite: #templateOwner
+| Relation | Type | Opposite | Comment |
+| `templates` | `FamixTTemplate` | `templateOwner` | |
+
 
 
 "

--- a/src/Famix-Traits/FamixTWithTraits.trait.st
+++ b/src/Famix-Traits/FamixTWithTraits.trait.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Children
-- Relation: #traits Type: #FamixTTrait Opposite: #traitOwner
+| Relation | Type | Opposite | Comment |
+| `traits` | `FamixTTrait` | `traitOwner` | |
+
 
 
 "

--- a/src/Famix-Traits/FamixTWithTypeAliases.trait.st
+++ b/src/Famix-Traits/FamixTWithTypeAliases.trait.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Other
-- Relation: #typeAliases Type: #FamixTTypeAlias Opposite: #aliasedType Comment: Aliases
+| Relation | Type | Opposite | Comment |
+| `typeAliases` | `FamixTTypeAlias` | `aliasedType` | Aliases|
+
 
 
 "

--- a/src/Famix-Traits/FamixTWithTypes.trait.st
+++ b/src/Famix-Traits/FamixTWithTypes.trait.st
@@ -3,8 +3,10 @@
 ======================
 
 ### Children
-- Relation: #types Type: #FamixTType Opposite: #typeContainer Comment: Types contained (declared) in this entity, if any.
-#types is declared in ContainerEntity because different kinds of container can embed types. Types are usually contained in a Famix.Namespace. But types can also be contained in a Famix.Class or Famix.Method (in Java with inner classes for example). Famix.Function can also contain some types such as structs.
+| Relation | Type | Opposite | Comment |
+| `types` | `FamixTType` | `typeContainer` | Types contained (declared) in this entity, if any.
+#types is declared in ContainerEntity because different kinds of container can embed types. Types are usually contained in a Famix.Namespace. But types can also be contained in a Famix.Class or Famix.Method (in Java with inner classes for example). Famix.Function can also contain some types such as structs.|
+
 
 
 "

--- a/src/FamixDocumentor-TestMetaModel/FDClass1.class.st
+++ b/src/FamixDocumentor-TestMetaModel/FDClass1.class.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Other
-- Relation: #myTrait Type: #FDTrait4 Opposite: #class1
+| Relation | Type | Opposite | Comment |
+| `myTrait` | `FDTrait4` | `class1` | |
+
 
 
 "

--- a/src/FamixDocumentor-TestMetaModel/FDTrait4.trait.st
+++ b/src/FamixDocumentor-TestMetaModel/FDTrait4.trait.st
@@ -3,13 +3,16 @@
 ======================
 
 ### Other
-- Relation: #class1 Type: #FDClass1 Opposite: #myTrait
+| Relation | Type | Opposite | Comment |
+| `class1` | `FDClass1` | `myTrait` | |
+
 
 ## Properties
 ======================
 
-- Named: #otherProp Type: Object Comment: Another property in the trait
-- Named: #someProp Type: String Comment: A property in the trait
+| Name | Type | Comment |
+| `otherProp` | Object | Another property in the trait|
+| `someProp` | String | A property in the trait|
 
 "
 Trait {

--- a/src/Moose-Core-Tests-Entities/MooseMSEImporterTestAttribute.class.st
+++ b/src/Moose-Core-Tests-Entities/MooseMSEImporterTestAttribute.class.st
@@ -3,18 +3,25 @@
 ======================
 
 ### Parents
-- Relation: #parentType Type: #FamixTWithAttributes Opposite: #attributes Comment: Type declaring the attribute. belongsTo implementation
+| Relation | Type | Opposite | Comment |
+| `parentType` | `FamixTWithAttributes` | `attributes` | Type declaring the attribute. belongsTo implementation|
+
 ### Incoming dependencies
-- Relation: #incomingAccesses Type: #FamixTAccess Opposite: #variable Comment: All Famix accesses pointing to this structural entity
+| Relation | Type | Opposite | Comment |
+| `incomingAccesses` | `FamixTAccess` | `variable` | All Famix accesses pointing to this structural entity|
+
 ### Other
-- Relation: #declaredType Type: #FamixTType Opposite: #typedEntities Comment: Type of the entity, if any
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
+| Relation | Type | Opposite | Comment |
+| `declaredType` | `FamixTType` | `typedEntities` | Type of the entity, if any|
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
-- Named: #name Type: String Comment: Basic name of the entity, not full reference.
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
+| `name` | String | Basic name of the entity, not full reference.|
 
 "
 Class {

--- a/src/Moose-Core-Tests-Entities/MooseMSEImporterTestClass.class.st
+++ b/src/Moose-Core-Tests-Entities/MooseMSEImporterTestClass.class.st
@@ -3,26 +3,37 @@
 ======================
 
 ### Parents
-- Relation: #typeContainer Type: #FamixTWithTypes Opposite: #types Comment: Container entity to which this type belongs. Container is a namespace, not a package (Smalltalk).
+| Relation | Type | Opposite | Comment |
+| `typeContainer` | `FamixTWithTypes` | `types` | Container entity to which this type belongs. Container is a namespace, not a package (Smalltalk).|
+
 ### Children
-- Relation: #attributes Type: #FamixTAttribute Opposite: #parentType Comment: List of attributes declared by this type.
-- Relation: #methods Type: #FamixTMethod Opposite: #parentType Comment: Methods declared by this type.
+| Relation | Type | Opposite | Comment |
+| `attributes` | `FamixTAttribute` | `parentType` | List of attributes declared by this type.|
+| `methods` | `FamixTMethod` | `parentType` | Methods declared by this type.|
+
 ### Outgoing dependencies
-- Relation: #superInheritances Type: #FamixTInheritance Opposite: #subclass Comment: Superinheritance relationships, i.e. known superclasses of this type.
+| Relation | Type | Opposite | Comment |
+| `superInheritances` | `FamixTInheritance` | `subclass` | Superinheritance relationships, i.e. known superclasses of this type.|
+
 ### Incoming dependencies
-- Relation: #incomingReferences Type: #FamixTReference Opposite: #referredType Comment: References to this entity by other entities.
-- Relation: #subInheritances Type: #FamixTInheritance Opposite: #superclass Comment: Subinheritance relationships, i.e. known subclasses of this type.
+| Relation | Type | Opposite | Comment |
+| `incomingReferences` | `FamixTReference` | `referredType` | References to this entity by other entities.|
+| `subInheritances` | `FamixTInheritance` | `superclass` | Subinheritance relationships, i.e. known subclasses of this type.|
+
 ### Other
-- Relation: #comments Type: #FamixTComment Opposite: #commentedEntity Comment: List of comments for the entity
-- Relation: #receivingInvocations Type: #FamixTInvocation Opposite: #receiver Comment: List of invocations performed on this entity (considered as the receiver)
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
-- Relation: #typedEntities Type: #FamixTTypedEntity Opposite: #declaredType Comment: Entities that have this type as declaredType
+| Relation | Type | Opposite | Comment |
+| `comments` | `FamixTComment` | `commentedEntity` | List of comments for the entity|
+| `receivingInvocations` | `FamixTInvocation` | `receiver` | List of invocations performed on this entity (considered as the receiver)|
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+| `typedEntities` | `FamixTTypedEntity` | `declaredType` | Entities that have this type as declaredType|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
-- Named: #name Type: String Comment: Basic name of the entity, not full reference.
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
+| `name` | String | Basic name of the entity, not full reference.|
 
 "
 Class {

--- a/src/Moose-Core-Tests-Entities/MooseMSEImporterTestComment.class.st
+++ b/src/Moose-Core-Tests-Entities/MooseMSEImporterTestComment.class.st
@@ -3,12 +3,15 @@
 ======================
 
 ### Other
-- Relation: #commentedEntity Type: #FamixTWithComments Opposite: #comments Comment: Source code commented by the comment
+| Relation | Type | Opposite | Comment |
+| `commentedEntity` | `FamixTWithComments` | `comments` | Source code commented by the comment|
+
 
 ## Properties
 ======================
 
-- Named: #content Type: String Comment: Content of the comment as a String
+| Name | Type | Comment |
+| `content` | String | Content of the comment as a String|
 
 "
 Class {

--- a/src/Moose-Core-Tests-Entities/MooseMSEImporterTestInheritance.class.st
+++ b/src/Moose-Core-Tests-Entities/MooseMSEImporterTestInheritance.class.st
@@ -3,18 +3,25 @@
 ======================
 
 ### Association source
-- Relation: #subclass Type: #FamixTWithInheritances Opposite: #superInheritances Comment: Subclass linked to in this relationship. from-side of the association
+| Relation | Type | Opposite | Comment |
+| `subclass` | `FamixTWithInheritances` | `superInheritances` | Subclass linked to in this relationship. from-side of the association|
+
 ### Association target
-- Relation: #superclass Type: #FamixTWithInheritances Opposite: #subInheritances Comment: Superclass linked to in this relationship. to-side of the association
+| Relation | Type | Opposite | Comment |
+| `superclass` | `FamixTWithInheritances` | `subInheritances` | Superclass linked to in this relationship. to-side of the association|
+
 ### Other
-- Relation: #next Type: #FamixTAssociation Opposite: #previous Comment: Next association in an ordered collection of associations. Currently not supported by the Moose importer
-- Relation: #previous Type: #FamixTAssociation Opposite: #next Comment: Previous association in an ordered collection of associations. Currently not supported by the Moose importer
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
+| Relation | Type | Opposite | Comment |
+| `next` | `FamixTAssociation` | `previous` | Next association in an ordered collection of associations. Currently not supported by the Moose importer|
+| `previous` | `FamixTAssociation` | `next` | Previous association in an ordered collection of associations. Currently not supported by the Moose importer|
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
 
 "
 Class {

--- a/src/Moose-Core-Tests-Entities/MooseMSEImporterTestMethod.class.st
+++ b/src/Moose-Core-Tests-Entities/MooseMSEImporterTestMethod.class.st
@@ -3,27 +3,38 @@
 ======================
 
 ### Parents
-- Relation: #parentType Type: #FamixTWithMethods Opposite: #methods Comment: Type declaring the method. It provides the implementation for belongsTo.
+| Relation | Type | Opposite | Comment |
+| `parentType` | `FamixTWithMethods` | `methods` | Type declaring the method. It provides the implementation for belongsTo.|
+
 ### Children
-- Relation: #implicitVariables Type: #FamixTImplicitVariable Opposite: #parentBehaviouralEntity Comment: Implicit variables used locally by this behaviour.
-- Relation: #localVariables Type: #FamixTLocalVariable Opposite: #parentBehaviouralEntity Comment: Variables locally defined by this behaviour.
-- Relation: #parameters Type: #FamixTParameter Opposite: #parentBehaviouralEntity Comment: List of formal parameters declared by this behaviour.
+| Relation | Type | Opposite | Comment |
+| `implicitVariables` | `FamixTImplicitVariable` | `parentBehaviouralEntity` | Implicit variables used locally by this behaviour.|
+| `localVariables` | `FamixTLocalVariable` | `parentBehaviouralEntity` | Variables locally defined by this behaviour.|
+| `parameters` | `FamixTParameter` | `parentBehaviouralEntity` | List of formal parameters declared by this behaviour.|
+
 ### Outgoing dependencies
-- Relation: #accesses Type: #FamixTAccess Opposite: #accessor Comment: Accesses to variables made by this behaviour.
-- Relation: #outgoingInvocations Type: #FamixTInvocation Opposite: #sender Comment: Outgoing invocations sent by this behaviour.
-- Relation: #outgoingReferences Type: #FamixTReference Opposite: #referencer Comment: References from this entity to other entities.
+| Relation | Type | Opposite | Comment |
+| `accesses` | `FamixTAccess` | `accessor` | Accesses to variables made by this behaviour.|
+| `outgoingInvocations` | `FamixTInvocation` | `sender` | Outgoing invocations sent by this behaviour.|
+| `outgoingReferences` | `FamixTReference` | `referencer` | References from this entity to other entities.|
+
 ### Incoming dependencies
-- Relation: #incomingInvocations Type: #FamixTInvocation Opposite: #candidates Comment: Incoming invocations from other behaviours computed by the candidate operator.
+| Relation | Type | Opposite | Comment |
+| `incomingInvocations` | `FamixTInvocation` | `candidates` | Incoming invocations from other behaviours computed by the candidate operator.|
+
 ### Other
-- Relation: #declaredType Type: #FamixTType Opposite: #typedEntities Comment: Type of the entity, if any
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
+| Relation | Type | Opposite | Comment |
+| `declaredType` | `FamixTType` | `typedEntities` | Type of the entity, if any|
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
-- Named: #name Type: String Comment: Basic name of the entity, not full reference.
-- Named: #signature Type: String Comment: Signature of the message being sent
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
+| `name` | String | Basic name of the entity, not full reference.|
+| `signature` | String | Signature of the message being sent|
 
 "
 Class {

--- a/src/Moose-Core-Tests-Entities/MooseMSEImporterTestNamedEntity.class.st
+++ b/src/Moose-Core-Tests-Entities/MooseMSEImporterTestNamedEntity.class.st
@@ -2,7 +2,8 @@
 ## Properties
 ======================
 
-- Named: #name Type: String Comment: Basic name of the entity, not full reference.
+| Name | Type | Comment |
+| `name` | String | Basic name of the entity, not full reference.|
 
 "
 Class {

--- a/src/Moose-Core-Tests-Entities/MooseMSEImporterTestNamespace.class.st
+++ b/src/Moose-Core-Tests-Entities/MooseMSEImporterTestNamespace.class.st
@@ -3,16 +3,21 @@
 ======================
 
 ### Children
-- Relation: #types Type: #FamixTType Opposite: #typeContainer Comment: Types contained (declared) in this entity, if any.
-#types is declared in ContainerEntity because different kinds of container can embed types. Types are usually contained in a Famix.Namespace. But types can also be contained in a Famix.Class or Famix.Method (in Java with inner classes for example). Famix.Function can also contain some types such as structs.
+| Relation | Type | Opposite | Comment |
+| `types` | `FamixTType` | `typeContainer` | Types contained (declared) in this entity, if any.
+#types is declared in ContainerEntity because different kinds of container can embed types. Types are usually contained in a Famix.Namespace. But types can also be contained in a Famix.Class or Famix.Method (in Java with inner classes for example). Famix.Function can also contain some types such as structs.|
+
 ### Other
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
+| Relation | Type | Opposite | Comment |
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
-- Named: #name Type: String Comment: Basic name of the entity, not full reference.
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
+| `name` | String | Basic name of the entity, not full reference.|
 
 "
 Class {

--- a/src/Moose-Core-Tests-Entities/MooseMSEImporterTestPackage.class.st
+++ b/src/Moose-Core-Tests-Entities/MooseMSEImporterTestPackage.class.st
@@ -3,19 +3,26 @@
 ======================
 
 ### Parents
-- Relation: #parentPackage Type: #FamixTPackage Opposite: #childEntities Comment: Package containing the entity in the code structure (if applicable)
+| Relation | Type | Opposite | Comment |
+| `parentPackage` | `FamixTPackage` | `childEntities` | Package containing the entity in the code structure (if applicable)|
+
 ### Children
-- Relation: #childEntities Type: #FamixTPackageable Opposite: #parentPackage
-- Relation: #types Type: #FamixTType Opposite: #typeContainer Comment: Types contained (declared) in this entity, if any.
-#types is declared in ContainerEntity because different kinds of container can embed types. Types are usually contained in a Famix.Namespace. But types can also be contained in a Famix.Class or Famix.Method (in Java with inner classes for example). Famix.Function can also contain some types such as structs.
+| Relation | Type | Opposite | Comment |
+| `childEntities` | `FamixTPackageable` | `parentPackage` | |
+| `types` | `FamixTType` | `typeContainer` | Types contained (declared) in this entity, if any.
+#types is declared in ContainerEntity because different kinds of container can embed types. Types are usually contained in a Famix.Namespace. But types can also be contained in a Famix.Class or Famix.Method (in Java with inner classes for example). Famix.Function can also contain some types such as structs.|
+
 ### Other
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
+| Relation | Type | Opposite | Comment |
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
-- Named: #name Type: String Comment: Basic name of the entity, not full reference.
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
+| `name` | String | Basic name of the entity, not full reference.|
 
 "
 Class {

--- a/src/Moose-Core-Tests-Entities/MooseMSEImporterTestPrimitiveType.class.st
+++ b/src/Moose-Core-Tests-Entities/MooseMSEImporterTestPrimitiveType.class.st
@@ -3,18 +3,25 @@
 ======================
 
 ### Parents
-- Relation: #typeContainer Type: #FamixTWithTypes Opposite: #types Comment: Container entity to which this type belongs. Container is a namespace, not a package (Smalltalk).
+| Relation | Type | Opposite | Comment |
+| `typeContainer` | `FamixTWithTypes` | `types` | Container entity to which this type belongs. Container is a namespace, not a package (Smalltalk).|
+
 ### Incoming dependencies
-- Relation: #incomingReferences Type: #FamixTReference Opposite: #referredType Comment: References to this entity by other entities.
+| Relation | Type | Opposite | Comment |
+| `incomingReferences` | `FamixTReference` | `referredType` | References to this entity by other entities.|
+
 ### Other
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
-- Relation: #typedEntities Type: #FamixTTypedEntity Opposite: #declaredType Comment: Entities that have this type as declaredType
+| Relation | Type | Opposite | Comment |
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+| `typedEntities` | `FamixTTypedEntity` | `declaredType` | Entities that have this type as declaredType|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
-- Named: #name Type: String Comment: Basic name of the entity, not full reference.
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
+| `name` | String | Basic name of the entity, not full reference.|
 
 "
 Class {

--- a/src/Moose-Core-Tests-Entities/MooseMSEImporterTestSourceAnchor.class.st
+++ b/src/Moose-Core-Tests-Entities/MooseMSEImporterTestSourceAnchor.class.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Other
-- Relation: #element Type: #FamixTSourceEntity Opposite: #sourceAnchor Comment: Enable the accessibility to the famix entity that this class is a source pointer for
+| Relation | Type | Opposite | Comment |
+| `element` | `FamixTSourceEntity` | `sourceAnchor` | Enable the accessibility to the famix entity that this class is a source pointer for|
+
 
 
 "

--- a/src/Moose-Core-Tests-Entities/MooseMSEImporterTestSourceLanguage.class.st
+++ b/src/Moose-Core-Tests-Entities/MooseMSEImporterTestSourceLanguage.class.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Other
-- Relation: #sourcedEntities Type: #FamixTWithSourceLanguages Opposite: #declaredSourceLanguage Comment: References to the entities saying explicitly that are written in this language.
+| Relation | Type | Opposite | Comment |
+| `sourcedEntities` | `FamixTWithSourceLanguages` | `declaredSourceLanguage` | References to the entities saying explicitly that are written in this language.|
+
 
 
 "

--- a/src/Moose-Core-Tests-Entities/MooseMSEImporterTestSourceTextAnchor.class.st
+++ b/src/Moose-Core-Tests-Entities/MooseMSEImporterTestSourceTextAnchor.class.st
@@ -3,12 +3,15 @@
 ======================
 
 ### Other
-- Relation: #element Type: #FamixTSourceEntity Opposite: #sourceAnchor Comment: Enable the accessibility to the famix entity that this class is a source pointer for
+| Relation | Type | Opposite | Comment |
+| `element` | `FamixTSourceEntity` | `sourceAnchor` | Enable the accessibility to the famix entity that this class is a source pointer for|
+
 
 ## Properties
 ======================
 
-- Named: #source Type: String Comment: Actual source code of the source entity
+| Name | Type | Comment |
+| `source` | String | Actual source code of the source entity|
 
 "
 Class {

--- a/src/Moose-Core-Tests-Entities/MooseMSEImporterTestSourcedEntity.class.st
+++ b/src/Moose-Core-Tests-Entities/MooseMSEImporterTestSourcedEntity.class.st
@@ -3,12 +3,15 @@
 ======================
 
 ### Other
-- Relation: #sourceAnchor Type: #FamixTSourceAnchor Opposite: #element Comment: SourceAnchor entity linking to the original source code for this entity
+| Relation | Type | Opposite | Comment |
+| `sourceAnchor` | `FamixTSourceAnchor` | `element` | SourceAnchor entity linking to the original source code for this entity|
+
 
 ## Properties
 ======================
 
-- Named: #isStub Type: Boolean Comment: Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.
+| Name | Type | Comment |
+| `isStub` | Boolean | Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.|
 
 "
 Class {

--- a/src/Moose-Core-Tests-Entities/MooseMSEImporterTestUnknownSourceLanguage.class.st
+++ b/src/Moose-Core-Tests-Entities/MooseMSEImporterTestUnknownSourceLanguage.class.st
@@ -3,7 +3,9 @@
 ======================
 
 ### Other
-- Relation: #sourcedEntities Type: #FamixTWithSourceLanguages Opposite: #declaredSourceLanguage Comment: References to the entities saying explicitly that are written in this language.
+| Relation | Type | Opposite | Comment |
+| `sourcedEntities` | `FamixTWithSourceLanguages` | `declaredSourceLanguage` | References to the entities saying explicitly that are written in this language.|
+
 
 
 "


### PR DESCRIPTION
Use tables instead of lists to display the properties

![image](https://github.com/moosetechnology/Famix/assets/9519971/8e7c36ee-7474-45ff-bc2a-0fb5b380ab03)
