### PR TITLE
Make comments children of commented entities

### DIFF
--- a/src/Famix-Java-Entities/FamixJavaAnnotationType.class.st
+++ b/src/Famix-Java-Entities/FamixJavaAnnotationType.class.st
@@ -12,6 +12,7 @@
 | Relation | Origin | Opposite | Type | Comment |
 |---|
 | `attributes` | `FamixTWithAttributes` | `parentType` | `FamixTAttribute` | List of attributes declared by this type.|
+| `comments` | `FamixTWithComments` | `commentedEntity` | `FamixTComment` | List of comments for the entity|
 
 ### Outgoing dependencies
 | Relation | Origin | Opposite | Type | Comment |
@@ -27,7 +28,6 @@
 ### Other
 | Relation | Origin | Opposite | Type | Comment |
 |---|
-| `comments` | `FamixTWithComments` | `commentedEntity` | `FamixTComment` | List of comments for the entity|
 | `instances` | `FamixTAnnotationType` | `annotationType` | `FamixTTypedAnnotationInstance` | Annotations of this type|
 
 

--- a/src/Famix-Java-Entities/FamixJavaAnnotationTypeAttribute.class.st
+++ b/src/Famix-Java-Entities/FamixJavaAnnotationTypeAttribute.class.st
@@ -7,6 +7,11 @@
 |---|
 | `parentType` | `FamixTAttribute` | `attributes` | `FamixTWithAttributes` | Type declaring the attribute. belongsTo implementation|
 
+### Children
+| Relation | Origin | Opposite | Type | Comment |
+|---|
+| `comments` | `FamixTWithComments` | `commentedEntity` | `FamixTComment` | List of comments for the entity|
+
 ### Incoming dependencies
 | Relation | Origin | Opposite | Type | Comment |
 |---|
@@ -17,7 +22,6 @@
 |---|
 | `annotationAttributeInstances` | `FamixTAnnotationTypeAttribute` | `annotationTypeAttribute` | `FamixTTypedAnnotationInstanceAttribute` | A collection of AnnotationInstanceAttribute which hold the usages of this attribute in actual AnnotationInstances|
 | `annotationTypeAttribute` | `FamixTTypedAnnotationInstanceAttribute` | `annotationAttributeInstances` | `FamixTAnnotationTypeAttribute` | This corresponds to the type of the attribute in an AnnotationInstance|
-| `comments` | `FamixTWithComments` | `commentedEntity` | `FamixTComment` | List of comments for the entity|
 | `declaredType` | `FamixTTypedEntity` | `typedEntities` | `FamixTType` | Type of the entity, if any|
 | `sourceAnchor` | `FamixTSourceEntity` | `element` | `FamixTSourceAnchor` | SourceAnchor entity linking to the original source code for this entity|
 

--- a/src/Famix-Java-Entities/FamixJavaAttribute.class.st
+++ b/src/Famix-Java-Entities/FamixJavaAttribute.class.st
@@ -7,6 +7,11 @@
 |---|
 | `parentType` | `FamixTAttribute` | `attributes` | `FamixTWithAttributes` | Type declaring the attribute. belongsTo implementation|
 
+### Children
+| Relation | Origin | Opposite | Type | Comment |
+|---|
+| `comments` | `FamixTWithComments` | `commentedEntity` | `FamixTComment` | List of comments for the entity|
+
 ### Incoming dependencies
 | Relation | Origin | Opposite | Type | Comment |
 |---|
@@ -15,7 +20,6 @@
 ### Other
 | Relation | Origin | Opposite | Type | Comment |
 |---|
-| `comments` | `FamixTWithComments` | `commentedEntity` | `FamixTComment` | List of comments for the entity|
 | `declaredType` | `FamixTTypedEntity` | `typedEntities` | `FamixTType` | Type of the entity, if any|
 | `receivingInvocations` | `FamixTInvocationsReceiver` | `receiver` | `FamixTInvocation` | List of invocations performed on this entity (considered as the receiver)|
 | `sourceAnchor` | `FamixTSourceEntity` | `element` | `FamixTSourceAnchor` | SourceAnchor entity linking to the original source code for this entity|

--- a/src/Famix-Java-Entities/FamixJavaClass.class.st
+++ b/src/Famix-Java-Entities/FamixJavaClass.class.st
@@ -12,6 +12,7 @@
 | Relation | Origin | Opposite | Type | Comment |
 |---|
 | `attributes` | `FamixTWithAttributes` | `parentType` | `FamixTAttribute` | List of attributes declared by this type.|
+| `comments` | `FamixTWithComments` | `commentedEntity` | `FamixTComment` | List of comments for the entity|
 | `methods` | `FamixTWithMethods` | `parentType` | `FamixTMethod` | Methods declared by this type.|
 
 ### Outgoing dependencies
@@ -31,7 +32,6 @@
 ### Other
 | Relation | Origin | Opposite | Type | Comment |
 |---|
-| `comments` | `FamixTWithComments` | `commentedEntity` | `FamixTComment` | List of comments for the entity|
 | `receivingInvocations` | `FamixTInvocationsReceiver` | `receiver` | `FamixTInvocation` | List of invocations performed on this entity (considered as the receiver)|
 | `sourceAnchor` | `FamixTSourceEntity` | `element` | `FamixTSourceAnchor` | SourceAnchor entity linking to the original source code for this entity|
 | `typedEntities` | `FamixTType` | `declaredType` | `FamixTTypedEntity` | Entities that have this type as declaredType|
