### PR TITLE
[DO NOT MERGE YET] Update TAccess to have candidates as targets

### DIFF
--- a/src/Famix-Java-Entities/FamixJavaAccess.class.st
+++ b/src/Famix-Java-Entities/FamixJavaAccess.class.st
@@ -10,7 +10,7 @@
 ### Association target
 | Relation | Origin | Opposite | Type | Comment |
 |---|
-| `variable` | `FamixTAccess` | `incomingAccesses` | `FamixTAccessible` | Variable accessed. to-side of the association|
+| `candidates` | `FamixTAccess` | `incomingAccesses` | `FamixTAccessible` | Variables that cas be the accessed variable. to-side of the association. Most of the time it will be only one variable, but some languages might have candidates such as Python.|
 
 ### Other
 | Relation | Origin | Opposite | Type | Comment |

--- a/src/Famix-Java-Entities/FamixJavaAnnotationTypeAttribute.class.st
+++ b/src/Famix-Java-Entities/FamixJavaAnnotationTypeAttribute.class.st
@@ -15,7 +15,7 @@
 ### Incoming dependencies
 | Relation | Origin | Opposite | Type | Comment |
 |---|
-| `incomingAccesses` | `FamixTAccessible` | `variable` | `FamixTAccess` | All Famix accesses pointing to this structural entity|
+| `incomingAccesses` | `FamixTAccessible` | `candidates` | `FamixTAccess` | All Famix accesses pointing to this structural entity|
 
 ### Other
 | Relation | Origin | Opposite | Type | Comment |

--- a/src/Famix-Java-Entities/FamixJavaAttribute.class.st
+++ b/src/Famix-Java-Entities/FamixJavaAttribute.class.st
@@ -15,7 +15,7 @@
 ### Incoming dependencies
 | Relation | Origin | Opposite | Type | Comment |
 |---|
-| `incomingAccesses` | `FamixTAccessible` | `variable` | `FamixTAccess` | All Famix accesses pointing to this structural entity|
+| `incomingAccesses` | `FamixTAccessible` | `candidates` | `FamixTAccess` | All Famix accesses pointing to this structural entity|
 
 ### Other
 | Relation | Origin | Opposite | Type | Comment |

--- a/src/Famix-Java-Entities/FamixJavaEnumValue.class.st
+++ b/src/Famix-Java-Entities/FamixJavaEnumValue.class.st
@@ -15,7 +15,7 @@
 ### Incoming dependencies
 | Relation | Origin | Opposite | Type | Comment |
 |---|
-| `incomingAccesses` | `FamixTAccessible` | `variable` | `FamixTAccess` | All Famix accesses pointing to this structural entity|
+| `incomingAccesses` | `FamixTAccessible` | `candidates` | `FamixTAccess` | All Famix accesses pointing to this structural entity|
 
 ### Other
 | Relation | Origin | Opposite | Type | Comment |

--- a/src/Famix-Java-Entities/FamixJavaImplicitVariable.class.st
+++ b/src/Famix-Java-Entities/FamixJavaImplicitVariable.class.st
@@ -10,7 +10,7 @@
 ### Incoming dependencies
 | Relation | Origin | Opposite | Type | Comment |
 |---|
-| `incomingAccesses` | `FamixTAccessible` | `variable` | `FamixTAccess` | All Famix accesses pointing to this structural entity|
+| `incomingAccesses` | `FamixTAccessible` | `candidates` | `FamixTAccess` | All Famix accesses pointing to this structural entity|
 
 ### Other
 | Relation | Origin | Opposite | Type | Comment |

--- a/src/Famix-Java-Entities/FamixJavaLocalVariable.class.st
+++ b/src/Famix-Java-Entities/FamixJavaLocalVariable.class.st
@@ -15,7 +15,7 @@
 ### Incoming dependencies
 | Relation | Origin | Opposite | Type | Comment |
 |---|
-| `incomingAccesses` | `FamixTAccessible` | `variable` | `FamixTAccess` | All Famix accesses pointing to this structural entity|
+| `incomingAccesses` | `FamixTAccessible` | `candidates` | `FamixTAccess` | All Famix accesses pointing to this structural entity|
 
 ### Other
 | Relation | Origin | Opposite | Type | Comment |

