### PR TITLE
Shared variable properties should be persisted

### DIFF
--- a/src/Famix-PharoSmalltalk-Entities/FamixStAttribute.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStAttribute.class.st
@@ -47,13 +47,16 @@ FamixStAttribute class >> annotation [
 	^ self
 ]
 
-{ #category : #'Famix-Implementation' }
+{ #category : #properties }
 FamixStAttribute >> beSharedVariable [
 
-	self propertyNamed: #sharedVariable put: true 
+	^ self attributeAt: #isSharedVariable put: true
 ]
 
-{ #category : #'Famix-Implementation' }
+{ #category : #testing }
 FamixStAttribute >> isSharedVariable [
-	^ self propertyNamed: #sharedVariable ifNil: [ false ]
+
+	<FMProperty: #isSharedVariable type: #Boolean>
+	<FMComment: 'True if the attribute is a shared variable'>
+	^ self attributeAt: #isSharedVariable ifAbsent: [ false ]
 ]

--- a/src/Famix-PharoSmalltalk-Tests/FamixPharoAttributeTest.class.st
+++ b/src/Famix-PharoSmalltalk-Tests/FamixPharoAttributeTest.class.st
@@ -6,8 +6,23 @@ Class {
 
 { #category : #tests }
 FamixPharoAttributeTest >> testIsClassSide [
+
 	| attribute |
 	attribute := FamixStAttribute new.
 	attribute isClassSide: true.
-	self assert: attribute isClassSide .
+	self assert: attribute isClassSide
+]
+
+{ #category : #tests }
+FamixPharoAttributeTest >> testSharedVariableArePersisted [
+
+	| attribute |
+	attribute := FamixStAttribute new.
+	attribute
+		isClassSide: true;
+		beSharedVariable.
+	self assert: attribute isSharedVariable.
+
+	attribute flush.
+	self assert: attribute isSharedVariable
 ]


### PR DESCRIPTION
Smalltalk attributes can be shared variable and we have a way to declare this. 

The problem is that this info can be lost when we flush the caches. This change fix this bug.

I also declared this as a property in the MM so that we can query it in the query browser

Fixes #790