### PR TITLE
Rename Moose-GenericImporter

### DIFF
--- a/src/BaselineOfFamix/BaselineOfFamix.class.st
+++ b/src/BaselineOfFamix/BaselineOfFamix.class.st
@@ -100,7 +100,7 @@ BaselineOfFamix >> groups: spec [
 		  with: #( 'Famix-PharoSmalltalk-Generator'
 			     'EntitiesSmalltalk' );
 		  group: 'Importers'
-		  with: #( 'Moose-GenericImporter' 'Moose-SmalltalkImporter' );
+		  with: #( 'Moose-Importers' 'Moose-SmalltalkImporter' );
 		  group: 'TestModels'
 		  with: #( 'Famix-Test1-Entities' 'Famix-Test2-Entities'
 			     'Famix-Test3-Entities' 'Famix-Test4-Entities' 'Famix-Test7-Entities' );
@@ -119,7 +119,7 @@ BaselineOfFamix >> groups: spec [
 			     'Famix-TestComposedMetamodel-Entities'
 			     'Famix-TestComposedMetamodel' 'Famix-TestComposedComposedMetamodel-Entities'
 			     'Famix-TestComposed3Metamodel-Entities'
-			     'Moose-GenericImporters-Tests' )
+			     'Moose-Importers-Tests' )
 ]
 
 { #category : #dependencies }
@@ -150,148 +150,73 @@ BaselineOfFamix >> packageRepositoryURL [
 BaselineOfFamix >> packages: spec [
 
 	spec
-		package: 'Moose-Query'
-		with: [
-			spec requires: #( 'Fame' 'DeepTraverser' 'CollectionExtensions' ) ];
-		package: 'Moose-Core'
-		with: [ spec requires: #( 'Fame' 'Moose-Query' ) ];
-		package: 'Moose-Core-Generator'
-		with: [ spec requires: #( 'Famix-MetamodelBuilder-Core' ) ];
-		package: 'Moose-Query-Extensions'
-		with: [ spec requires: #( 'Moose-Query' 'BasicTraits' ) ];
+		package: 'Moose-Query' with: [ spec requires: #( 'Fame' 'DeepTraverser' 'CollectionExtensions' ) ];
+		package: 'Moose-Core' with: [ spec requires: #( 'Fame' 'Moose-Query' ) ];
+		package: 'Moose-Core-Generator' with: [ spec requires: #( 'Famix-MetamodelBuilder-Core' ) ];
+		package: 'Moose-Query-Extensions' with: [ spec requires: #( 'Moose-Query' 'BasicTraits' ) ];
 		package: 'Famix-Traits' with: [ spec requires: #( 'Moose-Core' ) ];
-		package: 'Famix-MetamodelBuilder-Core'
-		with: [ spec requires: #( 'Moose-Core' 'SingularizePluralize' ) ];
-		package: 'Famix-MetamodelGeneration'
-		with: [ spec requires: #( 'Famix-MetamodelBuilder-Core' ) ];
-		package: 'Famix-Visualizations'
-		with: [ spec requires: #( 'Famix-Traits' 'Fame' 'Moose-Core' ) ];
-		package: 'Famix-BasicInfrastructure'
-		with: [ spec requires: #( 'Famix-MetamodelGeneration' ) ];
-		package: 'Famix-Smalltalk-Utils'
-		with: [ spec requires: #( 'Moose-Core' ) ];
-		package: 'Moose-GenericImporter'
-		with: [ spec requires: #( 'BasicTraits' ) ];
-		package: 'Moose-SmalltalkImporter' with: [
-			spec requires:
-					#( 'Moose-GenericImporter' 'RoelTyper' 'Famix-PharoSmalltalk-Entities' ) ];
-		package: 'Famix-VerveineJ-Tests'
-		with: [
-			spec requires: #( 'Moose-Core-Tests' 'Famix-Java-Entities' ) ];
-		package: 'Famix-PharoSmalltalk-Generator'
-		with: [ spec requires: #( 'Basic' ) ];
-		package: 'Famix-PharoSmalltalk-Entities'
-		with: [ spec requires: #( 'Famix-Smalltalk-Utils'
-				   'BasicTraits' ) ];
+		package: 'Famix-MetamodelBuilder-Core' with: [ spec requires: #( 'Moose-Core' 'SingularizePluralize' ) ];
+		package: 'Famix-MetamodelGeneration' with: [ spec requires: #( 'Famix-MetamodelBuilder-Core' ) ];
+		package: 'Famix-Visualizations' with: [ spec requires: #( 'Famix-Traits' 'Fame' 'Moose-Core' ) ];
+		package: 'Famix-BasicInfrastructure' with: [ spec requires: #( 'Famix-MetamodelGeneration' ) ];
+		package: 'Famix-Smalltalk-Utils' with: [ spec requires: #( 'Moose-Core' ) ];
+		package: 'Moose-Importers' with: [ spec requires: #( 'BasicTraits' ) ];
+		package: 'Moose-SmalltalkImporter' with: [ spec requires: #( 'Moose-Importers' 'RoelTyper' 'Famix-PharoSmalltalk-Entities' ) ];
+		package: 'Famix-VerveineJ-Tests' with: [ spec requires: #( 'Moose-Core-Tests' 'Famix-Java-Entities' ) ];
+		package: 'Famix-PharoSmalltalk-Generator' with: [ spec requires: #( 'Basic' ) ];
+		package: 'Famix-PharoSmalltalk-Entities' with: [ spec requires: #( 'Famix-Smalltalk-Utils' 'BasicTraits' ) ];
 		package: 'Famix-PharoSmalltalk-Tests' with: [
 			spec requires:
-					#( 'Famix-PharoSmalltalk-Entities'
-					   'Moose-SmalltalkImporter-Core-Tests'
-					   'PackageBlueprintTestResources'
-					   'Moose-TestResources-LCOM' 'KGBTestResources' ) ];
-		package: 'Famix-Java-Generator'
-		with: [ spec requires: #( 'Basic' ) ];
-		package: 'Famix-Java-Entities'
-		with: [ spec requires: #( 'BasicTraits' ) ];
-		package: 'Famix-Java-Visitor'
-		with: [ spec requires: #( 'Famix-Java-Entities' ) ];
-		package: 'Famix-Java-Tests'
-		with: [
-			spec requires: #( 'Famix-Java-Entities' 'Famix-Java-Generator' ) ];
+					#( 'Famix-PharoSmalltalk-Entities' 'Moose-SmalltalkImporter-Core-Tests' 'PackageBlueprintTestResources' 'Moose-TestResources-LCOM'
+					   'KGBTestResources' ) ];
+		package: 'Famix-Java-Generator' with: [ spec requires: #( 'Basic' ) ];
+		package: 'Famix-Java-Entities' with: [ spec requires: #( 'BasicTraits' ) ];
+		package: 'Famix-Java-Visitor' with: [ spec requires: #( 'Famix-Java-Entities' ) ];
+		package: 'Famix-Java-Tests' with: [ spec requires: #( 'Famix-Java-Entities' 'Famix-Java-Generator' ) ];
 		package: 'Moose-TestResources-LAN';
 		package: 'Moose-TestResources-LCOM';
-		package: 'Moose-Query-Test'
-		with: [ spec requires: #( 'Moose-Query' 'Famix-Java-Entities' ) ];
-		package: 'FamixTestGenerator'
-		with: [ spec requires: #( 'Famix-Tests' 'Fame' ) ];
-		package: 'Famix-Tests'
-		with: [ spec requires: #( 'BasicTraits' 'Talents' ) ];
-		package: 'Moose-Core-Tests'
-		with: [
-			spec requires: #( 'TestModels' 'Moose-Core-Tests-Entities' ) ];
-		package: 'Moose-Core-Tests-Entities'
-		with: [ spec requires: #( 'Moose-Core' 'BasicTraits' ) ];
-		package: 'Moose-GenericImporters-Tests'
-		with: [
-			spec requires: #( 'Moose-GenericImporter' 'Famix-Test1-Entities' ) ];
-		package: 'Famix-Smalltalk-Utils-Tests' with: [
-			spec requires:
-					#( 'Famix-Smalltalk-Utils' 'ReferenceTestResources' ) ];
-		package: 'Moose-SmalltalkImporter-Core-Tests' with: [
-			spec requires: #( 'Moose-Core-Tests' 'Moose-SmalltalkImporter'
-					   'ReferenceTestResources' ) ];
-		package: 'Moose-SmalltalkImporter-LAN-Tests' with: [
-			spec requires: #( 'Moose-SmalltalkImporter-Core-Tests'
-					   'Moose-TestResources-LAN' ) ];
-		package: 'Moose-SmalltalkImporter-KGB-Tests' with: [
-			spec requires:
-					#( 'KGBTestResources' 'Moose-SmalltalkImporter-Core-Tests' ) ];
-		package: 'Famix-TestGenerators'
-		with: [ spec requires: #( 'Basic' ) ];
+		package: 'Moose-Query-Test' with: [ spec requires: #( 'Moose-Query' 'Famix-Java-Entities' ) ];
+		package: 'FamixTestGenerator' with: [ spec requires: #( 'Famix-Tests' 'Fame' ) ];
+		package: 'Famix-Tests' with: [ spec requires: #( 'BasicTraits' 'Talents' ) ];
+		package: 'Moose-Core-Tests' with: [ spec requires: #( 'TestModels' 'Moose-Core-Tests-Entities' ) ];
+		package: 'Moose-Core-Tests-Entities' with: [ spec requires: #( 'Moose-Core' 'BasicTraits' ) ];
+		package: 'Moose-Importers-Tests' with: [ spec requires: #( 'Moose-Importers' 'Famix-Test1-Entities' ) ];
+		package: 'Famix-Smalltalk-Utils-Tests' with: [ spec requires: #( 'Famix-Smalltalk-Utils' 'ReferenceTestResources' ) ];
+		package: 'Moose-SmalltalkImporter-Core-Tests' with: [ spec requires: #( 'Moose-Core-Tests' 'Moose-SmalltalkImporter' 'ReferenceTestResources' ) ];
+		package: 'Moose-SmalltalkImporter-LAN-Tests' with: [ spec requires: #( 'Moose-SmalltalkImporter-Core-Tests' 'Moose-TestResources-LAN' ) ];
+		package: 'Moose-SmalltalkImporter-KGB-Tests' with: [ spec requires: #( 'KGBTestResources' 'Moose-SmalltalkImporter-Core-Tests' ) ];
+		package: 'Famix-TestGenerators' with: [ spec requires: #( 'Basic' ) ];
 		package: 'Famix-MetamodelBuilder-Tests' with: [
-			spec requires:
-					#( 'Famix-TestGenerators' 'Famix-MetamodelBuilder-TestsTraitsResources-A'
-					   'Famix-MetamodelBuilder-TestsTraitsResources-B'
+			spec requires: #( 'Famix-TestGenerators' 'Famix-MetamodelBuilder-TestsTraitsResources-A' 'Famix-MetamodelBuilder-TestsTraitsResources-B'
 					   'Famix-Test1-Entities' ) ];
-		package: 'Famix-MetamodelBuilder-TestsTraitsResources-A'
-		with: [ spec requires: #( 'Basic' ) ];
-		package: 'Famix-MetamodelBuilder-TestsTraitsResources-B' with: [
-			spec requires:
-					#( 'Basic' 'Famix-MetamodelBuilder-TestsTraitsResources-A' ) ];
-		package: 'Famix-Test1-Entities'
-		with: [ spec requires: #( 'BasicTraits' ) ];
-		package: 'Famix-Test1-Tests'
-		with: [ spec requires: #( 'Famix-Test1-Entities' ) ];
-		package: 'Famix-Test2-Entities'
-		with: [ spec requires: #( 'BasicTraits' ) ];
-		package: 'Famix-Test2-Tests'
-		with: [ spec requires: #( 'Famix-Test2-Entities' ) ];
-		package: 'Famix-Test3-Entities'
-		with: [ spec requires: #( 'BasicTraits' ) ];
-		package: 'Famix-Test3-Tests'
-		with: [ spec requires: #( 'Famix-Test3-Entities' ) ];
-		package: 'Famix-Test4-Entities'
-		with: [ spec requires: #( 'BasicTraits' ) ];
-		package: 'Famix-Test4-Tests'
-		with: [ spec requires: #( 'Famix-Test4-Entities' ) ];
-		package: 'Famix-Test5-Entities'
-		with: [ spec requires: #( 'BasicTraits' ) ];
-		package: 'Famix-Test5-Tests'
-		with: [ spec requires: #( 'Famix-Test5-Entities' ) ];
-		package: 'Famix-Test6-Entities'
-		with: [ spec requires: #( 'BasicTraits' ) ];
-		package: 'Famix-Test6-Tests'
-		with: [ spec requires: #( 'Famix-Test6-Entities' ) ];
-		package: 'Famix-Test7-Entities'
-		with: [ spec requires: #( 'BasicTraits' ) ];
-		package: 'Famix-Test7-Tests'
-		with: [ spec requires: #( 'Famix-Test7-Entities' ) ];
-		package: 'Famix-Test8-Entities'
-		with: [ spec requires: #( 'BasicTraits' ) ];
-		package: 'Famix-Test8-Tests'
-		with: [ spec requires: #( 'Famix-Test8-Entities' ) ];
-		package: 'Famix-TestComposedSubmetamodel1-Entities'
-		with: [ spec requires: #( 'BasicTraits' ) ];
-		package: 'Famix-TestComposedSubmetamodel2-Entities'
-		with: [ spec requires: #( 'BasicTraits' ) ];
-		package: 'Famix-TestComposedMetamodel-Entities' with: [
-			spec requires:
-					#( 'Famix-Test2-Entities' 'Famix-TestComposedSubmetamodel1-Entities'
-					   'Famix-TestComposedSubmetamodel2-Entities' ) ];
-		package: 'Famix-TestComposedComposedMetamodel-Entities'
-		with: [ spec requires: #( 'Famix-TestComposedMetamodel-Entities' ) ];
-		package: 'Famix-TestComposed3Metamodel-Entities'
-		with: [ spec requires: #( 'Famix-TestComposedMetamodel-Entities' ) ];
-		package: 'Famix-TestComposedMetamodel'
-		with: [ spec requires: #( 'Famix-TestComposedMetamodel-Entities' ) ];
-		package: 'Famix-Deprecated'
-		with: [
-			spec requires: #( 'Core' 'ModelJava' 'ModelSmalltalk'
-				   'Tests' ) ];
+		package: 'Famix-MetamodelBuilder-TestsTraitsResources-A' with: [ spec requires: #( 'Basic' ) ];
+		package: 'Famix-MetamodelBuilder-TestsTraitsResources-B' with: [ spec requires: #( 'Basic' 'Famix-MetamodelBuilder-TestsTraitsResources-A' ) ];
+		package: 'Famix-Test1-Entities' with: [ spec requires: #( 'BasicTraits' ) ];
+		package: 'Famix-Test1-Tests' with: [ spec requires: #( 'Famix-Test1-Entities' ) ];
+		package: 'Famix-Test2-Entities' with: [ spec requires: #( 'BasicTraits' ) ];
+		package: 'Famix-Test2-Tests' with: [ spec requires: #( 'Famix-Test2-Entities' ) ];
+		package: 'Famix-Test3-Entities' with: [ spec requires: #( 'BasicTraits' ) ];
+		package: 'Famix-Test3-Tests' with: [ spec requires: #( 'Famix-Test3-Entities' ) ];
+		package: 'Famix-Test4-Entities' with: [ spec requires: #( 'BasicTraits' ) ];
+		package: 'Famix-Test4-Tests' with: [ spec requires: #( 'Famix-Test4-Entities' ) ];
+		package: 'Famix-Test5-Entities' with: [ spec requires: #( 'BasicTraits' ) ];
+		package: 'Famix-Test5-Tests' with: [ spec requires: #( 'Famix-Test5-Entities' ) ];
+		package: 'Famix-Test6-Entities' with: [ spec requires: #( 'BasicTraits' ) ];
+		package: 'Famix-Test6-Tests' with: [ spec requires: #( 'Famix-Test6-Entities' ) ];
+		package: 'Famix-Test7-Entities' with: [ spec requires: #( 'BasicTraits' ) ];
+		package: 'Famix-Test7-Tests' with: [ spec requires: #( 'Famix-Test7-Entities' ) ];
+		package: 'Famix-Test8-Entities' with: [ spec requires: #( 'BasicTraits' ) ];
+		package: 'Famix-Test8-Tests' with: [ spec requires: #( 'Famix-Test8-Entities' ) ];
+		package: 'Famix-TestComposedSubmetamodel1-Entities' with: [ spec requires: #( 'BasicTraits' ) ];
+		package: 'Famix-TestComposedSubmetamodel2-Entities' with: [ spec requires: #( 'BasicTraits' ) ];
+		package: 'Famix-TestComposedMetamodel-Entities'
+		with: [ spec requires: #( 'Famix-Test2-Entities' 'Famix-TestComposedSubmetamodel1-Entities' 'Famix-TestComposedSubmetamodel2-Entities' ) ];
+		package: 'Famix-TestComposedComposedMetamodel-Entities' with: [ spec requires: #( 'Famix-TestComposedMetamodel-Entities' ) ];
+		package: 'Famix-TestComposed3Metamodel-Entities' with: [ spec requires: #( 'Famix-TestComposedMetamodel-Entities' ) ];
+		package: 'Famix-TestComposedMetamodel' with: [ spec requires: #( 'Famix-TestComposedMetamodel-Entities' ) ];
+		package: 'Famix-Deprecated' with: [ spec requires: #( 'Core' 'ModelJava' 'ModelSmalltalk' 'Tests' ) ];
 		package: 'Famix-UMLDocumentor' with: [ spec requires: #( 'Core' ) ];
-		package: 'Famix-UMLDocumentor-Tests' with: [
-			spec requires:
-					#( 'Famix-UMLDocumentor' 'FamixDocumentor-TestMetaModel' ) ];
+		package: 'Famix-UMLDocumentor-Tests' with: [ spec requires: #( 'Famix-UMLDocumentor' 'FamixDocumentor-TestMetaModel' ) ];
 		package: 'FamixDocumentor-TestMetaModel'
 ]
 

--- a/src/Moose-GenericImporter/package.st
+++ b/src/Moose-GenericImporter/package.st
@@ -1,1 +1,0 @@
-Package { #name : #'Moose-GenericImporter' }

--- a/src/Moose-GenericImporters-Tests/package.st
+++ b/src/Moose-GenericImporters-Tests/package.st
@@ -1,1 +1,0 @@
-Package { #name : #'Moose-GenericImporters-Tests' }

--- a/src/Moose-Importers-Tests/MooseFileStructureImporterTest.class.st
+++ b/src/Moose-Importers-Tests/MooseFileStructureImporterTest.class.st
@@ -5,7 +5,7 @@ Class {
 		'model',
 		'toDelete'
 	],
-	#category : #'Moose-GenericImporters-Tests'
+	#category : #'Moose-Importers-Tests'
 }
 
 { #category : #setup }

--- a/src/Moose-Importers-Tests/package.st
+++ b/src/Moose-Importers-Tests/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'Moose-Importers-Tests' }

--- a/src/Moose-Importers/FamixBasicInfrastructureMetamodelFactory.class.st
+++ b/src/Moose-Importers/FamixBasicInfrastructureMetamodelFactory.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #FamixBasicInfrastructureMetamodelFactory,
 	#superclass : #FMMetamodelFactory,
-	#category : #'Moose-GenericImporter-Factories'
+	#category : #'Moose-Importers-Factories'
 }
 
 { #category : #testing }

--- a/src/Moose-Importers/MooseAbstractImporter.class.st
+++ b/src/Moose-Importers/MooseAbstractImporter.class.st
@@ -10,7 +10,7 @@ Class {
 		'loggingStream',
 		'targetModel'
 	],
-	#category : #'Moose-GenericImporter-Importers'
+	#category : #'Moose-Importers-Importers'
 }
 
 { #category : #public }

--- a/src/Moose-Importers/MooseFileStructureImporter.class.st
+++ b/src/Moose-Importers/MooseFileStructureImporter.class.st
@@ -5,7 +5,7 @@ Class {
 		'mooseModel',
 		'factory'
 	],
-	#category : #'Moose-GenericImporter-Importers'
+	#category : #'Moose-Importers-Importers'
 }
 
 { #category : #accessing }

--- a/src/Moose-Importers/MooseImportingContext.class.st
+++ b/src/Moose-Importers/MooseImportingContext.class.st
@@ -33,7 +33,7 @@ Class {
 	#classInstVars : [
 		'entityDependencies'
 	],
-	#category : #'Moose-GenericImporter-Contexts'
+	#category : #'Moose-Importers-Contexts'
 }
 
 { #category : #'importing-filters' }

--- a/src/Moose-Importers/package.st
+++ b/src/Moose-Importers/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'Moose-Importers' }


### PR DESCRIPTION
Rename Moose-GenericImporter into Moose-Importers because the generic is not really explicit and we will really soon move some basic importers from MooseIDE to Famix.