### PR TITLE
Deprecated #detect:ifOne:

### DIFF
--- a/src/Famix-Deprecated/MooseAbstractGroup.extension.st
+++ b/src/Famix-Deprecated/MooseAbstractGroup.extension.st
@@ -1,0 +1,10 @@
+Extension { #name : #MooseAbstractGroup }
+
+{ #category : #'*Famix-Deprecated' }
+MooseAbstractGroup >> detect: aBlock ifOne: anotherBlock [
+
+	self deprecated: 'Use #detect:ifFound: instead.' transformWith: '`@rcv detect: `@arg1 ifOne: `@arg2' -> '`@rcv detect: `@arg1 ifFound: `@arg2'.
+	^ self
+		  detect: aBlock
+		  ifFound: anotherBlock
+]


### PR DESCRIPTION
I removed this method thinking that we had a doesNotUnderstant: to manage it, but apparently this has been removed. 

I'm adding the method as a deprecated method because it is used in some BL projects