### PR TITLE
Clean #numberOfComments

### DIFF
--- a/src/Famix-Java-Entities/FamixJavaClass.class.st
+++ b/src/Famix-Java-Entities/FamixJavaClass.class.st
@@ -173,17 +173,6 @@ FamixJavaClass >> methodsWithoutSutbsAndConstructors [
 		each isStub not and: [each isConstructor not]]) asSet
 ]
 
-{ #category : #accessing }
-FamixJavaClass >> numberOfComments [
-	"Overrides to include method comments in the numberOfComments of the class"
-
-	^ self lookUpPropertyNamed: #numberOfComments computedAs: [
-		  self children asArray inject: self comments size into: [ :sum :child |
-			  (child class includesTrait: FamixTWithComments)
-				  ifTrue: [ child numberOfComments + sum ]
-				  ifFalse: [ sum ] ] ]
-]
-
 { #category : #'Famix-Extensions' }
 FamixJavaClass >> structuralChildren [
 	^ (OrderedCollection withAll: self methods), self attributes

--- a/src/Famix-Java-Entities/FamixJavaMethod.class.st
+++ b/src/Famix-Java-Entities/FamixJavaMethod.class.st
@@ -280,14 +280,6 @@ FamixJavaMethod >> numberOfAccesses [
 		computedAs: [ self accesses size ]
 ]
 
-{ #category : #accessing }
-FamixJavaMethod >> numberOfComments [
-	<FMProperty: #numberOfComments type: #Number>
-	<FMComment: 'The number of comment fragments'>
-	<derived>
-	^ self lookUpPropertyNamed: #numberOfComments computedAs: [ self comments size ]
-]
-
 { #category : #'Famix-Extensions-private' }
 FamixJavaMethod >> numberOfConditionals [
 	<FMProperty: #numberOfConditionals type: #Number>

--- a/src/Famix-Java-Tests/FamixJavaCommentsTest.class.st
+++ b/src/Famix-Java-Tests/FamixJavaCommentsTest.class.st
@@ -25,5 +25,5 @@ FamixJavaCommentsTest >> testClassWithCommentAndMethodsWithComments [
 	FamixJavaComment new commentedEntity: (FamixJavaMethod new
 			 parentType: javaClass;
 			 yourself).
-	self assert: javaClass numberOfComments equals: 3 "one in the class, one on each of the 2 methods"
+	self assert: javaClass numberOfComments equals: 1 "Comments of children are not taken into account."
 ]

--- a/src/Famix-PharoSmalltalk-Entities/FamixStClass.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStClass.class.st
@@ -173,17 +173,6 @@ FamixStClass >> methodsWithoutSutbsAndConstructors [
 	^ (self methods select: [ :each | each isStub not and: [ each isConstructor not ] ]) asSet
 ]
 
-{ #category : #accessing }
-FamixStClass >> numberOfComments [
-	"Overrides to include method comments in the numberOfComments of the class"
-
-	^ self lookUpPropertyNamed: #numberOfComments computedAs: [
-		  self children asArray inject: self comments size into: [ :sum :child |
-			  (child class includesTrait: FamixTWithComments)
-				  ifTrue: [ child numberOfComments + sum ]
-				  ifFalse: [ sum ] ] ]
-]
-
 { #category : #metrics }
 FamixStClass >> numberOfMessageSends [
 	<FMProperty: #numberOfMessageSends type: #Number>

--- a/src/Famix-PharoSmalltalk-Entities/FamixStMethod.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStMethod.class.st
@@ -245,14 +245,6 @@ FamixStMethod >> numberOfAccesses [
 ]
 
 { #category : #'Famix-Extensions-private' }
-FamixStMethod >> numberOfComments [
-	<FMProperty: #numberOfComments type: #Number>
-	<FMComment: 'The number of comment fragments'>
-	<derived>
-	^ self lookUpPropertyNamed: #numberOfComments computedAs: [ self comments size ]
-]
-
-{ #category : #'Famix-Extensions-private' }
 FamixStMethod >> numberOfConditionals [
 	<FMProperty: #numberOfConditionals type: #Number>
 	<FMComment: 'The number of conditionals in a method'>

--- a/src/Famix-Traits/FamixTWithComments.trait.st
+++ b/src/Famix-Traits/FamixTWithComments.trait.st
@@ -61,13 +61,11 @@ FamixTWithComments >> hasComments [
 
 { #category : #accessing }
 FamixTWithComments >> numberOfComments [
+
 	<FMProperty: #numberOfComments type: #Number>
 	<derived>
-	<FMComment: 'The number of comments in the entity'>
-	^ self
-		lookUpPropertyNamed: #numberOfComments
-		computedAs: [ self comments size ]
-
+	<FMComment: 'The number of comments in the entity. Does not count comments of children entities (for example, for a class, I will count the comments associated to the class and not the methods or arguments.'>
+	^ self lookUpPropertyNamed: #numberOfComments computedAs: [ self comments size ]
 ]
 
 { #category : #accessing }

--- a/src/Moose-SmalltalkImporter-LAN-Tests/LANFamixPropertiesTest.class.st
+++ b/src/Moose-SmalltalkImporter-LAN-Tests/LANFamixPropertiesTest.class.st
@@ -78,9 +78,10 @@ LANFamixPropertiesTest >> testClassCategories [
 
 { #category : #testing }
 LANFamixPropertiesTest >> testClassComments [
+
 	self model allClasses do: [ :each | self assert: each numberOfComments >= 0 ].
-	self assert: (self nodeClass propertyNamed: #numberOfComments) equals: 11.
-	self assert: self nodeClass numberOfComments equals: 11
+	self assert: (self nodeClass propertyNamed: #numberOfComments) equals: 0.
+	self assert: self nodeClass numberOfComments equals: 0
 ]
 
 { #category : #testing }
@@ -156,6 +157,14 @@ LANFamixPropertiesTest >> testMethodAccesses [
 		assert: self lanInterfaceOriginateMethod numberOfAccesses
 		equals: (self lanInterfaceOriginateMethod propertyNamed: #numberOfAccesses).
 	self assert: (self model entityNamed: #'Smalltalk::LANInterface.originator()') numberOfAccesses equals: 3
+]
+
+{ #category : #testing }
+LANFamixPropertiesTest >> testMethodComments [
+
+	self model allMethods do: [ :each | self assert: each numberOfComments >= 0 ].
+	self assert: (self lanInterfaceOriginateMethod propertyNamed: #numberOfComments) equals: 6.
+	self assert: self lanInterfaceOriginateMethod numberOfComments equals: 6
 ]
 
 { #category : #testing }


### PR DESCRIPTION
Make the implementation more coherant and adapt tests.

It's weird for only classes to count children comments in the number of comments and I also removed some duplication.

Fixes #735