### PR TITLE
Fix `isSelf` implementation

### DIFF
--- a/src/Famix-Traits/FamixTImplicitVariable.trait.st
+++ b/src/Famix-Traits/FamixTImplicitVariable.trait.st
@@ -59,7 +59,7 @@ FamixTImplicitVariable >> isImplicitVariable [
 { #category : #testing }
 FamixTImplicitVariable >> isSelf [
 
-	^ self name == #self
+	^ self name = 'self'
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
Why was it using a symbol if the name is not a symbol...