### PR TITLE
Fix a bug with strings as default value for a property.

### DIFF
--- a/src/Famix-MetamodelBuilder-Core/FmxMBRingEnvironment.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxMBRingEnvironment.class.st
@@ -212,6 +212,8 @@ FmxMBRingEnvironment >> slotNamed: slotName cardinality: cardinality type: type 
 
 { #category : #initialization }
 FmxMBRingEnvironment >> slotNamed: slotName defaultValue: aValue [
+
 	aValue ifNil: [ ^ self slotNamed: slotName ].
-	^ (RGUnknownSlot named: slotName asSymbol) expression: ('FMProperty defaultValue: {1}' format: { aValue })
+	^ (RGUnknownSlot named: slotName asSymbol) expression:
+		  ('FMProperty defaultValue: {1}' format: { aValue printString })
 ]

--- a/src/Famix-MetamodelBuilder-Core/FmxMBTypedProperty.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxMBTypedProperty.class.st
@@ -43,7 +43,7 @@ FmxMBTypedProperty >> generateGetterIn: aClassOrTrait [
 	pragmaFormat := self defaultValue ifNil: [ '<FMProperty: #{1} type: #{2}>' ] 
 											   ifNotNil: [ '<FMProperty: #{1} type: #{2} defaultValue: {3}>' ]. 
 	propertyDefinition := pragmaFormat
-		format: { self name. self propertyType. self defaultValue }.
+		format: { self name. self propertyType. self defaultValue printString}.
 
 	commentDefinition := self comment
 		ifNotEmpty: [ '<FMComment: {1}>' format: { self comment printString } ].
@@ -58,7 +58,7 @@ FmxMBTypedProperty >> generateGetterIn: aClassOrTrait [
 			ifNotEmpty: [ s tab; nextPutAll: commentDefinition; cr].
 		s tab; nextPutAll: '^ '; nextPutAll: self name.
 		self defaultValue ifNotNil: [
-			s nextPutAll: (' ifNil: [ {1} := {2} ]' format: { self name. self defaultValue }) ] ].
+			s nextPutAll: (' ifNil: [ {1} := {2} ]' format: { self name. self defaultValue printString }) ] ].
 
 	self builder environment compile: methodSource in: aClassOrTrait classified: 'accessing'.	
 	

--- a/src/Famix-Test6-Entities/FamixTest6Bacon.class.st
+++ b/src/Famix-Test6-Entities/FamixTest6Bacon.class.st
@@ -4,6 +4,7 @@
 
 | Name | Type | Default value | Comment |
 |---|
+| `brand` | `String` | '' | |
 | `eggs` | `Number` | 12 | |
 | `isFood` | `Boolean` | true | |
 
@@ -12,8 +13,9 @@ Class {
 	#name : #FamixTest6Bacon,
 	#superclass : #FamixTest6Entity,
 	#instVars : [
-		'#isFood => FMProperty defaultValue: true',
-		'#eggs => FMProperty defaultValue: 12'
+		'#brand => FMProperty defaultValue: \'\'',
+		'#eggs => FMProperty defaultValue: 12',
+		'#isFood => FMProperty defaultValue: true'
 	],
 	#category : #'Famix-Test6-Entities-Entities'
 }
@@ -25,6 +27,20 @@ FamixTest6Bacon class >> annotation [
 	<package: #'Famix-Test6-Entities'>
 	<generated>
 	^ self
+]
+
+{ #category : #accessing }
+FamixTest6Bacon >> brand [
+
+	<FMProperty: #brand type: #String defaultValue: ''>
+	<generated>
+	^ brand ifNil: [ brand := '' ]
+]
+
+{ #category : #accessing }
+FamixTest6Bacon >> brand: anObject [
+	<generated>
+	brand := anObject
 ]
 
 { #category : #accessing }

--- a/src/Famix-Test6-Tests/FamixTest6Test.class.st
+++ b/src/Famix-Test6-Tests/FamixTest6Test.class.st
@@ -5,19 +5,36 @@ Class {
 }
 
 { #category : #running }
+FamixTest6Test >> testDefaultValueEmptyString [
+
+	| bacon brandProperty newBrand |
+	bacon := FamixTest6Bacon new.
+	brandProperty := bacon mooseDescription properties detect: [ :each |
+		                 each name = #brand ].
+
+	self assert: bacon brand equals: ''.
+	self assert: brandProperty defaultValue equals: ''.
+
+	newBrand := 'WonderfulBacon'.
+	bacon brand: newBrand.
+	self assert: bacon brand equals: newBrand.
+	self assert: brandProperty defaultValue equals: ''
+]
+
+{ #category : #running }
 FamixTest6Test >> testDefaultValueOnCreation [
 
-	| bacon foodProperty |
-	
+	| bacon brandProperty |
 	bacon := FamixTest6Bacon new.
-	foodProperty := (bacon mooseDescription properties select: [ :each | each name = #isFood ]) at: 1.
-	
-	self assert: bacon isFood equals: true.
-	self assert: foodProperty defaultValue equals: true.
-	
+	brandProperty := (bacon mooseDescription properties select: [ :each |
+		                  each name = #isFood ]) at: 1.
+
+	self assert: bacon isFood.
+	self assert: brandProperty defaultValue.
+
 	bacon isFood: false.
-	self assert: bacon isFood equals: false.
-	self assert: foodProperty defaultValue equals: true.
+	self deny: bacon isFood.
+	self assert: brandProperty defaultValue
 ]
 
 { #category : #running }

--- a/src/Famix-TestGenerators/FamixTest6Generator.class.st
+++ b/src/Famix-TestGenerators/FamixTest6Generator.class.st
@@ -42,5 +42,6 @@ FamixTest6Generator >> defineProperties [
 	super defineProperties.
 	bacon property: #isFood type: #Boolean defaultValue: true.
 	bacon property: #eggs type: #Number defaultValue: 12.
-	spam property: #isSomething type: #Boolean defaultValue: false
+	spam property: #isSomething type: #Boolean defaultValue: false.
+	bacon property: #brand type: #String defaultValue: ''
 ]


### PR DESCRIPTION
The generation failed because the string was integrated in the definition strings without quotes. 
This fixes this bug + adds tests