### PR TITLE
Generator-related fixes and cleaning.

### DIFF
--- a/src/Famix-MetamodelBuilder-Core/FmxMBPrintVisitor.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxMBPrintVisitor.class.st
@@ -13,54 +13,76 @@ Class {
 	#category : #'Famix-MetamodelBuilder-Core-Visitors'
 }
 
+{ #category : #'as yet unclassified' }
+FmxMBPrintVisitor >> prepareForPropertiesIn: aClassOrTrait [
+
+	(aClassOrTrait properties isNotEmpty or: [
+		 aClassOrTrait relations isNotEmpty ]) ifFalse: [ ^ self ].
+
+	Transcript
+		cr;
+		tab;
+		tab
+]
+
+{ #category : #visiting }
+FmxMBPrintVisitor >> separateProperties [
+
+	Transcript
+		cr;
+		tab;
+		tab
+]
+
 { #category : #visiting }
 FmxMBPrintVisitor >> visitBuilder: aBuilder [
-	aBuilder logCr.
+
+	self trace: aBuilder generator class.
 	super visitBuilder: aBuilder
 ]
 
 { #category : #visiting }
 FmxMBPrintVisitor >> visitClass: aClass [
-	Transcript
-		tab;
-		nextPutAll: aClass name;
-		cr.
-	Transcript
-		tab;
-		nextPutAll: ' -|> '.
-	aClass classGeneralization ifNotNil: [ :generalization | Transcript nextPutAll: generalization name ].
-	aClass traitGeneralizations
-		ifNotEmpty: [ :generalizations | 
-			generalizations
-				do: [ :generalization | 
-					Transcript
-						nextPutAll: ', ';
-						nextPutAll: generalization name ] ].
-	Transcript cr.
+
+	self traceCrTab: ''.
+	aClass name trace.
+	self trace: ' -|> '.
+	(aClass classGeneralization
+		 ifNil: [ 'Entity' ]
+		 ifNotNil: [ :generalization | generalization name ]) trace.
+	aClass traitGeneralizations ifNotEmpty: [ :generalizations |
+		generalizations
+			do: [ :generalization | generalization name trace ]
+			separatedBy: [ ', ' trace ] ].
 
 	super visitClass: aClass
 ]
 
 { #category : #visiting }
 FmxMBPrintVisitor >> visitRelationSide: aRelationSide [
-	Transcript tab.
-	Transcript tab.
-	aRelationSide name logCr
+
+	self trace:
+		aRelationSide name , ' (' , aRelationSide oppositeType , ')'
 ]
 
 { #category : #visiting }
 FmxMBPrintVisitor >> visitTrait: aTrait [
-	Transcript
-		tab;
-		nextPutAll: aTrait name;
-		cr.
+
+	self traceCrTab: ''.
+	aTrait name trace.
+
+	aTrait traitGeneralizations ifNotEmpty: [ :generalizations |
+		self trace: ' -|> '.
+		generalizations
+			do: [ :generalization | generalization name trace ]
+			separatedBy: [ ', ' trace ] ].
 
 	super visitTrait: aTrait
 ]
 
 { #category : #visiting }
 FmxMBPrintVisitor >> visitTypedProperty: aTypedProperty [
-	Transcript tab.
-	Transcript tab.
-	aTypedProperty logCr
+
+	self trace:
+		aTypedProperty name , ' (' , aTypedProperty propertyType , ')'
 ]

--- a/src/Famix-MetamodelBuilder-Core/FmxMBTrait.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxMBTrait.class.st
@@ -13,7 +13,9 @@ FmxMBTrait >> acceptVisitor: aVisitor [
 
 { #category : #accessing }
 FmxMBTrait >> allTraitGeneralizations [
-	^ (self traitGeneralizations flatCollect: [ :each | {each} , each allTraitGeneralizations ]) asSet
+
+	^ (self traitGeneralizations flatCollect: [ :each |
+		   { each } , each allTraitGeneralizations ]) removeDuplicates
 ]
 
 { #category : #accessing }

--- a/src/Famix-MetamodelBuilder-Core/FmxMBWalkerVisitor.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxMBWalkerVisitor.class.st
@@ -17,22 +17,43 @@ Class {
 }
 
 { #category : #visiting }
+FmxMBWalkerVisitor >> prepareForPropertiesIn: aClassOrTrait [
+	"Nothing to do by default"
+
+	
+]
+
+{ #category : #visiting }
+FmxMBWalkerVisitor >> separateProperties [
+	"Nothing to do by default"
+
+	
+]
+
+{ #category : #visiting }
 FmxMBWalkerVisitor >> visitBuilder: aBuilder [
 	"Visit every Traits, and classes after that."
+
 	aBuilder sortedTraits do: [ :each | each acceptVisitor: self ].
-	aBuilder sortedClasses do: [ :each | each acceptVisitor: self ].	
+	aBuilder sortedClasses do: [ :each | each acceptVisitor: self ]
 ]
 
 { #category : #visiting }
 FmxMBWalkerVisitor >> visitClass: aClass [
 	"Visit all properties of aClass"
 
-	aClass properties do: [ :each | each acceptVisitor: self ].
-
+	self prepareForPropertiesIn: aClass.
+	aClass properties
+		do: [ :each | each acceptVisitor: self ]
+		separatedBy: [ self separateProperties ]
 ]
 
 { #category : #visiting }
 FmxMBWalkerVisitor >> visitTrait: aTrait [
-	"visit aTrait leaves"
-	aTrait properties do: [ :each | each acceptVisitor: self ].
+	"visit all properties of aTrait"
+
+	self prepareForPropertiesIn: aTrait.
+	aTrait properties
+		do: [ :each | each acceptVisitor: self ]
+		separatedBy: [ self separateProperties ]
 ]

--- a/src/Famix-MetamodelBuilder-Tests/FmxMBBuilderTest.class.st
+++ b/src/Famix-MetamodelBuilder-Tests/FmxMBBuilderTest.class.st
@@ -190,22 +190,6 @@ FmxMBBuilderTest >> testSortedClasses [
 { #category : #tests }
 FmxMBBuilderTest >> testSortedTraits [
 
-	"traits should be sorted by name and by their hierarchy"
-
-	| t1 t2 t3 |
-	
-	t1 := builder newTraitNamed: 'T1'.
-	t2 := builder newTraitNamed: 'T2'.
-	t3 := builder newTraitNamed: 'T3'.
-	
-	t3 <|-- t2.
-	
-	self assert: builder sortedTraits asArray equals: { t1. t3. t2 }
-]
-
-{ #category : #tests }
-FmxMBBuilderTest >> testSortedTratis [
-
 	| t1 t2 t3 |
 	
 	t2 := builder newTraitNamed: #T2.
@@ -215,6 +199,41 @@ FmxMBBuilderTest >> testSortedTratis [
 	self assertCollection: builder sortedTraits asArray equals: { t1. t2. t3 }.
 	
 	
+]
+
+{ #category : #tests }
+FmxMBBuilderTest >> testSortedTraitsWith1LevelUsage [
+	"traits should be sorted by name and by their useage level"
+
+	| t1 t2 t3 |
+	t1 := builder newTraitNamed: 'T1'.
+	t2 := builder newTraitNamed: 'T2'.
+	t3 := builder newTraitNamed: 'T3'.
+
+	t3 <|-- t2.
+
+	self assert: builder sortedTraits asArray equals: {
+			t1.
+			t3.
+			t2 }
+]
+
+{ #category : #tests }
+FmxMBBuilderTest >> testSortedTraitsWith2LevelUsage [
+	"traits should be sorted by name and by their useage level"
+
+	| t1 t2 t3 |
+	t1 := builder newTraitNamed: 'T1'.
+	t2 := builder newTraitNamed: 'T2'.
+	t3 := builder newTraitNamed: 'T3'.
+
+	t2 <|-- t1.
+	t3 <|-- t2.
+
+	self assert: builder sortedTraits asArray equals: {
+			t3.
+			t2.
+			t1 }
 ]
 
 { #category : #tests }


### PR DESCRIPTION
#allTraitGeneralizations was broken, so tests are modified to include this bug and avoid further regressions. 
PrintVisitor was using code that has been removed from Pharo.