### PR TITLE
Clean test case management

### DIFF
--- a/src/Famix-Java-Entities/FamixJavaClass.class.st
+++ b/src/Famix-Java-Entities/FamixJavaClass.class.st
@@ -104,6 +104,13 @@ FamixJavaClass >> incomingAccesses [
 ]
 
 { #category : #testing }
+FamixJavaClass >> inheritsFromTestCase [
+	"In the past we checked for the one from junit, but Apache also have its own way to test with a superclass named TestCase."
+
+	^ self superclassHierarchy anySatisfy: [ :each | each name = #TestCase ]
+]
+
+{ #category : #testing }
 FamixJavaClass >> isADirectSubclassOf: aClass [
 	^ aClass class = FamixJavaClass
 		ifTrue: [ aClass directSubclasses includes: self ]
@@ -152,6 +159,24 @@ FamixJavaClass >> isIgnored [
 FamixJavaClass >> isInheritedBy: anInheritance [ 
 	 
 	^anInheritance superclass == self
+]
+
+{ #category : #testing }
+FamixJavaClass >> isJUnit4TestCase [
+
+	<FMProperty: #isJUnit4TestCase type: #Boolean>
+	<derived>
+	<FMComment: 'True if the method is considered as a Junit 4 Java test'>
+	^ self methods anySatisfy: [ :m | m isJUnit4Test ]
+]
+
+{ #category : #testing }
+FamixJavaClass >> isTestCase [
+
+	<FMProperty: #isTestCase type: #Boolean>
+	<derived>
+	<FMComment: 'True if the method is considered as a Java test'>
+	^ self inheritsFromTestCase or: [ self isJUnit4TestCase ]
 ]
 
 { #category : #private }

--- a/src/Famix-Java-Entities/FamixJavaType.class.st
+++ b/src/Famix-Java-Entities/FamixJavaType.class.st
@@ -125,19 +125,6 @@ FamixJavaType >> isInterface [
 ]
 
 { #category : #testing }
-FamixJavaType >> isJUnit3TestCase [
-	^ self superclassHierarchy anySatisfy: [:each | each mooseName =  #'junit::framework::TestCase']
-]
-
-{ #category : #testing }
-FamixJavaType >> isJUnit4TestCase [
-	<FMProperty: #isJUnit4TestCase type: #Boolean>
-	<derived>
-	<FMComment: 'True if the method is considered as a Junit 4 Java test'>
-	^ self methods anySatisfy: [ :m | m isJUnit4Test ]
-]
-
-{ #category : #testing }
 FamixJavaType >> isLonelyWithin: aClassGroup [
 	^ ( self subclassHierarchyGroup intersection: aClassGroup ) isEmpty and: [
 		( self superclassHierarchyGroup intersection: aClassGroup ) isEmpty ]
@@ -146,14 +133,6 @@ FamixJavaType >> isLonelyWithin: aClassGroup [
 { #category : #testing }
 FamixJavaType >> isParameterType [
 	^ false
-]
-
-{ #category : #testing }
-FamixJavaType >> isTestCase [
-	<FMProperty: #isTestCase type: #Boolean>
-	<derived>
-	<FMComment: 'True if the method is considered as a Java test'>
-	^ self isJUnit3TestCase or: [ self isJUnit4TestCase ] 
 ]
 
 { #category : #'Famix-Extensions-operations' }

--- a/src/Famix-PharoSmalltalk-Entities/FamixStClass.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStClass.class.st
@@ -145,6 +145,7 @@ FamixStClass >> isLonelyWithin: aClassGroup [
 
 { #category : #testing }
 FamixStClass >> isTestCase [
+
 	<FMProperty: #isTestCase type: #Boolean>
 	<derived>
 	<FMComment: 'True if the method is considered as a Java test'>

--- a/src/Famix-PharoSmalltalk-Entities/FamixStMethod.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStMethod.class.st
@@ -185,14 +185,6 @@ FamixStMethod >> isInternalImplementation [
 		and: [ self isPureAccessor not ]
 ]
 
-{ #category : #'Famix-Extensions-metrics-support' }
-FamixStMethod >> isJUnit4Test [
-	<FMProperty: #isJUnit4Test type: #Boolean>
-	<derived>
-	<FMComment: 'True if the method is considered as a Junit 4 Java test'>
-	^ self isAnnotatedWith: 'Test'
-]
-
 { #category : #testing }
 FamixStMethod >> isOverridden [
 	"If we have a stub and we don't have the container, we can't have the information"


### PR DESCRIPTION
- Push down #isTestCase from JavaType to JavaClass
- Make test about TestCase more permissif to match more test frameworks
- Remove #isJUnit4Test from St methods