--- a/src/Famix-Java-Entities/FamixJavaParameter.class.st
+++ b/src/Famix-Java-Entities/FamixJavaParameter.class.st
@@ -15,7 +15,7 @@
 ### Incoming dependencies
 | Relation | Origin | Opposite | Type | Comment |
 |---|
-| `incomingAccesses` | `FamixTAccessible` | `variable` | `FamixTAccess` | All Famix accesses pointing to this structural entity|
+| `incomingAccesses` | `FamixTAccessible` | `candidates` | `FamixTAccess` | All Famix accesses pointing to this structural entity|
 
 ### Other
 | Relation | Origin | Opposite | Type | Comment |

--- a/src/Famix-Java-Entities/FamixJavaUnknownVariable.class.st
+++ b/src/Famix-Java-Entities/FamixJavaUnknownVariable.class.st
@@ -5,7 +5,7 @@
 ### Incoming dependencies
 | Relation | Origin | Opposite | Type | Comment |
 |---|
-| `incomingAccesses` | `FamixTAccessible` | `variable` | `FamixTAccess` | All Famix accesses pointing to this structural entity|
+| `incomingAccesses` | `FamixTAccessible` | `candidates` | `FamixTAccess` | All Famix accesses pointing to this structural entity|
 
 ### Other
 | Relation | Origin | Opposite | Type | Comment |

