### PR TITLE
Header row in generated comments

### DIFF
--- a/src/Famix-MetamodelBuilder-Core/FmxMBBehavior.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxMBBehavior.class.st
@@ -148,6 +148,8 @@ FmxMBBehavior >> commentWithRelations [
 								  nextPutAll: relationKind;
 								  cr;
 								  nextPutAll: '| Relation | Origin | Opposite | Type | Comment |';
+								  cr;
+								  nextPutAll: '|---|';
 								  cr.
 							  (parents sorted: [ :parent | parent side generationStrategy relationSide name ] ascending) do: [ :parent |
 								  | strategy |
@@ -177,6 +179,8 @@ FmxMBBehavior >> commentWithRelations [
 				  cr;
 				  cr;
 				  nextPutAll: '| Name | Type | Default value | Comment |';
+				  cr;
+				  nextPutAll: '|---|';
 				  cr.
 
 			  (props sorted: #name ascending) do: [ :property |


### PR DESCRIPTION
Without header:
![image](https://github.com/moosetechnology/Famix/assets/78592838/0a3a4841-6022-4602-9ddd-9d5dcefc4185)

With header:
![image](https://github.com/moosetechnology/Famix/assets/78592838/53fd1622-adcd-4c2a-80f8-cd3b65f5da7b)

Semantically, I prefer it.
Visually, I'm not sure, because with the default theme it looks very similar to the background color.