### PR TITLE
Add `FamixStModel>>#newModelAddingAll:` to create a new expanded model

### DIFF
--- a/src/Moose-SmalltalkImporter/FamixStModel.extension.st
+++ b/src/Moose-SmalltalkImporter/FamixStModel.extension.st
@@ -1,0 +1,25 @@
+Extension { #name : #FamixStModel }
+
+{ #category : #'*Moose-SmalltalkImporter' }
+FamixStModel >> newModelAddingAll: classesAndPackages [
+	"Returns a new model with all current entities plus the requested classes and packages."
+
+	| model task request |
+	task := FamixStPharoImporterTask new
+		        model: (model := self class named: name);
+		        importingContext:
+			        FamixStImporterContext new mergeClassAndMetaclass
+				        importMaximum.
+
+	request := (self entityStorage selectAllWithType: FamixStPackage)
+		           collect: [ :famixPackage | famixPackage name asPackage ]
+		           as: Set.
+	request addAll: classesAndPackages.
+	request do: [ :packageOrClass |
+		packageOrClass isClass
+			ifTrue: [ task addClass: packageOrClass ]
+			ifFalse: [ task addFromPackage: packageOrClass ] ].
+
+	task runWithProgress.
+	^ model "no install: not added to root and groups not cached"
+]


### PR DESCRIPTION
This simple method doesn't leave much room for configurability, but I'm not sure this feature needs it, as it's mainly a means to quickly expand an existing model.
Projects that automate model creation can use the already existing `FamixStPharoImporterTask` API.

The idea is that if you're toying with a model and realize you're missing some dependencies, then instead of recreating a model by hand which is tedious because you have to select all previous packages plus the new one(s), you can just use this method, e.g.:
```st
"Add ByteString class and the package containing Association"
newModel := myModel newModelAddingAll: { ByteString. Association package }
```