### PR TITLE
Generalize `isSelf` by moving it to `FamixTImplicitVariable`

### DIFF
--- a/src/Famix-PharoSmalltalk-Entities/FamixStImplicitVariable.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStImplicitVariable.class.st
@@ -47,11 +47,6 @@ FamixStImplicitVariable class >> annotation [
 ]
 
 { #category : #testing }
-FamixStImplicitVariable >> isSelf [
-	^ self name = #self
-]
-
-{ #category : #testing }
 FamixStImplicitVariable >> isSuper [
 	^ self name == #super
 ]

--- a/src/Famix-Traits/FamixTImplicitVariable.trait.st
+++ b/src/Famix-Traits/FamixTImplicitVariable.trait.st
@@ -56,6 +56,12 @@ FamixTImplicitVariable >> isImplicitVariable [
 	^ true
 ]
 
+{ #category : #testing }
+FamixTImplicitVariable >> isSelf [
+
+	^ self name == #self
+]
+
 { #category : #accessing }
 FamixTImplicitVariable >> parentBehaviouralEntity [
 	"Relation named: #parentBehaviouralEntity type: #FamixTWithImplicitVariables opposite: #implicitVariables"


### PR DESCRIPTION
Even for Java, and presumably any other languages represented by Famix, an implicit variable for `this` (or equivalent) is named `self`.