### PR TITLE
Generate Equality Check for entities

### DIFF
--- a/src/Famix-MetamodelBuilder-Core/FmxMBClass.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxMBClass.class.st
@@ -3,7 +3,8 @@ Class {
 	#superclass : #FmxMBBehavior,
 	#instVars : [
 		'classGeneralization',
-		'isAbstractClass'
+		'isAbstractClass',
+		'propertiesForEqualityCheck'
 	],
 	#category : #'Famix-MetamodelBuilder-Core-Implementation'
 }
@@ -80,7 +81,70 @@ FmxMBClass >> generate [
 	self generatePrecedenceInTraitComposition: aClass.
 
 	self generateNavigationGroupsFor: aClass.
-	self generateAddToCollectionFor: aClass
+	self generateAddToCollectionFor: aClass.
+	
+	self generateEqualsMethodFor: aClass.
+	self generateHashMethodFor: aClass.
+]
+
+{ #category : #'generating-methods' }
+FmxMBClass >> generateEqualsMethodFor: aClass [
+
+	propertiesForEqualityCheck ifNotNil: [
+		| variableName |
+		variableName := 'a' , aClass name.
+		self builder environment
+			compile: (String streamContents: [ :stream |
+					 stream << '= '.
+					 stream << variableName.
+					 stream << '
+
+	<generated>
+	^ '.
+					 stream
+						 << variableName;
+						 << ' ';
+						 << propertiesForEqualityCheck first;
+						 << ' = self ';
+						 << propertiesForEqualityCheck first.
+					 propertiesForEqualityCheck size > 1 ifTrue: [
+						 2 to: propertiesForEqualityCheck size do: [ :idx |
+							 stream << ' and: [ '.
+							 stream
+								 << variableName;
+								 << ' ';
+								 << (propertiesForEqualityCheck at: idx);
+								 << ' = self ';
+								 << (propertiesForEqualityCheck at: idx) ].
+						 2 to: propertiesForEqualityCheck size do: [ :idx |
+						 stream << '] ' ] ] ])
+			in: aClass instanceSide
+			classified: #comparing ]
+]
+
+{ #category : #'generating-methods' }
+FmxMBClass >> generateHashMethodFor: aClass [
+
+	propertiesForEqualityCheck ifNotNil: [
+		self builder environment
+			compile: (String streamContents: [ :stream |
+					 stream << 'hash'.
+					 stream << '
+
+	<generated>
+	^ '.
+					 stream
+						 << 'self ';
+						 << propertiesForEqualityCheck first;
+						 << ' hash '.
+					 propertiesForEqualityCheck size > 1 ifTrue: [
+						 2 to: propertiesForEqualityCheck size do: [ :idx |
+							 stream
+								 << 'bitXor: self ';
+								 << (propertiesForEqualityCheck at: idx);
+								 << ' hash ' ] ] ])
+			in: aClass instanceSide
+			classified: #comparing ]
 ]
 
 { #category : #generating }
@@ -182,4 +246,10 @@ FmxMBClass >> traitsFromRelations [
 	"returns traits defined by relations"
 
 	^ (self relations collect: [ :each | each side trait ] thenSelect: #isNotNil) asSet
+]
+
+{ #category : #generalization }
+FmxMBClass >> withEqualityCheckOn: aCollectionOfPropertySymbol [
+
+	propertiesForEqualityCheck := aCollectionOfPropertySymbol
 ]

--- a/src/Famix-Test4-Entities/FamixTest4Book.class.st
+++ b/src/Famix-Test4-Entities/FamixTest4Book.class.st
@@ -8,12 +8,19 @@
 | `person` | `FamixTest4Book` | `books` | `FamixTest4Person` | |
 
 
+## Properties
+======================
+
+| Name | Type | Default value | Comment |
+|---|
+| `id` | `Number` | nil | |
 
 "
 Class {
 	#name : #FamixTest4Book,
 	#superclass : #FamixTest4Entity,
 	#instVars : [
+		'#id => FMProperty',
 		'#person => FMOne type: #FamixTest4Person opposite: #books'
 	],
 	#category : #'Famix-Test4-Entities-Entities'
@@ -26,6 +33,34 @@ FamixTest4Book class >> annotation [
 	<package: #'Famix-Test4-Entities'>
 	<generated>
 	^ self
+]
+
+{ #category : #comparing }
+FamixTest4Book >> = aFamixTest4Book [
+
+	<generated>
+	^ aFamixTest4Book id = self id
+]
+
+{ #category : #comparing }
+FamixTest4Book >> hash [
+
+	<generated>
+	^ self id hash 
+]
+
+{ #category : #accessing }
+FamixTest4Book >> id [
+
+	<FMProperty: #id type: #Number>
+	<generated>
+	^ id
+]
+
+{ #category : #accessing }
+FamixTest4Book >> id: anObject [
+	<generated>
+	id := anObject
 ]
 
 { #category : #accessing }

--- a/src/Famix-Test4-Entities/FamixTest4Person.class.st
+++ b/src/Famix-Test4-Entities/FamixTest4Person.class.st
@@ -13,6 +13,7 @@
 
 | Name | Type | Default value | Comment |
 |---|
+| `age` | `Number` | nil | |
 | `firstName` | `String` | nil | |
 | `lastName` | `String` | nil | |
 
@@ -23,6 +24,7 @@ Class {
 	#instVars : [
 		'#firstName => FMProperty',
 		'#lastName => FMProperty',
+		'#age => FMProperty',
 		'#books => FMMany type: #FamixTest4Book opposite: #person'
 	],
 	#category : #'Famix-Test4-Entities-Entities'
@@ -49,13 +51,27 @@ FamixTest4Person class >> isAbstract [
 FamixTest4Person >> = aFamixTest4Person [
 
 	<generated>
-	^ aFamixTest4Person firstName = self firstName and: [ aFamixTest4Person lastName = self lastName] 
+	^ aFamixTest4Person firstName = self firstName and: [ aFamixTest4Person lastName = self lastName and: [ aFamixTest4Person age = self age] ] 
 ]
 
 { #category : #adding }
 FamixTest4Person >> addBook: anObject [
 	<generated>
 	^ self books add: anObject
+]
+
+{ #category : #accessing }
+FamixTest4Person >> age [
+
+	<FMProperty: #age type: #Number>
+	<generated>
+	^ age
+]
+
+{ #category : #accessing }
+FamixTest4Person >> age: anObject [
+	<generated>
+	age := anObject
 ]
 
 { #category : #accessing }
@@ -99,7 +115,7 @@ FamixTest4Person >> firstName: anObject [
 FamixTest4Person >> hash [
 
 	<generated>
-	^ self firstName hash bitXor: self lastName hash 
+	^ self firstName hash bitXor: self lastName hash bitXor: self age hash 
 ]
 
 { #category : #accessing }

--- a/src/Famix-Test4-Entities/FamixTest4Person.class.st
+++ b/src/Famix-Test4-Entities/FamixTest4Person.class.st
@@ -8,12 +8,21 @@
 | `books` | `FamixTest4Person` | `person` | `FamixTest4Book` | |
 
 
+## Properties
+======================
+
+| Name | Type | Default value | Comment |
+|---|
+| `firstName` | `String` | nil | |
+| `lastName` | `String` | nil | |
 
 "
 Class {
 	#name : #FamixTest4Person,
 	#superclass : #FamixTest4Entity,
 	#instVars : [
+		'#firstName => FMProperty',
+		'#lastName => FMProperty',
 		'#books => FMMany type: #FamixTest4Book opposite: #person'
 	],
 	#category : #'Famix-Test4-Entities-Entities'
@@ -34,6 +43,13 @@ FamixTest4Person class >> isAbstract [
 
 	<generated>
 	^ self == FamixTest4Person
+]
+
+{ #category : #comparing }
+FamixTest4Person >> = aFamixTest4Person [
+
+	<generated>
+	^ aFamixTest4Person firstName = self firstName and: [ aFamixTest4Person lastName = self lastName] 
 ]
 
 { #category : #adding }
@@ -63,4 +79,39 @@ FamixTest4Person >> booksGroup [
 	<generated>
 	<navigation: 'Books'>
 	^ MooseSpecializedGroup withAll: self books asSet
+]
+
+{ #category : #accessing }
+FamixTest4Person >> firstName [
+
+	<FMProperty: #firstName type: #String>
+	<generated>
+	^ firstName
+]
+
+{ #category : #accessing }
+FamixTest4Person >> firstName: anObject [
+	<generated>
+	firstName := anObject
+]
+
+{ #category : #comparing }
+FamixTest4Person >> hash [
+
+	<generated>
+	^ self firstName hash bitXor: self lastName hash 
+]
+
+{ #category : #accessing }
+FamixTest4Person >> lastName [
+
+	<FMProperty: #lastName type: #String>
+	<generated>
+	^ lastName
+]
+
+{ #category : #accessing }
+FamixTest4Person >> lastName: anObject [
+	<generated>
+	lastName := anObject
 ]

--- a/src/Famix-Test4-Entities/FamixTest4School.class.st
+++ b/src/Famix-Test4-Entities/FamixTest4School.class.st
@@ -18,9 +18,9 @@ Class {
 	#superclass : #FamixTest4Entity,
 	#instVars : [
 		'#principal => FMOne type: #FamixTest4Principal opposite: #school',
-		'#rooms => FMMany type: #FamixTest4Room opposite: #school',
 		'#students => FMMany type: #FamixTest4Student opposite: #school',
-		'#teachers => FMMany type: #FamixTest4Teacher opposite: #school'
+		'#teachers => FMMany type: #FamixTest4Teacher opposite: #school',
+		'#rooms => FMMany type: #FamixTest4Room opposite: #school'
 	],
 	#category : #'Famix-Test4-Entities-Entities'
 }

--- a/src/Famix-Test4-Entities/FamixTest4TEntityCreator.trait.st
+++ b/src/Famix-Test4-Entities/FamixTest4TEntityCreator.trait.st
@@ -6,7 +6,7 @@ It provides an API for creating entities and adding them to the model.
 "
 Trait {
 	#name : #FamixTest4TEntityCreator,
-	#category : #'Famix-Test4-Entities-Traits'
+	#category : #'Famix-Test4-Entities-Model'
 }
 
 { #category : #meta }

--- a/src/Famix-Test4-Tests/FamixTest4Test.class.st
+++ b/src/Famix-Test4-Tests/FamixTest4Test.class.st
@@ -33,9 +33,13 @@ FamixTest4Test >> setUp [
 	student1 := FamixTest4Student new.
 	student1 := FamixTest4Student new.
 	student2 := FamixTest4Student new.
+	student2 firstName: 'firstname'.
+	student2 lastName: 'lastName'.
 	student3 := FamixTest4Student new.
 	teacher1 := FamixTest4Teacher new.
+	teacher1 firstName: 'John'.
 	teacher2 := FamixTest4Teacher new.
+	teacher2 firstName: 'Bob'.
 	book1 := FamixTest4Book new.
 	book2 := FamixTest4Book new.
 
@@ -56,6 +60,18 @@ FamixTest4Test >> testAbstractClasses [
 
 	self assert: FamixTest4Entity isAbstract.
 	self assert: FamixTest4Person isAbstract
+]
+
+{ #category : #tests }
+FamixTest4Test >> testEqualityStudent [
+
+	| sameStudent |
+	"A copy of student2 to test same"
+	sameStudent := FamixTest4Student new.
+	sameStudent firstName: 'firstname'.
+	sameStudent lastName: 'lastName'.
+
+	self assert: student2 equals: sameStudent
 ]
 
 { #category : #tests }

--- a/src/Famix-TestGenerators/FamixTest4Generator.class.st
+++ b/src/Famix-TestGenerators/FamixTest4Generator.class.st
@@ -69,9 +69,17 @@ FamixTest4Generator >> defineHierarchy [
 
 { #category : #definition }
 FamixTest4Generator >> defineProperties [
+
 	super defineProperties.
 
-	(builder ensureClassNamed: #Entity) property: #name type: #String
+	(builder ensureClassNamed: #Entity) property: #name type: #String.
+
+	person property: #firstName type: #String.
+	person property: #lastName type: #String.
+	person withEqualityCheckOn: { #firstName. #lastName }.
+
+	book property: #id type: #Number.
+	book withEqualityCheckOn: { #id }
 ]
 
 { #category : #definition }

--- a/src/Famix-TestGenerators/FamixTest4Generator.class.st
+++ b/src/Famix-TestGenerators/FamixTest4Generator.class.st
@@ -76,7 +76,8 @@ FamixTest4Generator >> defineProperties [
 
 	person property: #firstName type: #String.
 	person property: #lastName type: #String.
-	person withEqualityCheckOn: { #firstName. #lastName }.
+	person property: #age type: #Number.
+	person withEqualityCheckOn: { #firstName. #lastName. #age }.
 
 	book property: #id type: #Number.
 	book withEqualityCheckOn: { #id }


### PR DESCRIPTION
This PR aims to add in the generator the code to generate equality checks (method `=` and `hash`).
**We keep the current default behavior -> no breaking change possible :)**

I propose adding a method named: `withEqualityCheckOn:` that takes the list of properties as input to check for equality.
It then generates the `=` and `hash` methods considering this list.

I have modified `FamixTest4Generator` to take into consideration this update.
For instance, I added to `person` a firstName and lastName. And I added the quality check on them

```st
	person property: #firstName type: #String.
	person property: #lastName type: #String.
	person withEqualityCheckOn: { #firstName. #lastName }.
```

The same for book with an `id`

I update the setup to add identity information. And I added the test `testEqualityStudent` to particularly test this feature

For method `=`

The generation follows this pattern:

```st
= aFamixTest4Person 

	<generated>
	^ aFamixTest4Person firstName = self firstName and: [ aFamixTest4Person lastName = self lastName] 
```

And for `hash`

```st
hash

	<generated>
	^ self firstName hash bitXor: self lastName hash 
```

I based this template on existing methods in the system
