### PR TITLE
Java Enums can receive invocations

### DIFF
--- a/src/Famix-Java-Entities/FamixJavaEnum.class.st
+++ b/src/Famix-Java-Entities/FamixJavaEnum.class.st
@@ -31,6 +31,7 @@
 ### Other
 | Relation | Origin | Opposite | Type | Comment |
 |---|
+| `receivingInvocations` | `FamixTInvocationsReceiver` | `receiver` | `FamixTInvocation` | List of invocations performed on this entity (considered as the receiver)|
 | `sourceAnchor` | `FamixTSourceEntity` | `element` | `FamixTSourceAnchor` | SourceAnchor entity linking to the original source code for this entity|
 | `typedEntities` | `FamixTType` | `declaredType` | `FamixTTypedEntity` | Entities that have this type as declaredType|
 
@@ -48,8 +49,8 @@
 Class {
 	#name : #FamixJavaEnum,
 	#superclass : #FamixJavaType,
-	#traits : 'FamixTEnum + FamixTHasVisibility + FamixTImportable + FamixTWithAttributes + FamixTWithComments + FamixTWithImports + FamixTWithInheritances + FamixTWithMethods',
-	#classTraits : 'FamixTEnum classTrait + FamixTHasVisibility classTrait + FamixTImportable classTrait + FamixTWithAttributes classTrait + FamixTWithComments classTrait + FamixTWithImports classTrait + FamixTWithInheritances classTrait + FamixTWithMethods classTrait',
+	#traits : 'FamixTEnum + FamixTHasVisibility + FamixTImportable + FamixTInvocationsReceiver + FamixTWithAttributes + FamixTWithComments + FamixTWithImports + FamixTWithInheritances + FamixTWithMethods',
+	#classTraits : 'FamixTEnum classTrait + FamixTHasVisibility classTrait + FamixTImportable classTrait + FamixTInvocationsReceiver classTrait + FamixTWithAttributes classTrait + FamixTWithComments classTrait + FamixTWithImports classTrait + FamixTWithInheritances classTrait + FamixTWithMethods classTrait',
 	#category : #'Famix-Java-Entities-Entities'
 }
 

--- a/src/Famix-Java-Generator/FamixJavaGenerator.class.st
+++ b/src/Famix-Java-Generator/FamixJavaGenerator.class.st
@@ -274,6 +274,7 @@ FamixJavaGenerator >> defineHierarchy [
 	enum --|> #TWithComments.
 	enum --|> #TWithImports.
 	enum --|> #TImportable.
+	enum --|> #TInvocationsReceiver.
 
 	enumValue --|> variable.
 	enumValue --|> #TWithComments.


### PR DESCRIPTION
Since 79a7e2b3b09fe8f001ba13b5b923c5bd18637ac3, Java enums could no longer be invocation receivers in Famix, which is incorrect. This would cause an import error in such a case.
I'm not sure if TInvocationsReceiver is applicable to enums in all languages, so I only applied the change for Java.