### PR TITLE
Fix `allSuperclassesDo:`

### DIFF
--- a/src/Famix-Traits/FamixTWithInheritances.trait.st
+++ b/src/Famix-Traits/FamixTWithInheritances.trait.st
@@ -54,9 +54,14 @@ FamixTWithInheritances >> allSubclassesDo: aBlock [
 { #category : #enumerating }
 FamixTWithInheritances >> allSuperclassesDo: aBlock [
 
-	self superInheritances do: [ :each | 
-		aBlock value: each superclass.
-		each superclass allSuperclassesDo: aBlock ]
+	self superInheritances do: [ :each |
+		| superclass |
+		superclass := each superclass.
+		(superclass isParametricEntity and: [
+			 superclass isGenericEntity not ]) ifTrue: [
+			superclass := superclass genericEntity ].
+		aBlock value: superclass.
+		superclass allSuperclassesDo: aBlock ]
 ]
 
 { #category : #enumerating }


### PR DESCRIPTION
The inheritance chain is broken by parametric entities, this is just a temporary fix for this deeper issue.
Parametrics still need an overhaul.