### PR TITLE
Remove deprecated call in #allTargets

### DIFF
--- a/src/Famix-Traits/FamixTAssociation.trait.st
+++ b/src/Famix-Traits/FamixTAssociation.trait.st
@@ -75,7 +75,11 @@ FamixTAssociation classSide >> source: anEntity target: anotherEntity model: aMo
 FamixTAssociation >> allTargets [
 	"Since #target can return an entity or a collection, I ensure we always get a collection."
 
-	^ self target asCollection
+	| tempTarget |
+	tempTarget := self target.
+	^ tempTarget isCollection
+		  ifTrue: [ tempTarget ]
+		  ifFalse: [ OrderedCollection with: tempTarget ]
 ]
 
 { #category : #converting }


### PR DESCRIPTION
#allTargets call deprecated #asOrderedCollection. This removes the deprecated call