### PR TITLE
Improve MooseGroup sorting

### DIFF
--- a/src/Moose-Core-Tests/MooseGroupTest.class.st
+++ b/src/Moose-Core-Tests/MooseGroupTest.class.st
@@ -146,6 +146,29 @@ MooseGroupTest >> testObjectAsMooseGroup [
 
 { #category : #tests }
 MooseGroupTest >> testSort [
-	group addAll: #(4 3 1 2).
-	self assertCollection: (group sorted: #yourself ascending) hasSameElements: #(1 2 3 4)
+
+	| newGroup |
+	group addAll: #( 4 3 1 2 ).
+	newGroup := group sort: #yourself ascending.
+	"#sort: should sort the receiver."
+	self assert: group identicalTo: newGroup.
+	self assert: newGroup first equals: 1.
+	self assert: newGroup second equals: 2.
+	self assert: newGroup third equals: 3.
+	self assert: newGroup fourth equals: 4
+]
+
+{ #category : #tests }
+MooseGroupTest >> testSorted [
+
+	| newGroup |
+	group addAll: #( 4 3 1 2 ).
+	newGroup := group sorted: #yourself ascending.
+	"#sorted: should return a new collection and not sort the receiver."
+	self deny: group identicalTo: newGroup.
+	self assert: newGroup first equals: 1.
+	self assert: newGroup second equals: 2.
+	self assert: newGroup third equals: 3.
+	self assert: newGroup fourth equals: 4.
+	self assert: group first equals: 4
 ]

--- a/src/Moose-Core/MooseGroup.class.st
+++ b/src/Moose-Core/MooseGroup.class.st
@@ -186,7 +186,8 @@ MooseGroup >> select: aBlock [
 
 { #category : #'public interface' }
 MooseGroup >> sort: aBlock [
-	self entities: (self entities sorted: aBlock)
+
+	self entityStorage sort: aBlock
 ]
 
 { #category : #'public interface' }

--- a/src/Moose-Core/MooseGroupRuntimeStorage.class.st
+++ b/src/Moose-Core/MooseGroupRuntimeStorage.class.st
@@ -126,6 +126,12 @@ MooseGroupRuntimeStorage >> size [
 	^ elements size
 ]
 
+{ #category : #sorting }
+MooseGroupRuntimeStorage >> sort: aBlock [
+
+	self elements sort: aBlock
+]
+
 { #category : #accessing }
 MooseGroupRuntimeStorage >> species: anObject [
 


### PR DESCRIPTION
This change adds tests on sorting of MooseGroup (the only test was not testing anything on the sorting..) and speed up #sort: by no recreating a MooseGroupStorage.