### PR TITLE
Add missing enumerating methods for moosegroup

### DIFF
--- a/src/Moose-Core/MooseAbstractGroup.class.st
+++ b/src/Moose-Core/MooseAbstractGroup.class.st
@@ -302,9 +302,26 @@ MooseAbstractGroup >> detect: aBlock ifFound: anotherBlock [
 ]
 
 { #category : #enumerating }
+MooseAbstractGroup >> detect: aBlock ifFound: foundBlock ifNone: noneBlock [
+
+	^ self entities 
+		detect:  aBlock
+		ifFound: foundBlock
+		ifNone:  noneBlock
+]
+
+{ #category : #enumerating }
 MooseAbstractGroup >> detect: aBlock ifNone: anotherBlock [
 
 	^ self entities detect: aBlock ifNone: anotherBlock
+]
+
+{ #category : #enumerating }
+MooseAbstractGroup >> detect: aBlock ifOne: anotherBlock [
+
+	^ self entities
+		detect: aBlock
+		ifOne:  anotherBlock
 ]
 
 { #category : #enumerating }


### PR DESCRIPTION
added methods
- `#detect:ifOne:`
- `#detect:ifFound:ifNone:`