### PR TITLE
Add #detect:ifFound: to MooseAbstractGroup

### DIFF
--- a/src/Moose-Core/MooseAbstractGroup.class.st
+++ b/src/Moose-Core/MooseAbstractGroup.class.st
@@ -290,15 +290,21 @@ MooseAbstractGroup >> count: aBlock [
 ]
 
 { #category : #enumerating }
-MooseAbstractGroup >> detect: aBlock [ 
-	 
-	^self entities detect: aBlock
+MooseAbstractGroup >> detect: aBlock [
+
+	^ self entities detect: aBlock
 ]
 
 { #category : #enumerating }
-MooseAbstractGroup >> detect: aBlock ifNone: anotherBlock [ 
-	 
-	^self entities detect: aBlock ifNone: anotherBlock
+MooseAbstractGroup >> detect: aBlock ifFound: anotherBlock [
+
+	^ self entities detect: aBlock ifFound: anotherBlock
+]
+
+{ #category : #enumerating }
+MooseAbstractGroup >> detect: aBlock ifNone: anotherBlock [
+
+	^ self entities detect: aBlock ifNone: anotherBlock
 ]
 
 { #category : #enumerating }


### PR DESCRIPTION
Implementation choice still questionnable but this is needed for Famix-Tagging.