### PR TITLE
Smalltalk: Ensure all stubs are in the model

### DIFF
--- a/src/Moose-SmalltalkImporter-LAN-Tests/ImportStubMethodSpecialTest.class.st
+++ b/src/Moose-SmalltalkImporter-LAN-Tests/ImportStubMethodSpecialTest.class.st
@@ -29,3 +29,17 @@ ImportStubMethodSpecialTest >> testStubMethodCreation [
 	self denyEmpty: (model allMethods select: #isStub).
 	self denyEmpty: model allModelMethods
 ]
+
+{ #category : #tests }
+ImportStubMethodSpecialTest >> testStubParentsAreInMooseModel [
+
+	| method class |
+	method := model entityNamed: #'Smalltalk::False.ifTrue:(Object)'.
+	self assert: method mooseModel isNotNil.
+	self assert: method isStub.
+
+	class := method parentType.
+	self assert: class name equals: 'False'.
+	self assert: class mooseModel isNotNil.
+	self assert: class isStub
+]

--- a/src/Moose-SmalltalkImporter/CandidateListOperator.class.st
+++ b/src/Moose-SmalltalkImporter/CandidateListOperator.class.st
@@ -14,12 +14,13 @@ Class {
 { #category : #running }
 CandidateListOperator >> allCandidatesFor: invocation [
 
-	^ Array withAll: (groups at: invocation signature ifAbsent: [ 
+	^ Array withAll: (groups at: invocation signature ifAbsent: [
 			   | stubs |
-			   stubs := self importer ensureSmalltalkStubMethodsFor:
-				            invocation signature.
+			   stubs := self importer ensureSmalltalkStubMethodsFor: invocation signature.
 			   groups at: invocation signature put: stubs.
-			   stubs do: [ :each | model add: each ].
+			   stubs do: [ :each |
+				   model add: each.
+				   each allParents do: [ :parent | parent mooseModel = model ifFalse: [ model add: parent ] ] ].
 			   stubs ])
 ]
 


### PR DESCRIPTION
Currently the parents of the stubs are not in the MooseModel which causes some inconsistances. Here is a fix.

Related to #552