### PR TITLE
Remove #detect:ifOne:

### DIFF
--- a/src/Moose-Core/MooseAbstractGroup.class.st
+++ b/src/Moose-Core/MooseAbstractGroup.class.st
@@ -324,14 +324,6 @@ MooseAbstractGroup >> detect: aBlock ifNone: anotherBlock [
 ]
 
 { #category : #enumerating }
-MooseAbstractGroup >> detect: aBlock ifOne: anotherBlock [
-
-	^ self entities
-		detect: aBlock
-		ifOne:  anotherBlock
-]
-
-{ #category : #enumerating }
 MooseAbstractGroup >> detectMax: aString [
 
 	^ self entities detectMax: aString


### PR DESCRIPTION
This method is to delegate to another method from Collection-Extensions but we should not use this one. We should use #detect:ifFound: that is native of Pharo