### PR TITLE
Fix #745: Add #withoutStubs to MooseAbstractGroup

### DIFF
--- a/src/Moose-Core-Tests/MooseAbstractGroupTest.class.st
+++ b/src/Moose-Core-Tests/MooseAbstractGroupTest.class.st
@@ -494,6 +494,29 @@ MooseAbstractGroupTest >> testWithIndexDo [
 	self assertCollection: t hasSameElements: {{el1 . 1} . {el2 . 2} . {el3 . 3}}
 ]
 
+{ #category : #tests }
+MooseAbstractGroupTest >> testWithoutStubs [
+
+	| stubEntity1 stubEntity2 |
+
+	stubEntity1 := MooseEntity new
+		               isStub: true;
+		               yourself.
+	stubEntity2 := MooseEntity new
+		               isStub: true;
+		               yourself.
+	group
+		add: MooseEntity new;
+		add: MooseEntity new;
+		add: stubEntity1;
+		add: stubEntity2.
+
+	self assert: group size equals: 4.
+	self assert: group withoutStubs isMooseObject.
+	self assert: group withoutStubs size equals: 2.
+	group withoutStubs do: [ :entity | self deny: entity isStub ]
+]
+
 { #category : #utilities }
 MooseAbstractGroupTest >> twoClasses [
 	| classA classB |

--- a/src/Moose-Core/MooseAbstractGroup.class.st
+++ b/src/Moose-Core/MooseAbstractGroup.class.st
@@ -786,6 +786,12 @@ MooseAbstractGroup >> withIndexDo: aBlockClosure [
 	self entities withIndexDo: aBlockClosure 
 ]
 
+{ #category : #accessing }
+MooseAbstractGroup >> withoutStubs [
+
+	^ (self reject: #isStub) asMooseGroup
+]
+
 { #category : #'set operations' }
 MooseAbstractGroup >> | aCollection [
 	^ self union: aCollection

--- a/src/Moose-Core/MooseObject.class.st
+++ b/src/Moose-Core/MooseObject.class.st
@@ -359,6 +359,11 @@ MooseObject >> isMooseModel [
 ]
 
 { #category : #testing }
+MooseObject >> isMooseObject [
+	^ true
+]
+
+{ #category : #testing }
 MooseObject >> isOfType: aClassFAMIX [
 	^ self class isOfType: aClassFAMIX
 ]

--- a/src/Moose-Core/Object.extension.st
+++ b/src/Moose-Core/Object.extension.st
@@ -30,6 +30,11 @@ Object >> isMooseEntity [
 ]
 
 { #category : #'*Moose-Core' }
+Object >> isMooseObject [
+	^ false
+]
+
+{ #category : #'*Moose-Core' }
 Object class >> isOfType: aClassFAMIX [
 	^ false
 ]


### PR DESCRIPTION
It returns a MooseGroup.
+ add a test