### PR TITLE
Speed up #source and #target on associations

### DIFF
--- a/src/Famix-Traits/FamixTAssociation.trait.st
+++ b/src/Famix-Traits/FamixTAssociation.trait.st
@@ -147,12 +147,6 @@ FamixTAssociation >> source: aSource [
 ]
 
 { #category : #accessing }
-FamixTAssociation >> sourceSelector [
-	^ (self mooseDescription allComplexProperties detect: #isSource)
-		implementingSelector
-]
-
-{ #category : #accessing }
 FamixTAssociation >> target [
 	^ self targetSelector value: self
 ]
@@ -160,10 +154,4 @@ FamixTAssociation >> target [
 { #category : #accessing }
 FamixTAssociation >> target: aTarget [
 	self perform: (self targetSelector , ':') with: aTarget
-]
-
-{ #category : #accessing }
-FamixTAssociation >> targetSelector [
-	^ (self mooseDescription allComplexProperties detect: #isTarget)
-		implementingSelector
 ]

--- a/src/Moose-Core/Object.extension.st
+++ b/src/Moose-Core/Object.extension.st
@@ -1,6 +1,15 @@
 Extension { #name : #Object }
 
 { #category : #'*Moose-Core' }
+Object >> allComplexPropertiesIn: aMetamodel [
+	"All complex properties described in the metamodel.
+	A complex property is a property whose type is not a primitive."
+
+	aMetamodel ifNil: [ ^ OrderedCollection new ].
+	^ aMetamodel descriptionOf: self class instanceSide ifPresent: #allComplexProperties ifAbsent: [ OrderedCollection new ]
+]
+
+{ #category : #'*Moose-Core' }
 Object >> allDeclaredPropertiesIn: aMetamodel [
 	"All properties described in the metamodel"
 

--- a/src/Moose-Query/TAssociationMetaLevelDependency.trait.st
+++ b/src/Moose-Query/TAssociationMetaLevelDependency.trait.st
@@ -17,6 +17,12 @@ TAssociationMetaLevelDependency classSide >> annotation [
 	^ self
 ]
 
+{ #category : #accessing }
+TAssociationMetaLevelDependency classSide >> privateSourceSelectorIn: aMetamodel [
+
+	^ ((self allComplexPropertiesIn: aMetamodel) detect: #isSource) implementingSelector
+]
+
 { #category : #private }
 TAssociationMetaLevelDependency classSide >> privateSourceTypesIn: aMetamodel [
 	"I return the classes that could be my source"
@@ -24,6 +30,12 @@ TAssociationMetaLevelDependency classSide >> privateSourceTypesIn: aMetamodel [
 	^ (self allDeclaredPropertiesIn: aMetamodel)
 		select: #isSource
 		thenCollect: #implementingType
+]
+
+{ #category : #accessing }
+TAssociationMetaLevelDependency classSide >> privateTargetSelectorIn: aMetamodel [
+
+	^ ((self allComplexPropertiesIn: aMetamodel) detect: #isTarget) implementingSelector
 ]
 
 { #category : #private }
@@ -36,10 +48,22 @@ TAssociationMetaLevelDependency classSide >> privateTargetTypesIn: aMetamodel [
 ]
 
 { #category : #accessing }
+TAssociationMetaLevelDependency classSide >> sourceSelectorIn: aMetamodel [
+
+	^ aMetamodel additionalProperty: #sourceSelector for: self ifAbsentPut: [ self privateSourceSelectorIn: aMetamodel ]
+]
+
+{ #category : #accessing }
 TAssociationMetaLevelDependency classSide >> sourceTypesIn: aMetamodel [
 
 	^ aMetamodel additionalProperty: #sourceTypes for: self ifAbsentPut: [ self privateSourceTypesIn: aMetamodel ]
 
+]
+
+{ #category : #accessing }
+TAssociationMetaLevelDependency classSide >> targetSelectorIn: aMetamodel [
+
+	^ aMetamodel additionalProperty: #targetSelector for: self ifAbsentPut: [ self privateTargetSelectorIn: aMetamodel ]
 ]
 
 { #category : #accessing }
@@ -50,8 +74,20 @@ TAssociationMetaLevelDependency classSide >> targetTypesIn: aMetamodel [
 ]
 
 { #category : #accessing }
+TAssociationMetaLevelDependency >> sourceSelector [
+
+	^ self class sourceSelectorIn: self metamodel
+]
+
+{ #category : #accessing }
 TAssociationMetaLevelDependency >> sourceTypes [
 	^ self class sourceTypesIn: self metamodel
+]
+
+{ #category : #accessing }
+TAssociationMetaLevelDependency >> targetSelector [
+
+	^ self class targetSelectorIn: self metamodel
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
It is common to manipulate the sources and targets of associations in moose but in case we need them extensively it can take some time to get them because we compute them from the meta description.

In this change I'm adding a cache to get the source and target selectors which speed up quite a bit the code.

I had a piece of code taking 200ms that got down to 28ms with this change. Out of the 28ms, only 2ms are now spent in getting the source and target