@@ -176,11 +176,12 @@ FamixJavaClass >> methodsWithoutSutbsAndConstructors [
 { #category : #accessing }
 FamixJavaClass >> numberOfComments [
 	"Overrides to include method comments in the numberOfComments of the class"
-	^ self
-		lookUpPropertyNamed: #numberOfComments
-		computedAs: [ self children asArray
-			inject: self comments size into: [ :sum :child | child numberOfComments + sum ] ]
 
+	^ self lookUpPropertyNamed: #numberOfComments computedAs: [
+		  self children asArray inject: self comments size into: [ :sum :child |
+			  (child class includesTrait: FamixTWithComments)
+				  ifTrue: [ child numberOfComments + sum ]
+				  ifFalse: [ sum ] ] ]
 ]
 
 { #category : #'Famix-Extensions' }

--- a/src/Famix-Java-Entities/FamixJavaComment.class.st
+++ b/src/Famix-Java-Entities/FamixJavaComment.class.st
@@ -2,7 +2,7 @@
 ## Relations
 ======================
 
-### Other
+### Parents
 | Relation | Origin | Opposite | Type | Comment |
 |---|
 | `commentedEntity` | `FamixTComment` | `comments` | `FamixTWithComments` | Source code commented by the comment|

--- a/src/Famix-Java-Entities/FamixJavaEnum.class.st
+++ b/src/Famix-Java-Entities/FamixJavaEnum.class.st
@@ -11,6 +11,7 @@
 | Relation | Origin | Opposite | Type | Comment |
 |---|
 | `attributes` | `FamixTWithAttributes` | `parentType` | `FamixTAttribute` | List of attributes declared by this type.|
+| `comments` | `FamixTWithComments` | `commentedEntity` | `FamixTComment` | List of comments for the entity|
 | `enumValues` | `FamixTWithEnumValues` | `parentEnum` | `FamixTEnumValue` | |
 | `methods` | `FamixTWithMethods` | `parentType` | `FamixTMethod` | Methods declared by this type.|
 
@@ -30,7 +31,6 @@
 ### Other
 | Relation | Origin | Opposite | Type | Comment |
 |---|
-| `comments` | `FamixTWithComments` | `commentedEntity` | `FamixTComment` | List of comments for the entity|
 | `sourceAnchor` | `FamixTSourceEntity` | `element` | `FamixTSourceAnchor` | SourceAnchor entity linking to the original source code for this entity|
 | `typedEntities` | `FamixTType` | `declaredType` | `FamixTTypedEntity` | Entities that have this type as declaredType|
 

--- a/src/Famix-Java-Entities/FamixJavaEnumValue.class.st
+++ b/src/Famix-Java-Entities/FamixJavaEnumValue.class.st
@@ -7,6 +7,11 @@
 |---|
 | `parentEnum` | `FamixTEnumValue` | `enumValues` | `FamixTWithEnumValues` | The Enum declaring this value. It offers the implementation of belongsTo|
 
+### Children
+| Relation | Origin | Opposite | Type | Comment |
+|---|
+| `comments` | `FamixTWithComments` | `commentedEntity` | `FamixTComment` | List of comments for the entity|
+
 ### Incoming dependencies
 | Relation | Origin | Opposite | Type | Comment |
 |---|
@@ -15,7 +20,6 @@
 ### Other
 | Relation | Origin | Opposite | Type | Comment |
 |---|
-| `comments` | `FamixTWithComments` | `commentedEntity` | `FamixTComment` | List of comments for the entity|
 | `declaredType` | `FamixTTypedEntity` | `typedEntities` | `FamixTType` | Type of the entity, if any|
 | `sourceAnchor` | `FamixTSourceEntity` | `element` | `FamixTSourceAnchor` | SourceAnchor entity linking to the original source code for this entity|
 

--- a/src/Famix-Java-Entities/FamixJavaException.class.st
+++ b/src/Famix-Java-Entities/FamixJavaException.class.st
@@ -11,6 +11,7 @@
 | Relation | Origin | Opposite | Type | Comment |
 |---|
 | `attributes` | `FamixTWithAttributes` | `parentType` | `FamixTAttribute` | List of attributes declared by this type.|
+| `comments` | `FamixTWithComments` | `commentedEntity` | `FamixTComment` | List of comments for the entity|
 | `methods` | `FamixTWithMethods` | `parentType` | `FamixTMethod` | Methods declared by this type.|
 | `types` | `FamixTWithTypes` | `typeContainer` | `FamixTType` | Types contained (declared) in this entity, if any.
 #types is declared in ContainerEntity because different kinds of container can embed types. Types are usually contained in a Famix.Namespace. But types can also be contained in a Famix.Class or Famix.Method (in Java with inner classes for example). Famix.Function can also contain some types such as structs.|
@@ -32,7 +33,6 @@
 |---|
 | `annotationInstances` | `FamixTWithAnnotationInstances` | `annotatedEntity` | `FamixTAnnotationInstance` | This property corresponds to the set of annotations associated to the entity|
 | `catchingEntities` | `FamixTThrowable` | `caughtExceptions` | `FamixTWithExceptions` | |
-| `comments` | `FamixTWithComments` | `commentedEntity` | `FamixTComment` | List of comments for the entity|
 | `declaringEntities` | `FamixTThrowable` | `declaredExceptions` | `FamixTWithExceptions` | |
 | `receivingInvocations` | `FamixTInvocationsReceiver` | `receiver` | `FamixTInvocation` | List of invocations performed on this entity (considered as the receiver)|
 | `sourceAnchor` | `FamixTSourceEntity` | `element` | `FamixTSourceAnchor` | SourceAnchor entity linking to the original source code for this entity|

--- a/src/Famix-Java-Entities/FamixJavaInterface.class.st
+++ b/src/Famix-Java-Entities/FamixJavaInterface.class.st
@@ -11,6 +11,7 @@
 | Relation | Origin | Opposite | Type | Comment |
 |---|
 | `attributes` | `FamixTWithAttributes` | `parentType` | `FamixTAttribute` | List of attributes declared by this type.|
+| `comments` | `FamixTWithComments` | `commentedEntity` | `FamixTComment` | List of comments for the entity|
 | `methods` | `FamixTWithMethods` | `parentType` | `FamixTMethod` | Methods declared by this type.|
 
 ### Outgoing dependencies
@@ -29,7 +30,6 @@
 ### Other
 | Relation | Origin | Opposite | Type | Comment |
 |---|
-| `comments` | `FamixTWithComments` | `commentedEntity` | `FamixTComment` | List of comments for the entity|
 | `receivingInvocations` | `FamixTInvocationsReceiver` | `receiver` | `FamixTInvocation` | List of invocations performed on this entity (considered as the receiver)|
 
 

--- a/src/Famix-Java-Entities/FamixJavaLocalVariable.class.st
+++ b/src/Famix-Java-Entities/FamixJavaLocalVariable.class.st
@@ -7,6 +7,11 @@
 |---|
 | `parentBehaviouralEntity` | `FamixTLocalVariable` | `localVariables` | `FamixTWithLocalVariables` | Behavioural entity declaring this local variable. belongsTo implementation|
 
+### Children
+| Relation | Origin | Opposite | Type | Comment |
+|---|
+| `comments` | `FamixTWithComments` | `commentedEntity` | `FamixTComment` | List of comments for the entity|
+
 ### Incoming dependencies
 | Relation | Origin | Opposite | Type | Comment |
 |---|
@@ -15,7 +20,6 @@
 ### Other
 | Relation | Origin | Opposite | Type | Comment |
 |---|
-| `comments` | `FamixTWithComments` | `commentedEntity` | `FamixTComment` | List of comments for the entity|
 | `declaredType` | `FamixTTypedEntity` | `typedEntities` | `FamixTType` | Type of the entity, if any|
 | `receivingInvocations` | `FamixTInvocationsReceiver` | `receiver` | `FamixTInvocation` | List of invocations performed on this entity (considered as the receiver)|
 | `sourceAnchor` | `FamixTSourceEntity` | `element` | `FamixTSourceAnchor` | SourceAnchor entity linking to the original source code for this entity|

--- a/src/Famix-Java-Entities/FamixJavaMethod.class.st
+++ b/src/Famix-Java-Entities/FamixJavaMethod.class.st
@@ -10,6 +10,7 @@
 ### Children
 | Relation | Origin | Opposite | Type | Comment |
 |---|
+| `comments` | `FamixTWithComments` | `commentedEntity` | `FamixTComment` | List of comments for the entity|
 | `implicitVariables` | `FamixTWithImplicitVariables` | `parentBehaviouralEntity` | `FamixTImplicitVariable` | Implicit variables used locally by this behaviour.|
 | `localVariables` | `FamixTWithLocalVariables` | `parentBehaviouralEntity` | `FamixTLocalVariable` | Variables locally defined by this behaviour.|
 | `parameters` | `FamixTWithParameters` | `parentBehaviouralEntity` | `FamixTParameter` | List of formal parameters declared by this behaviour.|
@@ -31,7 +32,6 @@
 | Relation | Origin | Opposite | Type | Comment |
 |---|
 | `caughtExceptions` | `FamixTWithExceptions` | `catchingEntities` | `FamixTThrowable` | The exceptions caught by the method|
-| `comments` | `FamixTWithComments` | `commentedEntity` | `FamixTComment` | List of comments for the entity|
 | `declaredExceptions` | `FamixTWithExceptions` | `declaringEntities` | `FamixTThrowable` | The exceptions declared by the method|
 | `declaredType` | `FamixTTypedEntity` | `typedEntities` | `FamixTType` | Type of the entity, if any|
 | `sourceAnchor` | `FamixTSourceEntity` | `element` | `FamixTSourceAnchor` | SourceAnchor entity linking to the original source code for this entity|

--- a/src/Famix-Java-Entities/FamixJavaPackage.class.st
+++ b/src/Famix-Java-Entities/FamixJavaPackage.class.st
@@ -11,6 +11,7 @@
 | Relation | Origin | Opposite | Type | Comment |
 |---|
 | `childEntities` | `FamixTPackage` | `parentPackage` | `FamixTPackageable` | |
+| `comments` | `FamixTWithComments` | `commentedEntity` | `FamixTComment` | List of comments for the entity|
 
 ### Incoming dependencies
 | Relation | Origin | Opposite | Type | Comment |
@@ -20,7 +21,6 @@
 ### Other
 | Relation | Origin | Opposite | Type | Comment |
 |---|
-| `comments` | `FamixTWithComments` | `commentedEntity` | `FamixTComment` | List of comments for the entity|
 | `sourceAnchor` | `FamixTSourceEntity` | `element` | `FamixTSourceAnchor` | SourceAnchor entity linking to the original source code for this entity|
 
 

--- a/src/Famix-Java-Entities/FamixJavaParameter.class.st
+++ b/src/Famix-Java-Entities/FamixJavaParameter.class.st
@@ -7,6 +7,11 @@
 |---|
 | `parentBehaviouralEntity` | `FamixTParameter` | `parameters` | `FamixTWithParameters` | Behavioural entity containing this parameter. belongsTo implementation|
 
+### Children
+| Relation | Origin | Opposite | Type | Comment |
+|---|
+| `comments` | `FamixTWithComments` | `commentedEntity` | `FamixTComment` | List of comments for the entity|
+
 ### Incoming dependencies
 | Relation | Origin | Opposite | Type | Comment |
 |---|
@@ -15,7 +20,6 @@
 ### Other
 | Relation | Origin | Opposite | Type | Comment |
 |---|
-| `comments` | `FamixTWithComments` | `commentedEntity` | `FamixTComment` | List of comments for the entity|
 | `declaredType` | `FamixTTypedEntity` | `typedEntities` | `FamixTType` | Type of the entity, if any|
 | `sourceAnchor` | `FamixTSourceEntity` | `element` | `FamixTSourceAnchor` | SourceAnchor entity linking to the original source code for this entity|
 

--- a/src/Famix-MetamodelBuilder-Core/FmxPackageAddition.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxPackageAddition.class.st
@@ -34,7 +34,7 @@ FmxPackageAddition class >> named: aName [
 { #category : #accessing }
 FmxPackageAddition >> apply [
 
-	self packageOrganizer addPackage: self packageName
+	self packageOrganizer ensurePackage: self packageName
 ]
 
 { #category : #accessing }

--- a/src/Famix-MetamodelBuilder-Core/FmxPackageAddition.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxPackageAddition.class.st
@@ -33,7 +33,8 @@ FmxPackageAddition class >> named: aName [
 
 { #category : #accessing }
 FmxPackageAddition >> apply [
-	self packageOrganizer createPackageNamed: self packageName
+
+	self packageOrganizer addPackage: self packageName
 ]
 
 { #category : #accessing }

--- a/src/Famix-MetamodelGeneration/FamixGenerator.class.st
+++ b/src/Famix-MetamodelGeneration/FamixGenerator.class.st
@@ -987,6 +987,8 @@ FamixGenerator >> defineHierarchy [
 	tClassWithVisibility --|> tHasVisibility.
 
 	tClassGroup --|> tTypeGroup.
+	
+	tComment  --|> #TEntityMetaLevelDependency.
 
 	tCompilationUnit --|> tFile.
 
@@ -1251,7 +1253,8 @@ FamixGenerator >> defineRelations [
 			comment: 'The exceptions caught by the method').
 
 	((tComment property: #commentedEntity)
-			comment: 'Source code commented by the comment')
+			comment: 'Source code commented by the comment';
+			container)
 		*-
 	((tWithComments property: #comments)
 			comment: 'List of comments for the entity').

--- a/src/Famix-PharoSmalltalk-Entities/FamixStClass.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStClass.class.st
@@ -12,6 +12,7 @@
 | Relation | Origin | Opposite | Type | Comment |
 |---|
 | `attributes` | `FamixTWithAttributes` | `parentType` | `FamixTAttribute` | List of attributes declared by this type.|
+| `comments` | `FamixTWithComments` | `commentedEntity` | `FamixTComment` | List of comments for the entity|
 | `methods` | `FamixTWithMethods` | `parentType` | `FamixTMethod` | Methods declared by this type.|
 
 ### Outgoing dependencies
@@ -28,7 +29,6 @@
 ### Other
 | Relation | Origin | Opposite | Type | Comment |
 |---|
-| `comments` | `FamixTWithComments` | `commentedEntity` | `FamixTComment` | List of comments for the entity|
 | `receivingInvocations` | `FamixTInvocationsReceiver` | `receiver` | `FamixTInvocation` | List of invocations performed on this entity (considered as the receiver)|
 | `sourceAnchor` | `FamixTSourceEntity` | `element` | `FamixTSourceAnchor` | SourceAnchor entity linking to the original source code for this entity|
 | `typedEntities` | `FamixTType` | `declaredType` | `FamixTTypedEntity` | Entities that have this type as declaredType|
@@ -176,11 +176,12 @@ FamixStClass >> methodsWithoutSutbsAndConstructors [
 { #category : #accessing }
 FamixStClass >> numberOfComments [
 	"Overrides to include method comments in the numberOfComments of the class"
-	^ self
-		lookUpPropertyNamed: #numberOfComments
-		computedAs: [ self methods asArray
-			inject: self comments size into: [ :sum :child | child numberOfComments + sum ] ]
 
+	^ self lookUpPropertyNamed: #numberOfComments computedAs: [
+		  self children asArray inject: self comments size into: [ :sum :child |
+			  (child class includesTrait: FamixTWithComments)
+				  ifTrue: [ child numberOfComments + sum ]
+				  ifFalse: [ sum ] ] ]
 ]
 
 { #category : #metrics }

--- a/src/Famix-PharoSmalltalk-Entities/FamixStComment.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStComment.class.st
@@ -2,7 +2,7 @@
 ## Relations
 ======================
 
-### Other
+### Parents
 | Relation | Origin | Opposite | Type | Comment |
 |---|
 | `commentedEntity` | `FamixTComment` | `comments` | `FamixTWithComments` | Source code commented by the comment|

--- a/src/Famix-PharoSmalltalk-Entities/FamixStMethod.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStMethod.class.st
@@ -11,6 +11,7 @@
 ### Children
 | Relation | Origin | Opposite | Type | Comment |
 |---|
+| `comments` | `FamixTWithComments` | `commentedEntity` | `FamixTComment` | List of comments for the entity|
 | `definedAnnotationTypes` | `FamixTWithAnnotationTypes` | `annotationTypesContainer` | `FamixTAnnotationType` | The container in which the AnnotationTypes may be declared|
 | `implicitVariables` | `FamixTWithImplicitVariables` | `parentBehaviouralEntity` | `FamixTImplicitVariable` | Implicit variables used locally by this behaviour.|
 | `localVariables` | `FamixTWithLocalVariables` | `parentBehaviouralEntity` | `FamixTLocalVariable` | Variables locally defined by this behaviour.|
@@ -32,7 +33,6 @@
 | Relation | Origin | Opposite | Type | Comment |
 |---|
 | `annotationInstances` | `FamixTWithAnnotationInstances` | `annotatedEntity` | `FamixTAnnotationInstance` | This property corresponds to the set of annotations associated to the entity|
-| `comments` | `FamixTWithComments` | `commentedEntity` | `FamixTComment` | List of comments for the entity|
 | `declaredType` | `FamixTTypedEntity` | `typedEntities` | `FamixTType` | Type of the entity, if any|
 | `sourceAnchor` | `FamixTSourceEntity` | `element` | `FamixTSourceAnchor` | SourceAnchor entity linking to the original source code for this entity|
 

--- a/src/Famix-Test1-Entities/FamixTest1Class.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1Class.class.st
@@ -14,6 +14,7 @@ This a comment for the Class entity
 | Relation | Origin | Opposite | Type | Comment |
 |---|
 | `attributes` | `FamixTWithAttributes` | `parentType` | `FamixTAttribute` | List of attributes declared by this type.|
+| `comments` | `FamixTWithComments` | `commentedEntity` | `FamixTComment` | List of comments for the entity|
 | `methods` | `FamixTWithMethods` | `parentType` | `FamixTMethod` | Methods declared by this type.|
 
 ### Outgoing dependencies
@@ -30,7 +31,6 @@ This a comment for the Class entity
 ### Other
 | Relation | Origin | Opposite | Type | Comment |
 |---|
-| `comments` | `FamixTWithComments` | `commentedEntity` | `FamixTComment` | List of comments for the entity|
 | `declaredSourceLanguage` | `FamixTWithSourceLanguages` | `sourcedEntities` | `FamixTSourceLanguage` | The declared SourceLanguage for the source code of this entity|
 | `receivingInvocations` | `FamixTInvocationsReceiver` | `receiver` | `FamixTInvocation` | List of invocations performed on this entity (considered as the receiver)|
 | `sourceAnchor` | `FamixTSourceEntity` | `element` | `FamixTSourceAnchor` | SourceAnchor entity linking to the original source code for this entity|

--- a/src/Famix-Test1-Entities/FamixTest1Comment.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1Comment.class.st
@@ -2,7 +2,7 @@
 ## Relations
 ======================
 
-### Other
+### Parents
 | Relation | Origin | Opposite | Type | Comment |
 |---|
 | `commentedEntity` | `FamixTComment` | `comments` | `FamixTWithComments` | Source code commented by the comment|

--- a/src/Famix-Test1-Entities/FamixTest1Method.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1Method.class.st
@@ -10,6 +10,7 @@
 ### Children
 | Relation | Origin | Opposite | Type | Comment |
 |---|
+| `comments` | `FamixTWithComments` | `commentedEntity` | `FamixTComment` | List of comments for the entity|
 | `implicitVariables` | `FamixTWithImplicitVariables` | `parentBehaviouralEntity` | `FamixTImplicitVariable` | Implicit variables used locally by this behaviour.|
 | `localVariables` | `FamixTWithLocalVariables` | `parentBehaviouralEntity` | `FamixTLocalVariable` | Variables locally defined by this behaviour.|
 | `parameters` | `FamixTWithParameters` | `parentBehaviouralEntity` | `FamixTParameter` | List of formal parameters declared by this behaviour.|
@@ -29,7 +30,6 @@
 ### Other
 | Relation | Origin | Opposite | Type | Comment |
 |---|
-| `comments` | `FamixTWithComments` | `commentedEntity` | `FamixTComment` | List of comments for the entity|
 | `declaredSourceLanguage` | `FamixTWithSourceLanguages` | `sourcedEntities` | `FamixTSourceLanguage` | The declared SourceLanguage for the source code of this entity|
 | `declaredType` | `FamixTTypedEntity` | `typedEntities` | `FamixTType` | Type of the entity, if any|
 | `sourceAnchor` | `FamixTSourceEntity` | `element` | `FamixTSourceAnchor` | SourceAnchor entity linking to the original source code for this entity|

--- a/src/Famix-Test1-Tests/TEntityMetaLevelDependencyTest.class.st
+++ b/src/Famix-Test1-Tests/TEntityMetaLevelDependencyTest.class.st
@@ -51,13 +51,33 @@ TEntityMetaLevelDependencyTest >> testAllChildren [
 
 { #category : #tests }
 TEntityMetaLevelDependencyTest >> testAllChildrenTypes [
-	self
-		assertCollection: c1 allChildrenTypes
-		hasSameElements: {FamixTParameter . FamixTImplicitVariable . FamixTest1Attribute . FamixTAttribute . FamixTest1Method . FamixTLocalVariable . FamixTMethod}.
-	self
-		assertCollection: c2 allChildrenTypes
-		hasSameElements: {FamixTParameter . FamixTImplicitVariable . FamixTest1Attribute . FamixTAttribute . FamixTest1Method . FamixTLocalVariable . FamixTMethod}.
-	self assertCollection: m1 allChildrenTypes hasSameElements: {FamixTImplicitVariable . FamixTParameter . FamixTLocalVariable}
+
+	self assertCollection: c1 allChildrenTypes hasSameElements: {
+			FamixTParameter.
+			FamixTImplicitVariable.
+			FamixTest1Attribute.
+			FamixTAttribute.
+			FamixTest1Method.
+			FamixTLocalVariable.
+			FamixTMethod.
+			FamixTComment.
+			FamixTest1Comment }.
+	self assertCollection: c2 allChildrenTypes hasSameElements: {
+			FamixTParameter.
+			FamixTImplicitVariable.
+			FamixTest1Attribute.
+			FamixTAttribute.
+			FamixTest1Method.
+			FamixTLocalVariable.
+			FamixTMethod.
+			FamixTComment.
+			FamixTest1Comment }.
+	self assertCollection: m1 allChildrenTypes hasSameElements: {
+			FamixTImplicitVariable.
+			FamixTParameter.
+			FamixTLocalVariable.
+			FamixTComment.
+			FamixTest1Comment }
 ]
 
 { #category : #tests }
@@ -139,9 +159,10 @@ TEntityMetaLevelDependencyTest >> testChildren [
 
 { #category : #tests }
 TEntityMetaLevelDependencyTest >> testChildrenSelectors [
-	self assertCollection: m1 childrenSelectors hasSameElements: {#parameters . #localVariables . #implicitVariables}.
-	self assertCollection: c1 childrenSelectors hasSameElements: {#methods . #attributes}.
-	self assertCollection: c2 childrenSelectors hasSameElements: {#methods . #attributes}
+
+	self assertCollection: m1 childrenSelectors hasSameElements: { #parameters. #localVariables. #implicitVariables. #comments }.
+	self assertCollection: c1 childrenSelectors hasSameElements: { #methods. #attributes. #comments }.
+	self assertCollection: c2 childrenSelectors hasSameElements: { #methods. #attributes. #comments }
 ]
 
 { #category : #tests }

--- a/src/Famix-Test2-Entities/FamixTest2Class.class.st
+++ b/src/Famix-Test2-Entities/FamixTest2Class.class.st
@@ -11,6 +11,7 @@
 | Relation | Origin | Opposite | Type | Comment |
 |---|
 | `attributes` | `FamixTWithAttributes` | `parentType` | `FamixTAttribute` | List of attributes declared by this type.|
+| `comments` | `FamixTWithComments` | `commentedEntity` | `FamixTComment` | List of comments for the entity|
 | `methods` | `FamixTWithMethods` | `parentType` | `FamixTMethod` | Methods declared by this type.|
 
 ### Outgoing dependencies
@@ -27,7 +28,6 @@
 ### Other
 | Relation | Origin | Opposite | Type | Comment |
 |---|
-| `comments` | `FamixTWithComments` | `commentedEntity` | `FamixTComment` | List of comments for the entity|
 | `receivingInvocations` | `FamixTInvocationsReceiver` | `receiver` | `FamixTInvocation` | List of invocations performed on this entity (considered as the receiver)|
 | `sourceAnchor` | `FamixTSourceEntity` | `element` | `FamixTSourceAnchor` | SourceAnchor entity linking to the original source code for this entity|
 | `typedEntities` | `FamixTType` | `declaredType` | `FamixTTypedEntity` | Entities that have this type as declaredType|

--- a/src/Famix-Test2-Entities/FamixTest2Comment.class.st
+++ b/src/Famix-Test2-Entities/FamixTest2Comment.class.st
@@ -2,7 +2,7 @@
 ## Relations
 ======================
 
-### Other
+### Parents
 | Relation | Origin | Opposite | Type | Comment |
 |---|
 | `commentedEntity` | `FamixTComment` | `comments` | `FamixTWithComments` | Source code commented by the comment|

--- a/src/Famix-Test3-Entities/FamixTest3Class.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3Class.class.st
@@ -12,6 +12,7 @@
 | Relation | Origin | Opposite | Type | Comment |
 |---|
 | `attributes` | `FamixTWithAttributes` | `parentType` | `FamixTAttribute` | List of attributes declared by this type.|
+| `comments` | `FamixTWithComments` | `commentedEntity` | `FamixTComment` | List of comments for the entity|
 | `methods` | `FamixTWithMethods` | `parentType` | `FamixTMethod` | Methods declared by this type.|
 
 ### Outgoing dependencies
@@ -28,7 +29,6 @@
 ### Other
 | Relation | Origin | Opposite | Type | Comment |
 |---|
-| `comments` | `FamixTWithComments` | `commentedEntity` | `FamixTComment` | List of comments for the entity|
 | `receivingInvocations` | `FamixTInvocationsReceiver` | `receiver` | `FamixTInvocation` | List of invocations performed on this entity (considered as the receiver)|
 | `sourceAnchor` | `FamixTSourceEntity` | `element` | `FamixTSourceAnchor` | SourceAnchor entity linking to the original source code for this entity|
 | `typedEntities` | `FamixTType` | `declaredType` | `FamixTTypedEntity` | Entities that have this type as declaredType|

--- a/src/Famix-Test3-Entities/FamixTest3Comment.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3Comment.class.st
@@ -2,7 +2,7 @@
 ## Relations
 ======================
 
-### Other
+### Parents
 | Relation | Origin | Opposite | Type | Comment |
 |---|
 | `commentedEntity` | `FamixTComment` | `comments` | `FamixTWithComments` | Source code commented by the comment|

--- a/src/Famix-Test3-Tests/FamixTest3MooseQueryTest.class.st
+++ b/src/Famix-Test3-Tests/FamixTest3MooseQueryTest.class.st
@@ -66,7 +66,14 @@ FamixTest3MooseQueryTest >> testAtScopeWithNonMatchingEntitiesDo [
 
 { #category : #tests }
 FamixTest3MooseQueryTest >> testChildrenTypes [
-	self assertCollection: self c1 childrenTypes hasSameElements: {FamixTAttribute . FamixTMethod . FamixTest3Attribute . FamixTest3Method}
+
+	self assertCollection: self c1 childrenTypes hasSameElements: {
+			FamixTAttribute.
+			FamixTMethod.
+			FamixTest3Attribute.
+			FamixTest3Method.
+			FamixTComment.
+			FamixTest3Comment }
 ]
 
 { #category : #tests }

--- a/src/Famix-Test6-Entities/FamixTest6Comment.class.st
+++ b/src/Famix-Test6-Entities/FamixTest6Comment.class.st
@@ -2,7 +2,7 @@
 ## Relations
 ======================
 
-### Other
+### Parents
 | Relation | Origin | Opposite | Type | Comment |
 |---|
 | `commentedEntity` | `FamixTComment` | `comments` | `FamixTWithComments` | Source code commented by the comment|

--- a/src/Famix-Test6-Entities/FamixTest6Entity.class.st
+++ b/src/Famix-Test6-Entities/FamixTest6Entity.class.st
@@ -27,3 +27,10 @@ FamixTest6Entity class >> metamodel [
 	<generated>
 	^ FamixTest6Model metamodel
 ]
+
+{ #category : #testing }
+FamixTest6Entity >> isQueryable [
+
+	<generated>
+	^ false
+]

--- a/src/Famix-Test7-Entities/FamixTest7Class.class.st
+++ b/src/Famix-Test7-Entities/FamixTest7Class.class.st
@@ -11,6 +11,7 @@
 | Relation | Origin | Opposite | Type | Comment |
 |---|
 | `attributes` | `FamixTWithAttributes` | `parentType` | `FamixTAttribute` | List of attributes declared by this type.|
+| `comments` | `FamixTWithComments` | `commentedEntity` | `FamixTComment` | List of comments for the entity|
 | `methods` | `FamixTWithMethods` | `parentType` | `FamixTMethod` | Methods declared by this type.|
 
 ### Outgoing dependencies
@@ -27,7 +28,6 @@
 ### Other
 | Relation | Origin | Opposite | Type | Comment |
 |---|
-| `comments` | `FamixTWithComments` | `commentedEntity` | `FamixTComment` | List of comments for the entity|
 | `receivingInvocations` | `FamixTInvocationsReceiver` | `receiver` | `FamixTInvocation` | List of invocations performed on this entity (considered as the receiver)|
 | `sourceAnchor` | `FamixTSourceEntity` | `element` | `FamixTSourceAnchor` | SourceAnchor entity linking to the original source code for this entity|
 | `typedEntities` | `FamixTType` | `declaredType` | `FamixTTypedEntity` | Entities that have this type as declaredType|

--- a/src/Famix-Test7-Entities/FamixTest7Comment.class.st
+++ b/src/Famix-Test7-Entities/FamixTest7Comment.class.st
@@ -2,7 +2,7 @@
 ## Relations
 ======================
 
-### Other
+### Parents
 | Relation | Origin | Opposite | Type | Comment |
 |---|
 | `commentedEntity` | `FamixTComment` | `comments` | `FamixTWithComments` | Source code commented by the comment|

--- a/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1Class.class.st
+++ b/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1Class.class.st
@@ -11,6 +11,7 @@
 | Relation | Origin | Opposite | Type | Comment |
 |---|
 | `attributes` | `FamixTWithAttributes` | `parentType` | `FamixTAttribute` | List of attributes declared by this type.|
+| `comments` | `FamixTWithComments` | `commentedEntity` | `FamixTComment` | List of comments for the entity|
 | `methods` | `FamixTWithMethods` | `parentType` | `FamixTMethod` | Methods declared by this type.|
 
 ### Outgoing dependencies
@@ -27,7 +28,6 @@
 ### Other
 | Relation | Origin | Opposite | Type | Comment |
 |---|
-| `comments` | `FamixTWithComments` | `commentedEntity` | `FamixTComment` | List of comments for the entity|
 | `receivingInvocations` | `FamixTInvocationsReceiver` | `receiver` | `FamixTInvocation` | List of invocations performed on this entity (considered as the receiver)|
 | `sourceAnchor` | `FamixTSourceEntity` | `element` | `FamixTSourceAnchor` | SourceAnchor entity linking to the original source code for this entity|
 | `typedEntities` | `FamixTType` | `declaredType` | `FamixTTypedEntity` | Entities that have this type as declaredType|

--- a/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1Comment.class.st
+++ b/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1Comment.class.st
@@ -2,7 +2,7 @@
 ## Relations
 ======================
 
-### Other
+### Parents
 | Relation | Origin | Opposite | Type | Comment |
 |---|
 | `commentedEntity` | `FamixTComment` | `comments` | `FamixTWithComments` | Source code commented by the comment|

--- a/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2Class.class.st
+++ b/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2Class.class.st
@@ -11,6 +11,7 @@
 | Relation | Origin | Opposite | Type | Comment |
 |---|
 | `attributes` | `FamixTWithAttributes` | `parentType` | `FamixTAttribute` | List of attributes declared by this type.|
+| `comments` | `FamixTWithComments` | `commentedEntity` | `FamixTComment` | List of comments for the entity|
 | `methods` | `FamixTWithMethods` | `parentType` | `FamixTMethod` | Methods declared by this type.|
 
 ### Outgoing dependencies
@@ -27,7 +28,6 @@
 ### Other
 | Relation | Origin | Opposite | Type | Comment |
 |---|
-| `comments` | `FamixTWithComments` | `commentedEntity` | `FamixTComment` | List of comments for the entity|
 | `receivingInvocations` | `FamixTInvocationsReceiver` | `receiver` | `FamixTInvocation` | List of invocations performed on this entity (considered as the receiver)|
 | `sourceAnchor` | `FamixTSourceEntity` | `element` | `FamixTSourceAnchor` | SourceAnchor entity linking to the original source code for this entity|
 | `typedEntities` | `FamixTType` | `declaredType` | `FamixTTypedEntity` | Entities that have this type as declaredType|

--- a/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2Comment.class.st
+++ b/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2Comment.class.st
@@ -2,7 +2,7 @@
 ## Relations
 ======================
 
-### Other
+### Parents
 | Relation | Origin | Opposite | Type | Comment |
 |---|
 | `commentedEntity` | `FamixTComment` | `comments` | `FamixTWithComments` | Source code commented by the comment|

--- a/src/Famix-Traits/FamixTCanBeAbstract.trait.st
+++ b/src/Famix-Traits/FamixTCanBeAbstract.trait.st
@@ -10,7 +10,7 @@
 Trait {
 	#name : #FamixTCanBeAbstract,
 	#instVars : [
-		'#isAbstract => FMProperty'
+		'#isAbstract => FMProperty defaultValue: false'
 	],
 	#category : #'Famix-Traits-Traits'
 }

--- a/src/Famix-Traits/FamixTCanBeFinal.trait.st
+++ b/src/Famix-Traits/FamixTCanBeFinal.trait.st
@@ -10,7 +10,7 @@
 Trait {
 	#name : #FamixTCanBeFinal,
 	#instVars : [
-		'#isFinal => FMProperty'
+		'#isFinal => FMProperty defaultValue: false'
 	],
 	#category : #'Famix-Traits-Traits'
 }

--- a/src/Famix-Traits/FamixTClass.trait.st
+++ b/src/Famix-Traits/FamixTClass.trait.st
@@ -17,6 +17,7 @@ A class is typically scoped in a namespace. To model nested or anonymous classes
 | Relation | Origin | Opposite | Type | Comment |
 |---|
 | `attributes` | `FamixTWithAttributes` | `parentType` | `FamixTAttribute` | List of attributes declared by this type.|
+| `comments` | `FamixTWithComments` | `commentedEntity` | `FamixTComment` | List of comments for the entity|
 | `methods` | `FamixTWithMethods` | `parentType` | `FamixTMethod` | Methods declared by this type.|
 
 ### Outgoing dependencies
@@ -33,7 +34,6 @@ A class is typically scoped in a namespace. To model nested or anonymous classes
 ### Other
 | Relation | Origin | Opposite | Type | Comment |
 |---|
-| `comments` | `FamixTWithComments` | `commentedEntity` | `FamixTComment` | List of comments for the entity|
 | `receivingInvocations` | `FamixTInvocationsReceiver` | `receiver` | `FamixTInvocation` | List of invocations performed on this entity (considered as the receiver)|
 | `sourceAnchor` | `FamixTSourceEntity` | `element` | `FamixTSourceAnchor` | SourceAnchor entity linking to the original source code for this entity|
 | `typedEntities` | `FamixTType` | `declaredType` | `FamixTTypedEntity` | Entities that have this type as declaredType|

--- a/src/Famix-Traits/FamixTClassWithVisibility.trait.st
+++ b/src/Famix-Traits/FamixTClassWithVisibility.trait.st
@@ -11,6 +11,7 @@
 | Relation | Origin | Opposite | Type | Comment |
 |---|
 | `attributes` | `FamixTWithAttributes` | `parentType` | `FamixTAttribute` | List of attributes declared by this type.|
+| `comments` | `FamixTWithComments` | `commentedEntity` | `FamixTComment` | List of comments for the entity|
 | `methods` | `FamixTWithMethods` | `parentType` | `FamixTMethod` | Methods declared by this type.|
 
 ### Outgoing dependencies
@@ -27,7 +28,6 @@
 ### Other
 | Relation | Origin | Opposite | Type | Comment |
 |---|
-| `comments` | `FamixTWithComments` | `commentedEntity` | `FamixTComment` | List of comments for the entity|
 | `receivingInvocations` | `FamixTInvocationsReceiver` | `receiver` | `FamixTInvocation` | List of invocations performed on this entity (considered as the receiver)|
 | `sourceAnchor` | `FamixTSourceEntity` | `element` | `FamixTSourceAnchor` | SourceAnchor entity linking to the original source code for this entity|
 | `typedEntities` | `FamixTType` | `declaredType` | `FamixTTypedEntity` | Entities that have this type as declaredType|

--- a/src/Famix-Traits/FamixTComment.trait.st
+++ b/src/Famix-Traits/FamixTComment.trait.st
@@ -4,7 +4,7 @@ FamixTComment represents one instance of a comment (in the sense of programming 
 ## Relations
 ======================
 
-### Other
+### Parents
 | Relation | Origin | Opposite | Type | Comment |
 |---|
 | `commentedEntity` | `FamixTComment` | `comments` | `FamixTWithComments` | Source code commented by the comment|
@@ -24,6 +24,8 @@ Trait {
 		'#commentedEntity => FMOne type: #FamixTWithComments opposite: #comments',
 		'#content => FMProperty'
 	],
+	#traits : 'TEntityMetaLevelDependency',
+	#classTraits : 'TEntityMetaLevelDependency classTrait',
 	#category : #'Famix-Traits-Comment'
 }
 
@@ -49,6 +51,7 @@ FamixTComment >> commentedEntity [
 
 	<generated>
 	<FMComment: 'Source code commented by the comment'>
+	<container>
 	^ commentedEntity
 ]
 
@@ -57,6 +60,13 @@ FamixTComment >> commentedEntity: anObject [
 
 	<generated>
 	commentedEntity := anObject
+]
+
+{ #category : #navigation }
+FamixTComment >> commentedEntityGroup [
+	<generated>
+	<navigation: 'CommentedEntity'>
+	^ MooseSpecializedGroup with: self commentedEntity
 ]
 
 { #category : #accessing }

--- a/src/Famix-Traits/FamixTException.trait.st
+++ b/src/Famix-Traits/FamixTException.trait.st
@@ -13,6 +13,7 @@ This is the abstract representation of an Exception. It is specific to Java. It 
 | Relation | Origin | Opposite | Type | Comment |
 |---|
 | `attributes` | `FamixTWithAttributes` | `parentType` | `FamixTAttribute` | List of attributes declared by this type.|
+| `comments` | `FamixTWithComments` | `commentedEntity` | `FamixTComment` | List of comments for the entity|
 | `methods` | `FamixTWithMethods` | `parentType` | `FamixTMethod` | Methods declared by this type.|
 
 ### Outgoing dependencies
@@ -30,7 +31,6 @@ This is the abstract representation of an Exception. It is specific to Java. It 
 | Relation | Origin | Opposite | Type | Comment |
 |---|
 | `catchingEntities` | `FamixTThrowable` | `caughtExceptions` | `FamixTWithExceptions` | |
-| `comments` | `FamixTWithComments` | `commentedEntity` | `FamixTComment` | List of comments for the entity|
 | `declaringEntities` | `FamixTThrowable` | `declaredExceptions` | `FamixTWithExceptions` | |
 | `receivingInvocations` | `FamixTInvocationsReceiver` | `receiver` | `FamixTInvocation` | List of invocations performed on this entity (considered as the receiver)|
 | `sourceAnchor` | `FamixTSourceEntity` | `element` | `FamixTSourceAnchor` | SourceAnchor entity linking to the original source code for this entity|

--- a/src/Famix-Traits/FamixTSourceEntity.trait.st
+++ b/src/Famix-Traits/FamixTSourceEntity.trait.st
@@ -21,7 +21,7 @@ FamixTSourcedEntity models any fact in a program source and it is the superclass
 Trait {
 	#name : #FamixTSourceEntity,
 	#instVars : [
-		'#isStub => FMProperty',
+		'#isStub => FMProperty defaultValue: false',
 		'#sourceAnchor => FMOne type: #FamixTSourceAnchor opposite: #element'
 	],
 	#category : #'Famix-Traits-SourceAnchor'

--- a/src/Famix-Traits/FamixTWithComments.trait.st
+++ b/src/Famix-Traits/FamixTWithComments.trait.st
@@ -2,7 +2,7 @@
 ## Relations
 ======================
 
-### Other
+### Children
 | Relation | Origin | Opposite | Type | Comment |
 |---|
 | `comments` | `FamixTWithComments` | `commentedEntity` | `FamixTComment` | List of comments for the entity|

--- a/src/Moose-Core-Tests-Entities/MooseMSEImporterTestClass.class.st
+++ b/src/Moose-Core-Tests-Entities/MooseMSEImporterTestClass.class.st
@@ -11,6 +11,7 @@
 | Relation | Origin | Opposite | Type | Comment |
 |---|
 | `attributes` | `FamixTWithAttributes` | `parentType` | `FamixTAttribute` | List of attributes declared by this type.|
+| `comments` | `FamixTWithComments` | `commentedEntity` | `FamixTComment` | List of comments for the entity|
 | `methods` | `FamixTWithMethods` | `parentType` | `FamixTMethod` | Methods declared by this type.|
 
 ### Outgoing dependencies
@@ -27,7 +28,6 @@
 ### Other
 | Relation | Origin | Opposite | Type | Comment |
 |---|
-| `comments` | `FamixTWithComments` | `commentedEntity` | `FamixTComment` | List of comments for the entity|
 | `receivingInvocations` | `FamixTInvocationsReceiver` | `receiver` | `FamixTInvocation` | List of invocations performed on this entity (considered as the receiver)|
 | `sourceAnchor` | `FamixTSourceEntity` | `element` | `FamixTSourceAnchor` | SourceAnchor entity linking to the original source code for this entity|
 | `typedEntities` | `FamixTType` | `declaredType` | `FamixTTypedEntity` | Entities that have this type as declaredType|

--- a/src/Moose-Core-Tests-Entities/MooseMSEImporterTestComment.class.st
+++ b/src/Moose-Core-Tests-Entities/MooseMSEImporterTestComment.class.st
@@ -2,7 +2,7 @@
 ## Relations
 ======================
 
-### Other
+### Parents
 | Relation | Origin | Opposite | Type | Comment |
 |---|
 | `commentedEntity` | `FamixTComment` | `comments` | `FamixTWithComments` | Source code commented by the comment|

--- a/src/Moose-Query-Test/MooseQueryTest.class.st
+++ b/src/Moose-Query-Test/MooseQueryTest.class.st
@@ -395,7 +395,7 @@ MooseQueryTest >> testChildren [
 MooseQueryTest >> testChildrenSelectors [
 	self
 		assertCollection: class1 childrenSelectors
-		hasSameElements: #(#types #attributes #methods #definedAnnotationTypes)
+		hasSameElements: #(#types #attributes #methods #definedAnnotationTypes #comments)
 ]
 
 { #category : #tests }


### PR DESCRIPTION
This change adds the trait TEntityMetaLevelDependency to TWithComment and add a containment relation between the comment and the commented entity.