### PR TITLE
Speedup #allUsing:

### DIFF
--- a/src/Moose-Core/MooseAbstractGroup.class.st
+++ b/src/Moose-Core/MooseAbstractGroup.class.st
@@ -106,12 +106,12 @@ MooseAbstractGroup >> allUsing: aTrait [
 
 { #category : #groups }
 MooseAbstractGroup >> allUsing: aTrait ofGroupClass: aGroupClass [
+
 	aTrait isTrait ifFalse: [ MooseAllUsingOnClass signal ].
-	^ self
-		cacheAt: aTrait
-		ifAbsentPut: [ aGroupClass
-				withAll: ((aTrait allUsers flattened flatCollect: #withAllSubclasses) asSet flatCollect: [ :each | self entityStorage selectAllWithType: each ])
-				withDescription: 'All ' , aTrait name asLowercase asEnglishPlural ]
+	^ self cacheAt: aTrait ifAbsentPut: [
+		  aGroupClass
+			  withAll: (self entityStorage select: [ :entity | entity class traitComposition includesTrait: aTrait ])
+			  withDescription: 'All ' , aTrait name asLowercase asEnglishPlural ]
 ]
 
 { #category : #groups }


### PR DESCRIPTION
#allUsing: is pretty slow when we call it a lot. This is because it is trying to find all optential users of a trait in the image and then iterates over all entities of the group to find those matching the found classes and traits. 

I propose an alternative way that is to iterate once and ask the trait composition if it includes the trait.

I had an architectural map taking 5sec to open and with this improvement it is down to 0.8sec. I plan to also do an improvement in Pharo 12 to speedup #includesTrait: so that this becomes even faster. If it works I might propose it for P11 aswell