--- a/src/Famix-MetamodelGeneration/FamixGenerator.class.st
+++ b/src/Famix-MetamodelGeneration/FamixGenerator.class.st
@@ -1277,10 +1277,10 @@ FamixGenerator >> defineRelations [
 	((tWithAccesses property: #accesses)
 			comment: 'Accesses to variables made by this behaviour.').
 
-	((tAccess property: #variable)
-			comment: 'Variable accessed. to-side of the association';
+	((tAccess property: #candidates)
+			comment: 'Variables that cas be the accessed variable. to-side of the association. Most of the time it will be only one variable, but some languages might have candidates such as Python.';
 			target)
-		*-
+		*-*
 	((tAccessible property: #incomingAccesses)
 			comment: 'All Famix accesses pointing to this structural entity').
 

--- a/src/Famix-PharoSmalltalk-Entities/FamixStAccess.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStAccess.class.st
@@ -10,7 +10,7 @@
 ### Association target
 | Relation | Origin | Opposite | Type | Comment |
 |---|
-| `variable` | `FamixTAccess` | `incomingAccesses` | `FamixTAccessible` | Variable accessed. to-side of the association|
+| `candidates` | `FamixTAccess` | `incomingAccesses` | `FamixTAccessible` | Variables that cas be the accessed variable. to-side of the association. Most of the time it will be only one variable, but some languages might have candidates such as Python.|
 
 ### Other
 | Relation | Origin | Opposite | Type | Comment |

--- a/src/Famix-PharoSmalltalk-Entities/FamixStAnnotationTypeAttribute.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStAnnotationTypeAttribute.class.st
@@ -10,7 +10,7 @@
 ### Incoming dependencies
 | Relation | Origin | Opposite | Type | Comment |
 |---|
-| `incomingAccesses` | `FamixTAccessible` | `variable` | `FamixTAccess` | All Famix accesses pointing to this structural entity|
+| `incomingAccesses` | `FamixTAccessible` | `candidates` | `FamixTAccess` | All Famix accesses pointing to this structural entity|
 
 ### Other
 | Relation | Origin | Opposite | Type | Comment |

--- a/src/Famix-PharoSmalltalk-Entities/FamixStAttribute.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStAttribute.class.st
@@ -10,7 +10,7 @@
 ### Incoming dependencies
 | Relation | Origin | Opposite | Type | Comment |
 |---|
-| `incomingAccesses` | `FamixTAccessible` | `variable` | `FamixTAccess` | All Famix accesses pointing to this structural entity|
+| `incomingAccesses` | `FamixTAccessible` | `candidates` | `FamixTAccess` | All Famix accesses pointing to this structural entity|
 
 ### Other
 | Relation | Origin | Opposite | Type | Comment |

--- a/src/Famix-PharoSmalltalk-Entities/FamixStGlobalVariable.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStGlobalVariable.class.st
@@ -10,7 +10,7 @@
 ### Incoming dependencies
 | Relation | Origin | Opposite | Type | Comment |
 |---|
-| `incomingAccesses` | `FamixTAccessible` | `variable` | `FamixTAccess` | All Famix accesses pointing to this structural entity|
+| `incomingAccesses` | `FamixTAccessible` | `candidates` | `FamixTAccess` | All Famix accesses pointing to this structural entity|
 
 ### Other
 | Relation | Origin | Opposite | Type | Comment |

--- a/src/Famix-PharoSmalltalk-Entities/FamixStImplicitVariable.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStImplicitVariable.class.st
@@ -10,7 +10,7 @@
 ### Incoming dependencies
 | Relation | Origin | Opposite | Type | Comment |
 |---|
-| `incomingAccesses` | `FamixTAccessible` | `variable` | `FamixTAccess` | All Famix accesses pointing to this structural entity|
+| `incomingAccesses` | `FamixTAccessible` | `candidates` | `FamixTAccess` | All Famix accesses pointing to this structural entity|
 
 ### Other
 | Relation | Origin | Opposite | Type | Comment |

--- a/src/Famix-PharoSmalltalk-Entities/FamixStLocalVariable.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStLocalVariable.class.st
@@ -10,7 +10,7 @@
 ### Incoming dependencies
 | Relation | Origin | Opposite | Type | Comment |
 |---|
-| `incomingAccesses` | `FamixTAccessible` | `variable` | `FamixTAccess` | All Famix accesses pointing to this structural entity|
+| `incomingAccesses` | `FamixTAccessible` | `candidates` | `FamixTAccess` | All Famix accesses pointing to this structural entity|
 
 ### Other
 | Relation | Origin | Opposite | Type | Comment |

--- a/src/Famix-PharoSmalltalk-Entities/FamixStParameter.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStParameter.class.st
@@ -10,7 +10,7 @@
 ### Incoming dependencies
 | Relation | Origin | Opposite | Type | Comment |
 |---|
-| `incomingAccesses` | `FamixTAccessible` | `variable` | `FamixTAccess` | All Famix accesses pointing to this structural entity|
+| `incomingAccesses` | `FamixTAccessible` | `candidates` | `FamixTAccess` | All Famix accesses pointing to this structural entity|
 
 ### Other
 | Relation | Origin | Opposite | Type | Comment |

--- a/src/Famix-PharoSmalltalk-Entities/FamixStUnknownVariable.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStUnknownVariable.class.st
@@ -5,7 +5,7 @@
 ### Incoming dependencies
 | Relation | Origin | Opposite | Type | Comment |
 |---|
-| `incomingAccesses` | `FamixTAccessible` | `variable` | `FamixTAccess` | All Famix accesses pointing to this structural entity|
+| `incomingAccesses` | `FamixTAccessible` | `candidates` | `FamixTAccess` | All Famix accesses pointing to this structural entity|
 
 ### Other
 | Relation | Origin | Opposite | Type | Comment |

--- a/src/Famix-Test1-Entities/FamixTest1Attribute.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1Attribute.class.st
@@ -10,7 +10,7 @@
 ### Incoming dependencies
 | Relation | Origin | Opposite | Type | Comment |
 |---|
-| `incomingAccesses` | `FamixTAccessible` | `variable` | `FamixTAccess` | All Famix accesses pointing to this structural entity|
+| `incomingAccesses` | `FamixTAccessible` | `candidates` | `FamixTAccess` | All Famix accesses pointing to this structural entity|
 
 ### Other
 | Relation | Origin | Opposite | Type | Comment |

--- a/src/Famix-Test3-Entities/FamixTest3Access.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3Access.class.st
@@ -10,7 +10,7 @@
 ### Association target
 | Relation | Origin | Opposite | Type | Comment |
 |---|
-| `variable` | `FamixTAccess` | `incomingAccesses` | `FamixTAccessible` | Variable accessed. to-side of the association|
+| `candidates` | `FamixTAccess` | `incomingAccesses` | `FamixTAccessible` | Variables that cas be the accessed variable. to-side of the association. Most of the time it will be only one variable, but some languages might have candidates such as Python.|
 
 ### Other
 | Relation | Origin | Opposite | Type | Comment |

--- a/src/Famix-Test3-Entities/FamixTest3Attribute.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3Attribute.class.st
@@ -10,7 +10,7 @@
 ### Incoming dependencies
 | Relation | Origin | Opposite | Type | Comment |
 |---|
-| `incomingAccesses` | `FamixTAccessible` | `variable` | `FamixTAccess` | All Famix accesses pointing to this structural entity|
+| `incomingAccesses` | `FamixTAccessible` | `candidates` | `FamixTAccess` | All Famix accesses pointing to this structural entity|
 
 ### Other
 | Relation | Origin | Opposite | Type | Comment |

--- a/src/Famix-Traits/FamixTAccess.trait.st
+++ b/src/Famix-Traits/FamixTAccess.trait.st
@@ -23,7 +23,7 @@ For each access in the source code, there is one famix access created even if it
 ### Association target
 | Relation | Origin | Opposite | Type | Comment |
 |---|
-| `variable` | `FamixTAccess` | `incomingAccesses` | `FamixTAccessible` | Variable accessed. to-side of the association|
+| `candidates` | `FamixTAccess` | `incomingAccesses` | `FamixTAccessible` | Variables that cas be the accessed variable. to-side of the association. Most of the time it will be only one variable, but some languages might have candidates such as Python.|
 
 ### Other
 | Relation | Origin | Opposite | Type | Comment |
@@ -45,8 +45,8 @@ Trait {
 	#name : #FamixTAccess,
 	#instVars : [
 		'#accessor => FMOne type: #FamixTWithAccesses opposite: #accesses',
-		'#isWrite => FMProperty defaultValue: false',
-		'#variable => FMOne type: #FamixTAccessible opposite: #incomingAccesses'
+		'#candidates => FMMany type: #FamixTAccessible opposite: #incomingAccesses',
+		'#isWrite => FMProperty defaultValue: false'
 	],
 	#traits : 'FamixTAssociation',
 	#classTraits : 'FamixTAssociation classTrait',
@@ -79,10 +79,46 @@ FamixTAccess >> accessor: anObject [
 	accessor := anObject
 ]
 
+{ #category : #adding }
+FamixTAccess >> addCandidate: anObject [
+	<generated>
+	^ self candidates add: anObject
+]
+
+{ #category : #accessing }
+FamixTAccess >> candidates [
+	"Relation named: #candidates type: #FamixTAccessible opposite: #incomingAccesses"
+
+	<generated>
+	<FMComment: 'Variables that cas be the accessed variable. to-side of the association. Most of the time it will be only one variable, but some languages might have candidates such as Python.'>
+	<derived>
+	<target>
+	^ candidates
+]
+
+{ #category : #accessing }
+FamixTAccess >> candidates: anObject [
+
+	<generated>
+	candidates value: anObject
+]
+
+{ #category : #printing }
+FamixTAccess >> displayFullStringOn: aStream [
+
+	self source displayFullStringOn: aStream.
+	aStream nextPutAll: ' -> '.
+	(self candidates size = 1
+		 ifTrue: [ self variable ]
+		 ifFalse: [ self candidates ]) displayStringOn: aStream
+]
+
 { #category : #printing }
 FamixTAccess >> displayStringOn: aStream [
 
-	variable displayStringOn: aStream.
+	(self candidates size = 1
+		 ifTrue: [ self variable ]
+		 ifFalse: [ self candidates ]) displayStringOn: aStream.
 	aStream << ' accessed in '.
 	accessor displayStringOn: aStream
 ]
@@ -131,18 +167,25 @@ FamixTAccess >> printOn: aStream [
 ]
 
 { #category : #accessing }
-FamixTAccess >> variable [
-	"Relation named: #variable type: #FamixTAccessible opposite: #incomingAccesses"
+FamixTAccess >> target: aTarget [
 
-	<generated>
-	<FMComment: 'Variable accessed. to-side of the association'>
-	<target>
-	^ variable
+	aTarget isCollection
+		ifTrue: [ self candidates: aTarget ]
+		ifFalse: [ self variable: aTarget ]
 ]
 
 { #category : #accessing }
-FamixTAccess >> variable: anObject [
+FamixTAccess >> variable [
+	"This method returns only one candidate if there is one, or raises an error if there is more or less than one candidate."
 
-	<generated>
-	variable := anObject
+	self candidates size = 1 ifFalse: [
+		self error: '1 candidate was expected but ' , self candidates size asString , ' candidates are present in this invocation.' ].
+
+	^ self candidates anyOne
+]
+
+{ #category : #accessing }
+FamixTAccess >> variable: anEntity [
+
+	^ self candidates: { anEntity }
 ]

--- a/src/Famix-Traits/FamixTAccessible.trait.st
+++ b/src/Famix-Traits/FamixTAccessible.trait.st
@@ -5,7 +5,7 @@
 ### Incoming dependencies
 | Relation | Origin | Opposite | Type | Comment |
 |---|
-| `incomingAccesses` | `FamixTAccessible` | `variable` | `FamixTAccess` | All Famix accesses pointing to this structural entity|
+| `incomingAccesses` | `FamixTAccessible` | `candidates` | `FamixTAccess` | All Famix accesses pointing to this structural entity|
 
 
 
@@ -13,7 +13,7 @@
 Trait {
 	#name : #FamixTAccessible,
 	#instVars : [
-		'#incomingAccesses => FMMany type: #FamixTAccess opposite: #variable'
+		'#incomingAccesses => FMMany type: #FamixTAccess opposite: #candidates'
 	],
 	#category : #'Famix-Traits-Access'
 }
@@ -69,11 +69,10 @@ FamixTAccessible >> globalAccesses [
 
 { #category : #accessing }
 FamixTAccessible >> incomingAccesses [
-	"Relation named: #incomingAccesses type: #FamixTAccess opposite: #variable"
+	"Relation named: #incomingAccesses type: #FamixTAccess opposite: #candidates"
 
 	<generated>
 	<FMComment: 'All Famix accesses pointing to this structural entity'>
-	<derived>
 	^ incomingAccesses
 ]
 

--- a/src/Famix-Traits/FamixTAnnotationTypeAttribute.trait.st
+++ b/src/Famix-Traits/FamixTAnnotationTypeAttribute.trait.st
@@ -27,7 +27,7 @@ Instance Variables:
 ### Incoming dependencies
 | Relation | Origin | Opposite | Type | Comment |
 |---|
-| `incomingAccesses` | `FamixTAccessible` | `variable` | `FamixTAccess` | All Famix accesses pointing to this structural entity|
+| `incomingAccesses` | `FamixTAccessible` | `candidates` | `FamixTAccess` | All Famix accesses pointing to this structural entity|
 
 ### Other
 | Relation | Origin | Opposite | Type | Comment |

--- a/src/Famix-Traits/FamixTAttribute.trait.st
+++ b/src/Famix-Traits/FamixTAttribute.trait.st
@@ -13,7 +13,7 @@ FamixTAttribute represents a field of a class. It is an attribute of the parent 
 ### Incoming dependencies
 | Relation | Origin | Opposite | Type | Comment |
 |---|
-| `incomingAccesses` | `FamixTAccessible` | `variable` | `FamixTAccess` | All Famix accesses pointing to this structural entity|
+| `incomingAccesses` | `FamixTAccessible` | `candidates` | `FamixTAccess` | All Famix accesses pointing to this structural entity|
 
 ### Other
 | Relation | Origin | Opposite | Type | Comment |

--- a/src/Famix-Traits/FamixTEnumValue.trait.st
+++ b/src/Famix-Traits/FamixTEnumValue.trait.st
@@ -22,7 +22,7 @@ Instance Variables:
 ### Incoming dependencies
 | Relation | Origin | Opposite | Type | Comment |
 |---|
-| `incomingAccesses` | `FamixTAccessible` | `variable` | `FamixTAccess` | All Famix accesses pointing to this structural entity|
+| `incomingAccesses` | `FamixTAccessible` | `candidates` | `FamixTAccess` | All Famix accesses pointing to this structural entity|
 
 ### Other
 | Relation | Origin | Opposite | Type | Comment |

--- a/src/Famix-Traits/FamixTGlobalVariable.trait.st
+++ b/src/Famix-Traits/FamixTGlobalVariable.trait.st
@@ -13,7 +13,7 @@ FamixTGlobalVariable represents a global variable in the source code.
 ### Incoming dependencies
 | Relation | Origin | Opposite | Type | Comment |
 |---|
-| `incomingAccesses` | `FamixTAccessible` | `variable` | `FamixTAccess` | All Famix accesses pointing to this structural entity|
+| `incomingAccesses` | `FamixTAccessible` | `candidates` | `FamixTAccess` | All Famix accesses pointing to this structural entity|
 
 ### Other
 | Relation | Origin | Opposite | Type | Comment |

--- a/src/Famix-Traits/FamixTImplicitVariable.trait.st
+++ b/src/Famix-Traits/FamixTImplicitVariable.trait.st
@@ -12,7 +12,7 @@ FamixTImplicitVariable represents a variable defined by the compiler in a contex
 ### Incoming dependencies
 | Relation | Origin | Opposite | Type | Comment |
 |---|
-| `incomingAccesses` | `FamixTAccessible` | `variable` | `FamixTAccess` | All Famix accesses pointing to this structural entity|
+| `incomingAccesses` | `FamixTAccessible` | `candidates` | `FamixTAccess` | All Famix accesses pointing to this structural entity|
 
 ### Other
 | Relation | Origin | Opposite | Type | Comment |

--- a/src/Famix-Traits/FamixTInvocation.trait.st
+++ b/src/Famix-Traits/FamixTInvocation.trait.st
@@ -215,3 +215,11 @@ FamixTInvocation >> sender: anObject [
 	<generated>
 	sender := anObject
 ]
+
+{ #category : #accessing }
+FamixTInvocation >> target: aTarget [
+
+	aTarget isCollection
+		ifTrue: [ self candidates: aTarget ]
+		ifFalse: [ self invokedEntity: aTarget ]
+]

--- a/src/Famix-Traits/FamixTLocalVariable.trait.st
+++ b/src/Famix-Traits/FamixTLocalVariable.trait.st
@@ -12,7 +12,7 @@ FamixTLocalVariable represents a local variable in the scope of a behavioural en
 ### Incoming dependencies
 | Relation | Origin | Opposite | Type | Comment |
 |---|
-| `incomingAccesses` | `FamixTAccessible` | `variable` | `FamixTAccess` | All Famix accesses pointing to this structural entity|
+| `incomingAccesses` | `FamixTAccessible` | `candidates` | `FamixTAccess` | All Famix accesses pointing to this structural entity|
 
 ### Other
 | Relation | Origin | Opposite | Type | Comment |

--- a/src/Famix-Traits/FamixTParameter.trait.st
+++ b/src/Famix-Traits/FamixTParameter.trait.st
@@ -22,7 +22,7 @@ int addNumbers(int a, int b) {
 ### Incoming dependencies
 | Relation | Origin | Opposite | Type | Comment |
 |---|
-| `incomingAccesses` | `FamixTAccessible` | `variable` | `FamixTAccess` | All Famix accesses pointing to this structural entity|
+| `incomingAccesses` | `FamixTAccessible` | `candidates` | `FamixTAccess` | All Famix accesses pointing to this structural entity|
 
 ### Other
 | Relation | Origin | Opposite | Type | Comment |

--- a/src/Famix-Traits/FamixTStructuralEntity.trait.st
+++ b/src/Famix-Traits/FamixTStructuralEntity.trait.st
@@ -7,7 +7,7 @@ FamixTStructuralEntity is the abstract superclass for basic data structure in th
 ### Incoming dependencies
 | Relation | Origin | Opposite | Type | Comment |
 |---|
-| `incomingAccesses` | `FamixTAccessible` | `variable` | `FamixTAccess` | All Famix accesses pointing to this structural entity|
+| `incomingAccesses` | `FamixTAccessible` | `candidates` | `FamixTAccess` | All Famix accesses pointing to this structural entity|
 
 ### Other
 | Relation | Origin | Opposite | Type | Comment |

--- a/src/Famix-Traits/FamixTUnknownVariable.trait.st
+++ b/src/Famix-Traits/FamixTUnknownVariable.trait.st
@@ -5,7 +5,7 @@
 ### Incoming dependencies
 | Relation | Origin | Opposite | Type | Comment |
 |---|
-| `incomingAccesses` | `FamixTAccessible` | `variable` | `FamixTAccess` | All Famix accesses pointing to this structural entity|
+| `incomingAccesses` | `FamixTAccessible` | `candidates` | `FamixTAccess` | All Famix accesses pointing to this structural entity|
 
 ### Other
 | Relation | Origin | Opposite | Type | Comment |

--- a/src/Famix-Visitor/FamixTVisitor.trait.st
+++ b/src/Famix-Visitor/FamixTVisitor.trait.st
@@ -37,7 +37,7 @@ FamixTVisitor >> visitFamixTAccess: aFamixTAccess [
 	self visitFamixTAssociation: aFamixTAccess.
 
 	self visitEntity: aFamixTAccess accessor.
-	self visitEntity: aFamixTAccess variable
+	self visitCollection: aFamixTAccess candidates
 ]
 
 { #category : #visiting }

--- a/src/Moose-Core-Tests-Entities/MooseMSEImporterTestAttribute.class.st
+++ b/src/Moose-Core-Tests-Entities/MooseMSEImporterTestAttribute.class.st
@@ -10,7 +10,7 @@
 ### Incoming dependencies
 | Relation | Origin | Opposite | Type | Comment |
 |---|
-| `incomingAccesses` | `FamixTAccessible` | `variable` | `FamixTAccess` | All Famix accesses pointing to this structural entity|
+| `incomingAccesses` | `FamixTAccessible` | `candidates` | `FamixTAccess` | All Famix accesses pointing to this structural entity|
 
 ### Other
 | Relation | Origin | Opposite | Type | Comment |

--- a/src/Moose-SmalltalkImporter-Core-Tests/FamixReferenceModelImporterTest.class.st
+++ b/src/Moose-SmalltalkImporter-Core-Tests/FamixReferenceModelImporterTest.class.st
@@ -163,7 +163,7 @@ FamixReferenceModelImporterTest >> testAccessingGlobalVariableFromInstanceSide [
 FamixReferenceModelImporterTest >> testAccessingGlobalVariableHavingNamespaceNameFromInstanceSide [
 	| accessDefinition methodUniqueName |
 	methodUniqueName := (TheRoot >> #accessingGlobalVariableHavingNamespaceName) mooseName.
-	accessDefinition := (self model entityNamed: methodUniqueName) accesses select: [ :acc | acc target mooseName = #SmalltalkGlobalVariable ].
+	accessDefinition := (self model entityNamed: methodUniqueName) accesses select: [ :acc | acc variable mooseName = #SmalltalkGlobalVariable ].
 	self assert: accessDefinition size equals: 1
 ]
 
@@ -189,21 +189,22 @@ FamixReferenceModelImporterTest >> testAccessingLocalVariable [
 FamixReferenceModelImporterTest >> testAccessingNamespace2 [
 	| accessDefinition |
 	accessDefinition := (self model entityNamed: 'Smalltalk::TheRoot.accessingGlobalVariableHavingNamespaceName()') accesses
-		select: [ :acc | acc target mooseName = #SmalltalkGlobalVariable ].
+		select: [ :acc | acc variable mooseName = #SmalltalkGlobalVariable ].
 	self assert: accessDefinition size equals: 1
 ]
 
 { #category : #tests }
 FamixReferenceModelImporterTest >> testAccessingNamespaceAsGlobalVariable [
+
 	| accessDefinition method globalVariable |
 	"TheRoot>>accessingNamespace
 		Smalltalk"
 	globalVariable := self model entityNamed: #SmalltalkGlobalVariable.
-	method := self model entityNamed: (TheRoot >> #accessingNamespace) mooseName.	"since we have two methods accessing to Smalltalk 
+	method := self model entityNamed: (TheRoot >> #accessingNamespace) mooseName. "since we have two methods accessing to Smalltalk 
 	we have two accesses"
-	self assert: (self model allAccesses select: [ :acc | acc target name = #SmalltalkGlobalVariable ]) size equals: 2.
-	self assert: (self model allAccesses select: [ :ref | ref target = globalVariable ]) size equals: 2.
-	accessDefinition := self model allAccesses select: [ :ref | ref target = globalVariable and: [ ref source == method ] ].
+	self assert: (self model allAccesses select: [ :acc | acc variable name = #SmalltalkGlobalVariable ]) size equals: 2.
+	self assert: (self model allAccesses select: [ :ref | ref variable = globalVariable ]) size equals: 2.
+	accessDefinition := self model allAccesses select: [ :ref | ref variable = globalVariable and: [ ref source == method ] ].
 	self assert: accessDefinition size equals: 1
 ]
 


### PR DESCRIPTION
Until now we only modelized languages for whom we knew for sure who accessed the variables. But in Python we cannot know. We have candidates like for invocations. 

We discussed with Clotilde and Nicolas and we should probably update TAccess to have candidates. Here is the Famix PR. Before merging we should update VerveineJ.