### PR TITLE
Replacing  '::' by '.'  in mooseName and adapting methods and tests consequently

### DIFF
--- a/src/Famix-Java-Entities/FamixJavaClass.class.st
+++ b/src/Famix-Java-Entities/FamixJavaClass.class.st
@@ -205,7 +205,7 @@ FamixJavaClass >> mooseNameOn: aStream [
 		parent mooseNameOn: aStream.
 		self isInnerClass
 			ifTrue: [ aStream nextPut: $$ ]
-			ifFalse: [ aStream nextPutAll: '::' ] ].
+			ifFalse: [ aStream nextPutAll: '.' ] ].
 	self name ifNotNil: [ :n | aStream nextPutAll: n ]
 ]
 

--- a/src/Famix-Java-Entities/FamixJavaModel.class.st
+++ b/src/Famix-Java-Entities/FamixJavaModel.class.st
@@ -36,13 +36,13 @@ FamixJavaModel class >> importingContextClass [
 FamixJavaModel >> inferPackageParentsBasedOnNames [
 	<menuItem: 'Infer Namespace Parents Based on Names' category: 'Utilities'>
 	| parent parentNameSize currentPosition parentName package |
+	self deprecated: ':: has been replaced by . in mooseName. inferPackageParentsBasedOnNames is now useless'.
 	package := self allPackages.
 	MooseCustomTask new
 		with: [ :task | 
 			package
 				do: [ :each | 
 					currentPosition := 1.
-					each name: (each name copyReplaceAll: '.' with: '::').
 					[ currentPosition := each name indexOf: $: startingAt: currentPosition.
 					currentPosition isZero ]
 						whileFalse: [ parentName := (each name copyFrom: 1 to: currentPosition - 1) asSymbol.

--- a/src/Famix-Java-Entities/FamixJavaPackage.class.st
+++ b/src/Famix-Java-Entities/FamixJavaPackage.class.st
@@ -240,8 +240,7 @@ FamixJavaPackage >> mooseNameOn: stream [
 	parent ifNotNil: 
 		[ parent mooseNameOn: stream.
 		stream
-			nextPut: $:;
-			nextPut: $: ].
+			nextPut: $. ].
 	self name ifNotNil: [stream nextPutAll: self name]
 ]
 

--- a/src/Famix-Java-Tests/FamixJavaTest.class.st
+++ b/src/Famix-Java-Tests/FamixJavaTest.class.st
@@ -68,8 +68,8 @@ FamixJavaTest >> testImportAnnotations [
 		do: [ :i | 
 			self assert: (i annotationType instances includes: i).
 			self assert: (i annotatedEntity annotationInstances includes: i) ].
-	self assert: (model allAnnotationTypes entityNamed: #'aPackage::AnAnnotation') instances size equals: 2.
-	self assert: (model allAnnotationTypes entityNamed: #'aPackage::AnotherAnnotation') instances size equals: 1.
+	self assert: (model allAnnotationTypes entityNamed: #'aPackage.AnAnnotation') instances size equals: 2.
+	self assert: (model allAnnotationTypes entityNamed: #'aPackage.AnotherAnnotation') instances size equals: 1.
 	model allAnnotationTypes
 		do: [ :each | 
 			self assert: (each typeContainer definedAnnotationTypes includes: each).
@@ -118,17 +118,6 @@ FamixJavaTest >> testImportExceptions [
 	
 	self assertCollection: exceptionA declaringEntities  hasSameElements: { method2. method3 }.
 	self assertCollection: exceptionA throwingEntities  hasSameElements: { method2 }.
-]
-
-{ #category : #tests }
-FamixJavaTest >> testInferNamespaces [
-	| model |
-	model  := FamixJavaModel new.
-	model add: (FamixJavaPackage new name: 'org.project.package1').
-	model add: (FamixJavaPackage new name: 'org.project.package2').
-	self assert: model allPackages size equals: 2.
-	model inferPackageParentsBasedOnNames.
-	self assert: model allPackages size equals: 4
 ]
 
 { #category : #tests }

--- a/src/Famix-PharoSmalltalk-Entities/FamixStNamespace.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStNamespace.class.st
@@ -70,8 +70,7 @@ FamixStNamespace >> mooseNameOn: aStream [
 	parent ifNotNil: 
 		[ parent mooseNameOn: aStream.
 		aStream
-			nextPut: $:;
-			nextPut: $: ].
+			nextPut: $. ].
 	self name ifNotNil: [aStream nextPutAll: self name]
 ]
 

--- a/src/Famix-PharoSmalltalk-Tests/FamixMetricsTest.class.st
+++ b/src/Famix-PharoSmalltalk-Tests/FamixMetricsTest.class.st
@@ -52,16 +52,16 @@ FamixMetricsTest >> importLCOMClasses [
 	| lcomModel |
 	lcomModel := LCOMTestResource current model.
 
-	classA := lcomModel entityNamed: #'Smalltalk::ClassA'.
-	classB := lcomModel entityNamed: #'Smalltalk::ClassB'.
-	classB1 := lcomModel entityNamed: #'Smalltalk::ClassB1'.
-	classB2 := lcomModel entityNamed: #'Smalltalk::ClassB2'.
-	classC := lcomModel entityNamed: #'Smalltalk::ClassC'.
-	classD := lcomModel entityNamed: #'Smalltalk::ClassD'.
-	classE := lcomModel entityNamed: #'Smalltalk::ClassE'.
-	classF := lcomModel entityNamed: #'Smalltalk::ClassF'.
-	classF1 := lcomModel entityNamed: #'Smalltalk::ClassF1'.
-	classG := lcomModel entityNamed: #'Smalltalk::ClassG'
+	classA := lcomModel entityNamed: #'Smalltalk.ClassA'.
+	classB := lcomModel entityNamed: #'Smalltalk.ClassB'.
+	classB1 := lcomModel entityNamed: #'Smalltalk.ClassB1'.
+	classB2 := lcomModel entityNamed: #'Smalltalk.ClassB2'.
+	classC := lcomModel entityNamed: #'Smalltalk.ClassC'.
+	classD := lcomModel entityNamed: #'Smalltalk.ClassD'.
+	classE := lcomModel entityNamed: #'Smalltalk.ClassE'.
+	classF := lcomModel entityNamed: #'Smalltalk.ClassF'.
+	classF1 := lcomModel entityNamed: #'Smalltalk.ClassF1'.
+	classG := lcomModel entityNamed: #'Smalltalk.ClassG'
 ]
 
 { #category : #running }

--- a/src/Famix-Smalltalk-Utils-Tests/FamixSmalltalkNameResolverTest.class.st
+++ b/src/Famix-Smalltalk-Utils-Tests/FamixSmalltalkNameResolverTest.class.st
@@ -12,7 +12,7 @@ FamixSmalltalkNameResolverTest >> actualClass [
 { #category : #tests }
 FamixSmalltalkNameResolverTest >> testFamixFullClassNameForSmalltalkClass [
 	self assert: self class name equals: (self actualClass moosify: self class name) asSymbol.
-	self assert: self class class mooseName equals: ('Smalltalk::' , (self actualClass moosify: self class name) , self actualClass metaclassTag) asSymbol
+	self assert: self class class mooseName equals: ('Smalltalk.' , (self actualClass moosify: self class name) , self actualClass metaclassTag) asSymbol
 ]
 
 { #category : #tests }

--- a/src/Famix-Smalltalk-Utils-Tests/MooseNamingTest.class.st
+++ b/src/Famix-Smalltalk-Utils-Tests/MooseNamingTest.class.st
@@ -6,23 +6,23 @@ Class {
 
 { #category : #testing }
 MooseNamingTest >> testMooseNameOfClassVariable [
-	self assert: TheRoot @ #TheSharedVariable equals: #'Smalltalk::TheRoot.TheSharedVariable'.	"contrary to compiled method notation we do not garanty that the class has an iv"	"we could! Now do we want? We could also have @@ for class variables."	"now the name of shared variable is always its class and not its metaclass"
-	self assert: TheRoot class @ #TheSharedVariable equals: #'Smalltalk::TheRoot.TheSharedVariable'
+	self assert: TheRoot @ #TheSharedVariable equals: #'Smalltalk.TheRoot.TheSharedVariable'.	"contrary to compiled method notation we do not garanty that the class has an iv"	"we could! Now do we want? We could also have @@ for class variables."	"now the name of shared variable is always its class and not its metaclass"
+	self assert: TheRoot class @ #TheSharedVariable equals: #'Smalltalk.TheRoot.TheSharedVariable'
 ]
 
 { #category : #testing }
 MooseNamingTest >> testMooseNameOfCompiledMethod [
 	self
 		assert: (TheRoot class >> #accessInstanceVariable) mooseName
-		equals: #'Smalltalk::TheRoot_class.accessInstanceVariable()'.
-	self assert: (TheRoot >> #accessingClass) mooseName equals: #'Smalltalk::TheRoot.accessingClass()'.	"May be we could fix that too. using another notation so that we could use the notation create method
+		equals: #'Smalltalk.TheRoot_class.accessInstanceVariable()'.
+	self assert: (TheRoot >> #accessingClass) mooseName equals: #'Smalltalk.TheRoot.accessingClass()'.	"May be we could fix that too. using another notation so that we could use the notation create method
 	name too"
 	self should: [ (TheRoot >> #zork) mooseName ] raise: Error
 ]
 
 { #category : #testing }
 MooseNamingTest >> testMooseNameOfInstanceVariable [
-	self assert: TheRoot @ #x equals: #'Smalltalk::TheRoot.x'.	"contrary to compiled method notation we do not garanty that the class has an iv"	"we could! Now do we want"
-	self assert: TheRoot @ #foo equals: #'Smalltalk::TheRoot.foo'.
-	self assert: TheRoot class @ #mx equals: #'Smalltalk::TheRoot_class.mx'
+	self assert: TheRoot @ #x equals: #'Smalltalk.TheRoot.x'.	"contrary to compiled method notation we do not garanty that the class has an iv"	"we could! Now do we want"
+	self assert: TheRoot @ #foo equals: #'Smalltalk.TheRoot.foo'.
+	self assert: TheRoot class @ #mx equals: #'Smalltalk.TheRoot_class.mx'
 ]

--- a/src/Famix-Smalltalk-Utils/Class.extension.st
+++ b/src/Famix-Smalltalk-Utils/Class.extension.st
@@ -4,5 +4,5 @@ Extension { #name : #Class }
 Class >> mooseName [
 	"asnwer the full moose name"
 
-	^ ('Smalltalk::' , self name) asSymbol
+	^ ('Smalltalk.' , self name) asSymbol
 ]

--- a/src/Famix-Smalltalk-Utils/Metaclass.extension.st
+++ b/src/Famix-Smalltalk-Utils/Metaclass.extension.st
@@ -2,5 +2,5 @@ Extension { #name : #Metaclass }
 
 { #category : #'*Famix-Smalltalk-Utils' }
 Metaclass >> mooseName [
-	^ ('Smalltalk::' , self soleInstance name , '_class') asSymbol
+	^ ('Smalltalk.' , self soleInstance name , '_class') asSymbol
 ]

--- a/src/Famix-Traits/FamixTAnnotationType.trait.st
+++ b/src/Famix-Traits/FamixTAnnotationType.trait.st
@@ -106,7 +106,6 @@ FamixTAnnotationType >> mooseNameOn: aStream [
 		ifNotNil: [ :parent | 
 			parent mooseNameOn: aStream.
 			aStream
-				nextPut: $:;
-				nextPut: $: ].
+				nextPut: $. ].
 	self name ifNotNil: [ aStream nextPutAll: self name ]
 ]

--- a/src/Famix-Traits/FamixTType.trait.st
+++ b/src/Famix-Traits/FamixTType.trait.st
@@ -89,7 +89,7 @@ FamixTType >> mooseNameOn: aStream [
 	self typeContainer
 		ifNotNil: [ :parent |
 			parent mooseNameOn: aStream.
-			aStream nextPutAll: '::' ].
+			aStream nextPutAll: '.' ].
 	self name ifNotNil: [ :n | aStream nextPutAll: n ]
 ]
 

--- a/src/Famix-VerveineJ-Tests/VerveineJModelTest.class.st
+++ b/src/Famix-VerveineJ-Tests/VerveineJModelTest.class.st
@@ -21,12 +21,12 @@ VerveineJModelTest >> setUp [
 
 { #category : #tests }
 VerveineJModelTest >> testCyclomaticComplexity [
-	self assert: (model allMethods entityNamed: #'moose::lan::server::PrintServer.output(Packet)') cyclomaticComplexity equals: 2
+	self assert: (model allMethods entityNamed: #'moose.lan.server.PrintServer.output(Packet)') cyclomaticComplexity equals: 2
 ]
 
 { #category : #tests }
 VerveineJModelTest >> testNumberOfLinesOfCode [
-	self assert: (model allMethods entityNamed: #'moose::lan::server::PrintServer.output(Packet)') numberOfLinesOfCode equals: 9
+	self assert: (model allMethods entityNamed: #'moose.lan.server.PrintServer.output(Packet)') numberOfLinesOfCode equals: 9
 ]
 
 { #category : #tests }
@@ -34,7 +34,7 @@ VerveineJModelTest >> testNumberOfStatements [
 
 	self
 		assert: (model allMethods entityNamed:
-				 #'moose::lan::server::PrintServer.output(Packet)')
+				 #'moose.lan.server.PrintServer.output(Packet)')
 				numberOfStatements
 		equals: MooseUnavailableMetric
 ]

--- a/src/Moose-Core-Tests-Entities/MooseMSEImporterTestClass.class.st
+++ b/src/Moose-Core-Tests-Entities/MooseMSEImporterTestClass.class.st
@@ -64,6 +64,6 @@ MooseMSEImporterTestClass >> mooseNameOn: aStream [
 
 	self typeContainer ifNotNil: [ :parent | 
 		parent mooseNameOn: aStream.
-		aStream nextPutAll: '::' ].
+		aStream nextPutAll: '.' ].
 	self name ifNotNil: [ :n | aStream nextPutAll: n ]
 ]

--- a/src/Moose-Core-Tests/MooseMSEImporterTest.class.st
+++ b/src/Moose-Core-Tests/MooseMSEImporterTest.class.st
@@ -137,7 +137,7 @@ MooseMSEImporterTest >> testSimple [
 	self
 		assert: (mooseModel allPackages collect: #name) asArray
 		equals: { 'aPackage'. 'aPackage' }.
-	classA := mooseModel entityNamed: #'aNamespace::ClassA'.
+	classA := mooseModel entityNamed: #'aNamespace.ClassA'.
 	self assert: classA isNotNil.
 	self
 		assert: classA typeContainer

--- a/src/Moose-Core/MooseObject.class.st
+++ b/src/Moose-Core/MooseObject.class.st
@@ -430,8 +430,7 @@ MooseObject >> mooseNameOn: aStream [
 
 { #category : #printing }
 MooseObject >> mooseNameWithDots [
-	"This method is used outside of Moose. This brings the question: Why use `::` and not `.`? We should discuss that in a moose meeting."
-
+	self deprecated: ':: has been replaced by . in mooseName. This method is now useless'.
 	^ self mooseName ifNotNil: [ :mName | mName copyReplaceAll: '::' with: '.' ]
 ]
 

--- a/src/Moose-SmalltalkImporter-Core-Tests/FamixReferenceModelImporterTest.class.st
+++ b/src/Moose-SmalltalkImporter-Core-Tests/FamixReferenceModelImporterTest.class.st
@@ -68,8 +68,8 @@ FamixReferenceModelImporterTest >> testAbstractMethodAnnotation [
 { #category : #tests }
 FamixReferenceModelImporterTest >> testAccessReadOnly [
 	self
-		privateTestAccessingVar: #'Smalltalk::TheRoot.x'
-		from: #'Smalltalk::TheRoot.x()'
+		privateTestAccessingVar: #'Smalltalk.TheRoot.x'
+		from: #'Smalltalk.TheRoot.x()'
 		shouldBeRead: true
 		hasAccessesSize: 1
 ]
@@ -89,7 +89,7 @@ FamixReferenceModelImporterTest >> testAccessSharedVariableFromTheInstanceSide [
 	| accessDefinition |
 	accessDefinition := self model allAccesses
 		select: [ :acc | 
-			acc variable mooseName = 'Smalltalk::TheRoot.TheRootSharedVariable'
+			acc variable mooseName = 'Smalltalk.TheRoot.TheRootSharedVariable'
 				and: [ acc accessor mooseName = (TheRoot >> #accessSharedVariableFromTheInstanceSide) mooseName ] ].
 	self assert: accessDefinition size equals: 1.
 	self assert: (accessDefinition at: 1) isWrite
@@ -122,7 +122,7 @@ FamixReferenceModelImporterTest >> testAccessSharedVariableOfSuperclassInstanceS
 	|  accessDefinition |
 	accessDefinition := self model allAccesses
 		select: [ :acc | 
-			acc variable mooseName = 'Smalltalk::TheRoot.TheRootSharedVariable'
+			acc variable mooseName = 'Smalltalk.TheRoot.TheRootSharedVariable'
 				and: [ acc accessor mooseName = (SubRootLevelOne >> #accessSharedVariableOfSuperclassInstanceSide) mooseName ] ].
 	self assert: accessDefinition size equals: 1.
 	self assert: (accessDefinition at: 1) isWrite
@@ -131,8 +131,8 @@ FamixReferenceModelImporterTest >> testAccessSharedVariableOfSuperclassInstanceS
 { #category : #tests }
 FamixReferenceModelImporterTest >> testAccessWriteOnly [
 	self
-		privateTestAccessingVar: #'Smalltalk::TheRoot.x'
-		from: #'Smalltalk::TheRoot.x:(Object)'
+		privateTestAccessingVar: #'Smalltalk.TheRoot.x'
+		from: #'Smalltalk.TheRoot.x:(Object)'
 		shouldBeRead: false
 		hasAccessesSize: 1
 ]
@@ -140,8 +140,8 @@ FamixReferenceModelImporterTest >> testAccessWriteOnly [
 { #category : #tests }
 FamixReferenceModelImporterTest >> testAccessingFormalParameter [
 	self
-		privateTestAccessingVar: #'Smalltalk::TheRoot.accessingArgument:(Object).anArgument'
-		from: #'Smalltalk::TheRoot.accessingArgument:(Object)'
+		privateTestAccessingVar: #'Smalltalk.TheRoot.accessingArgument:(Object).anArgument'
+		from: #'Smalltalk.TheRoot.accessingArgument:(Object)'
 		shouldBeRead: true
 		hasAccessesSize: 1
 ]
@@ -151,7 +151,7 @@ FamixReferenceModelImporterTest >> testAccessingGlobalVariableFromInstanceSide [
 	| declaredType |
 	self
 		privateTestAccessingVar: #Transcript
-		from: #'Smalltalk::TheRoot.accessingGlobalVariableFromInstanceSide()'
+		from: #'Smalltalk.TheRoot.accessingGlobalVariableFromInstanceSide()'
 		shouldBeRead: true
 		hasAccessesSize: 1.
 	declaredType := (self model allGlobalVariables entityNamed: #Transcript) declaredType.
@@ -170,8 +170,8 @@ FamixReferenceModelImporterTest >> testAccessingGlobalVariableHavingNamespaceNam
 { #category : #tests }
 FamixReferenceModelImporterTest >> testAccessingImportedClassWithinReturnVariable [
 	| method var accesses |
-	method := self model entityNamed: #'Smalltalk::TheRoot.returningImportedClass()'.
-	var := self model entityNamed: #'Smalltalk::TheRoot'.
+	method := self model entityNamed: #'Smalltalk.TheRoot.returningImportedClass()'.
+	var := self model entityNamed: #'Smalltalk.TheRoot'.
 	accesses := self model allReferences select: [ :each | each source = method and: [ each target = var ] ].
 	self assert: accesses size equals: 1
 ]
@@ -179,8 +179,8 @@ FamixReferenceModelImporterTest >> testAccessingImportedClassWithinReturnVariabl
 { #category : #tests }
 FamixReferenceModelImporterTest >> testAccessingLocalVariable [
 	self
-		privateTestAccessingVar: #'Smalltalk::TheRoot.assigningLocalVariable().tmp'
-		from: #'Smalltalk::TheRoot.assigningLocalVariable()'
+		privateTestAccessingVar: #'Smalltalk.TheRoot.assigningLocalVariable().tmp'
+		from: #'Smalltalk.TheRoot.assigningLocalVariable()'
 		shouldBeRead: false
 		hasAccessesSize: 1
 ]
@@ -188,7 +188,7 @@ FamixReferenceModelImporterTest >> testAccessingLocalVariable [
 { #category : #tests }
 FamixReferenceModelImporterTest >> testAccessingNamespace2 [
 	| accessDefinition |
-	accessDefinition := (self model entityNamed: 'Smalltalk::TheRoot.accessingGlobalVariableHavingNamespaceName()') accesses
+	accessDefinition := (self model entityNamed: 'Smalltalk.TheRoot.accessingGlobalVariableHavingNamespaceName()') accesses
 		select: [ :acc | acc target mooseName = #SmalltalkGlobalVariable ].
 	self assert: accessDefinition size equals: 1
 ]
@@ -287,7 +287,7 @@ FamixReferenceModelImporterTest >> testAnnotationTypes [
 { #category : #tests }
 FamixReferenceModelImporterTest >> testClassAnnotation [
 	| definingClassName famixClass |
-	definingClassName := #'Smalltalk::SubRootLevelOne' mooseName.
+	definingClassName := #'Smalltalk.SubRootLevelOne' mooseName.
 	famixClass := self model entityNamed: definingClassName.
 	self assert: famixClass parentPackage name equals: #'Moose-TestResources-Reference-Core'
 ]
@@ -305,11 +305,11 @@ FamixReferenceModelImporterTest >> testClassClassAnnotation [
 { #category : #tests }
 FamixReferenceModelImporterTest >> testClassMetaclassInstanceVariableAndShared [
 	| insVar theRoot insMetaclassVar shared theRootMeta |
-	insVar := self model entityNamed: #'Smalltalk::TheRoot.z'.
-	insMetaclassVar := self model entityNamed: #'Smalltalk::TheRoot_class.mz'.
-	shared := self model entityNamed: #'Smalltalk::TheRoot.TheRootSharedVariable'.
-	theRoot := self model entityNamed: #'Smalltalk::TheRoot'.
-	theRootMeta := self model entityNamed: #'Smalltalk::TheRoot_class'.
+	insVar := self model entityNamed: #'Smalltalk.TheRoot.z'.
+	insMetaclassVar := self model entityNamed: #'Smalltalk.TheRoot_class.mz'.
+	shared := self model entityNamed: #'Smalltalk.TheRoot.TheRootSharedVariable'.
+	theRoot := self model entityNamed: #'Smalltalk.TheRoot'.
+	theRootMeta := self model entityNamed: #'Smalltalk.TheRoot_class'.
 	self deny: insVar isClassSide.
 	self assert: insMetaclassVar isClassSide.
 	self assert: shared isClassSide.
@@ -324,7 +324,7 @@ FamixReferenceModelImporterTest >> testClassMetaclassInstanceVariableAndShared [
 { #category : #tests }
 FamixReferenceModelImporterTest >> testClassMethodAnnotation [
 	| method |
-	method := self model entityNamed: 'Smalltalk::SubRootLevelOne_class.accessSharedVariableOfSuperClassClassSide()'.
+	method := self model entityNamed: 'Smalltalk.SubRootLevelOne_class.accessSharedVariableOfSuperClassClassSide()'.
 	self assert: method protocol equals: #'accessing superclassinstance on class side'
 ]
 
@@ -361,17 +361,17 @@ FamixReferenceModelImporterTest >> testClassSelfSend [
 			invocation signature = (FamixSmalltalkNameResolver signatureFromSmalltalkSelectorOn: calleeMethodName)
 				and: [ invocation sender mooseName = callingMethodUniqueName ] ].
 	self assert: invocations size equals: 1.
-	self assert: invocations first receiver mooseName equals: #'Smalltalk::Object_class'
+	self assert: invocations first receiver mooseName equals: #'Smalltalk.Object_class'
 ]
 
 { #category : #tests }
 FamixReferenceModelImporterTest >> testConflictingInstanceVarNames [
 	| insVar theRoot insMetaclassVar shared theRootMeta |
-	insVar := self model entityNamed: #'Smalltalk::TheRoot.instanceAndClassPotentiallyConflictingName'.
-	insMetaclassVar := self model entityNamed: #'Smalltalk::TheRoot_class.instanceAndClassPotentiallyConflictingName'.
-	shared := self model entityNamed: #'Smalltalk::TheRoot.TheRootSharedVariable'.
-	theRoot := self model entityNamed: #'Smalltalk::TheRoot'.
-	theRootMeta := self model entityNamed: #'Smalltalk::TheRoot_class'.
+	insVar := self model entityNamed: #'Smalltalk.TheRoot.instanceAndClassPotentiallyConflictingName'.
+	insMetaclassVar := self model entityNamed: #'Smalltalk.TheRoot_class.instanceAndClassPotentiallyConflictingName'.
+	shared := self model entityNamed: #'Smalltalk.TheRoot.TheRootSharedVariable'.
+	theRoot := self model entityNamed: #'Smalltalk.TheRoot'.
+	theRootMeta := self model entityNamed: #'Smalltalk.TheRoot_class'.
 	self deny: insVar isClassSide.
 	self assert: insMetaclassVar isClassSide.
 	self assert: shared isClassSide.
@@ -505,7 +505,7 @@ FamixReferenceModelImporterTest >> testExternalExtension [
 { #category : #tests }
 FamixReferenceModelImporterTest >> testFormalParameterReified [
 	| formalParameterName |
-	formalParameterName := #'Smalltalk::TheRoot.accessingArgument:(Object).anArgument'.
+	formalParameterName := #'Smalltalk.TheRoot.accessingArgument:(Object).anArgument'.
 	self assert: (self model entityNamed: formalParameterName) isNotNil
 ]
 
@@ -530,14 +530,14 @@ FamixReferenceModelImporterTest >> testGlobalVariableReified [
 
 { #category : #tests }
 FamixReferenceModelImporterTest >> testImplicitVariableReified [
-	self assert: (self model entityNamed: 'Smalltalk::TheRoot.singleSelfSend().self') isNotNil
+	self assert: (self model entityNamed: 'Smalltalk.TheRoot.singleSelfSend().self') isNotNil
 ]
 
 { #category : #tests }
 FamixReferenceModelImporterTest >> testInstVariableAccessInDefiningClass [
 	self
-		privateTestAccessingVar: #'Smalltalk::SubRootLevelOne.k'
-		from: #'Smalltalk::SubRootLevelOne.accessSuperclassInstVar()'
+		privateTestAccessingVar: #'Smalltalk.SubRootLevelOne.k'
+		from: #'Smalltalk.SubRootLevelOne.accessSuperclassInstVar()'
 		shouldBeRead: false
 		hasAccessesSize: 1
 ]
@@ -545,8 +545,8 @@ FamixReferenceModelImporterTest >> testInstVariableAccessInDefiningClass [
 { #category : #tests }
 FamixReferenceModelImporterTest >> testInstVariableAccessInDefiningMetaclass [
 	self
-		privateTestAccessingVar: #'Smalltalk::TheRoot_class.mx'
-		from: #'Smalltalk::TheRoot_class.accessInstanceVariable()'
+		privateTestAccessingVar: #'Smalltalk.TheRoot_class.mx'
+		from: #'Smalltalk.TheRoot_class.accessInstanceVariable()'
 		shouldBeRead: false
 		hasAccessesSize: 1
 ]
@@ -555,7 +555,7 @@ FamixReferenceModelImporterTest >> testInstVariableAccessInDefiningMetaclass [
 FamixReferenceModelImporterTest >> testInstVariableAccessInSuperClass [
 	self
 		privateTestAccessingVar: (TheRoot mooseNameOf: #x)
-		from: #'Smalltalk::SubRootLevelOne.accessSuperclassInstVar()'
+		from: #'Smalltalk.SubRootLevelOne.accessSuperclassInstVar()'
 		shouldBeRead: true
 		hasAccessesSize: 1.
 
@@ -578,20 +578,20 @@ FamixReferenceModelImporterTest >> testInstVariableAccessTwiceTheSameVariable [
 { #category : #tests }
 FamixReferenceModelImporterTest >> testInstanceVariableReified [
 	| instVar |
-	instVar := self model entityNamed: 'Smalltalk::SubRootLevelOne.k'.
+	instVar := self model entityNamed: 'Smalltalk.SubRootLevelOne.k'.
 	self deny: instVar isClassSide
 ]
 
 { #category : #tests }
 FamixReferenceModelImporterTest >> testLocalVariableReified [
-	self assert: (self model entityNamed: 'Smalltalk::TheRoot.assigningLocalVariable().tmp') isNotNil
+	self assert: (self model entityNamed: 'Smalltalk.TheRoot.assigningLocalVariable().tmp') isNotNil
 ]
 
 { #category : #tests }
 FamixReferenceModelImporterTest >> testMetaclassAttributeIsClassSide [
 	| attribute theRoot |
-	attribute := self model entityNamed: #'Smalltalk::TheRoot_class.mz'.
-	theRoot := self model entityNamed: #'Smalltalk::TheRoot_class'.
+	attribute := self model entityNamed: #'Smalltalk.TheRoot_class.mz'.
+	theRoot := self model entityNamed: #'Smalltalk.TheRoot_class'.
 	self assert: attribute isClassSide.
 	self assert: attribute belongsTo equals: theRoot
 ]
@@ -599,7 +599,7 @@ FamixReferenceModelImporterTest >> testMetaclassAttributeIsClassSide [
 { #category : #tests }
 FamixReferenceModelImporterTest >> testMethodAnnotation [
 	| method |
-	method := self model entityNamed: 'Smalltalk::SubRootLevelOne.accessSuperclassInstVar()' ifAbsent: [ nil ].
+	method := self model entityNamed: 'Smalltalk.SubRootLevelOne.accessSuperclassInstVar()' ifAbsent: [ nil ].
 	self assert: method name equals: #accessSuperclassInstVar.
 	self assert: method protocol equals: #accessingSuperclassInstVar
 ]
@@ -609,7 +609,7 @@ FamixReferenceModelImporterTest >> testMethodReification [
 
 	| method |
 	method := self model entityNamed:
-		          'Smalltalk::SubRootLevelOne.accessSuperclassInstVar()'.
+		          'Smalltalk.SubRootLevelOne.accessSuperclassInstVar()'.
 	self assert: method isNotNil.
 	self
 		assert: method belongsTo
@@ -625,7 +625,7 @@ FamixReferenceModelImporterTest >> testMethodReification [
 { #category : #tests }
 FamixReferenceModelImporterTest >> testOutOfModelInheritedInstanceVariableReified [
 	| instVar |
-	instVar := self model entityNamed: 'Smalltalk::Model.dependents'.
+	instVar := self model entityNamed: 'Smalltalk.Model.dependents'.
 	self deny: instVar isClassSide.
 	self assert: instVar belongsTo mooseName equals: Model mooseName
 ]
@@ -634,7 +634,7 @@ FamixReferenceModelImporterTest >> testOutOfModelInheritedInstanceVariableReifie
 FamixReferenceModelImporterTest >> testReadAndWrite [
 	| accessDefinition |
 	accessDefinition := self model allAccesses
-		select: [ :acc | acc variable mooseName = 'Smalltalk::SubRootLevelOne.k' and: [ acc accessor mooseName = (SubRootLevelOne >> #accessTwiceTheSameVariableReadAndWrite) mooseName ] ].
+		select: [ :acc | acc variable mooseName = 'Smalltalk.SubRootLevelOne.k' and: [ acc accessor mooseName = (SubRootLevelOne >> #accessTwiceTheSameVariableReadAndWrite) mooseName ] ].
 	self assert: accessDefinition size equals: 2.
 	self assert: (accessDefinition at: 1) isRead | (accessDefinition at: 1) isWrite.
 	self assert: (accessDefinition at: 2) isRead | (accessDefinition at: 2) isWrite
@@ -653,8 +653,8 @@ FamixReferenceModelImporterTest >> testSelfAccessInDefiningClass [
 		self accessSharedVariableFromTheInstanceSide"
 
 	self
-		privateTestAccessingVar: #'Smalltalk::TheRoot.singleSelfSend().self'
-		from: #'Smalltalk::TheRoot.singleSelfSend()'
+		privateTestAccessingVar: #'Smalltalk.TheRoot.singleSelfSend().self'
+		from: #'Smalltalk.TheRoot.singleSelfSend()'
 		shouldBeRead: true
 		hasAccessesSize: 1
 ]
@@ -662,8 +662,8 @@ FamixReferenceModelImporterTest >> testSelfAccessInDefiningClass [
 { #category : #tests }
 FamixReferenceModelImporterTest >> testSelfAccessInDefiningClassOnClassSide [
 	self
-		privateTestAccessingVar: #'Smalltalk::TheRoot_class.singleSelfSendOnClassSide().self'
-		from: #'Smalltalk::TheRoot_class.singleSelfSendOnClassSide()'
+		privateTestAccessingVar: #'Smalltalk.TheRoot_class.singleSelfSendOnClassSide().self'
+		from: #'Smalltalk.TheRoot_class.singleSelfSendOnClassSide()'
 		shouldBeRead: true
 		hasAccessesSize: 1
 ]
@@ -690,7 +690,7 @@ FamixReferenceModelImporterTest >> testSetterMethod [
 { #category : #tests }
 FamixReferenceModelImporterTest >> testSharedVariableReification [
 	| shared |
-	shared := self model entityNamed: #'Smalltalk::TheRoot.TheRootSharedVariable'.
+	shared := self model entityNamed: #'Smalltalk.TheRoot.TheRootSharedVariable'.
 	self assert: shared isClassSide.
 	self assert: shared isSharedVariable.
 	self assert: shared belongsTo equals: (self model entityNamed: TheRoot mooseName)
@@ -725,7 +725,7 @@ FamixReferenceModelImporterTest >> testSingleSelfSendOnClassSide [
 			invocation signature = (FamixSmalltalkNameResolver signatureFromSmalltalkSelectorOn: calleeMethodName)
 				and: [ invocation sender mooseName = callingMethodUniqueName ] ].
 	self assert: invocations size equals: 1.
-	self assert: invocations first receiver mooseName equals: #'Smalltalk::TheRoot_class.singleSelfSendOnClassSide().self'
+	self assert: invocations first receiver mooseName equals: #'Smalltalk.TheRoot_class.singleSelfSendOnClassSide().self'
 ]
 
 { #category : #tests }
@@ -747,7 +747,7 @@ FamixReferenceModelImporterTest >> testSingleSelfSendWithReturn [
 { #category : #tests }
 FamixReferenceModelImporterTest >> testStubInstanceVariableReified [
 	| instVar |
-	instVar := self model entityNamed: 'Smalltalk::Model.dependents'.
+	instVar := self model entityNamed: 'Smalltalk.Model.dependents'.
 	self deny: instVar isNil.
 	self assert: instVar isStub
 ]
@@ -766,7 +766,7 @@ FamixReferenceModelImporterTest >> testStubSharedVariableAccess [
 { #category : #tests }
 FamixReferenceModelImporterTest >> testStubSharedVariableReified [
 	| classVar |
-	classVar := self model entityNamed: 'Smalltalk::Behavior.ClassProperties'.
+	classVar := self model entityNamed: 'Smalltalk.Behavior.ClassProperties'.
 	self deny: classVar isNil.
 	self assert: classVar isStub.
 	self assert: classVar isSharedVariable.
@@ -799,7 +799,7 @@ FamixReferenceModelImporterTest >> testUnknownVariableAccess [
 
 	self
 		privateTestAccessingVar: #undeclaredStubInstVar
-		from: #'Smalltalk::TheRoot.accessingUnknowVariable()'
+		from: #'Smalltalk.TheRoot.accessingUnknowVariable()'
 		shouldBeRead: true
 		hasAccessesSize: 1
 ]

--- a/src/Moose-SmalltalkImporter-Core-Tests/FamixReferenceModelMergingClassAndMetaclassImporterTest.class.st
+++ b/src/Moose-SmalltalkImporter-Core-Tests/FamixReferenceModelMergingClassAndMetaclassImporterTest.class.st
@@ -33,7 +33,7 @@ FamixReferenceModelMergingClassAndMetaclassImporterTest >> testAllClassInNamespa
 { #category : #tests }
 FamixReferenceModelMergingClassAndMetaclassImporterTest >> testAttributInRoot [
 	| theRoot |
-	theRoot := self model entityNamed: #'Smalltalk::TheRoot'.
+	theRoot := self model entityNamed: #'Smalltalk.TheRoot'.
 	self assert: (theRoot attributes inject: false into: [:bool : method | bool or: [method name = #y]]).
 	self assert: (theRoot attributes inject: false into: [:bool : method | bool or: [method name = #z]]).
 	self assert: (theRoot attributes inject: false into: [:bool : method | bool or: [method name = #'CIV#mz']])
@@ -42,8 +42,8 @@ FamixReferenceModelMergingClassAndMetaclassImporterTest >> testAttributInRoot [
 { #category : #tests }
 FamixReferenceModelMergingClassAndMetaclassImporterTest >> testClassAttributeHasInstanceScope [
 	| attribute theRoot |
-	attribute := self model entityNamed: #'Smalltalk::TheRoot.x'.
-	theRoot := self model entityNamed: #'Smalltalk::TheRoot'.
+	attribute := self model entityNamed: #'Smalltalk.TheRoot.x'.
+	theRoot := self model entityNamed: #'Smalltalk.TheRoot'.
 	self deny: attribute isClassSide.
 	self assert: attribute belongsTo equals: theRoot
 ]
@@ -51,10 +51,10 @@ FamixReferenceModelMergingClassAndMetaclassImporterTest >> testClassAttributeHas
 { #category : #tests }
 FamixReferenceModelMergingClassAndMetaclassImporterTest >> testClassMetaclassInstanceVariableAndShared [
 	| insVar theRoot insMetaclassVar shared |
-	insVar := self model entityNamed: #'Smalltalk::TheRoot.z'.
-	insMetaclassVar := self model entityNamed: #'Smalltalk::TheRoot.CIV#mz'.
-	shared := self model entityNamed: #'Smalltalk::TheRoot.TheRootSharedVariable'.
-	theRoot := self model entityNamed: #'Smalltalk::TheRoot'.
+	insVar := self model entityNamed: #'Smalltalk.TheRoot.z'.
+	insMetaclassVar := self model entityNamed: #'Smalltalk.TheRoot.CIV#mz'.
+	shared := self model entityNamed: #'Smalltalk.TheRoot.TheRootSharedVariable'.
+	theRoot := self model entityNamed: #'Smalltalk.TheRoot'.
 	self deny: insVar isClassSide.
 	self assert: insMetaclassVar isClassSide.
 	self assert: shared isClassSide.
@@ -69,10 +69,10 @@ FamixReferenceModelMergingClassAndMetaclassImporterTest >> testClassMetaclassIns
 { #category : #tests }
 FamixReferenceModelMergingClassAndMetaclassImporterTest >> testConflictingInstanceVarNames [
 	| insVar theRoot insMetaclassVar shared |
-	insVar := self model entityNamed: #'Smalltalk::TheRoot.instanceAndClassPotentiallyConflictingName'.
-	insMetaclassVar := self model entityNamed: #'Smalltalk::TheRoot.CIV#instanceAndClassPotentiallyConflictingName'.
-	shared := self model entityNamed: #'Smalltalk::TheRoot.TheRootSharedVariable'.
-	theRoot := self model entityNamed: #'Smalltalk::TheRoot'.
+	insVar := self model entityNamed: #'Smalltalk.TheRoot.instanceAndClassPotentiallyConflictingName'.
+	insMetaclassVar := self model entityNamed: #'Smalltalk.TheRoot.CIV#instanceAndClassPotentiallyConflictingName'.
+	shared := self model entityNamed: #'Smalltalk.TheRoot.TheRootSharedVariable'.
+	theRoot := self model entityNamed: #'Smalltalk.TheRoot'.
 	self deny: insVar isClassSide.
 	self assert: insMetaclassVar isClassSide.
 	self assert: shared isClassSide.
@@ -84,8 +84,8 @@ FamixReferenceModelMergingClassAndMetaclassImporterTest >> testConflictingInstan
 { #category : #tests }
 FamixReferenceModelMergingClassAndMetaclassImporterTest >> testInstanceAndClassSideWhenMergingClassAndMetaclass [
 	| node |
-	node := self model entityNamed: #'Smalltalk::TheRoot'.
-	self assert: (self model entityNamed: #'Smalltalk::TheRoot_class' ifAbsent: [ nil ]) isNil.
+	node := self model entityNamed: #'Smalltalk.TheRoot'.
+	self assert: (self model entityNamed: #'Smalltalk.TheRoot_class' ifAbsent: [ nil ]) isNil.
 	self assert: node instanceSide identicalTo: node.
 	self assert: node classSide identicalTo: nil
 ]
@@ -93,8 +93,8 @@ FamixReferenceModelMergingClassAndMetaclassImporterTest >> testInstanceAndClassS
 { #category : #tests }
 FamixReferenceModelMergingClassAndMetaclassImporterTest >> testMetaclassAttributeIsClassSide [
 	| attribute theRoot |
-	attribute := self model entityNamed: #'Smalltalk::TheRoot.CIV#mz'.
-	theRoot := self model entityNamed: #'Smalltalk::TheRoot'.
+	attribute := self model entityNamed: #'Smalltalk.TheRoot.CIV#mz'.
+	theRoot := self model entityNamed: #'Smalltalk.TheRoot'.
 	self assert: attribute isClassSide.
 	self assert: attribute belongsTo equals: theRoot
 ]
@@ -102,9 +102,9 @@ FamixReferenceModelMergingClassAndMetaclassImporterTest >> testMetaclassAttribut
 { #category : #tests }
 FamixReferenceModelMergingClassAndMetaclassImporterTest >> testMetaclassMethodHasClassScope [
 	| theRoot instanceMethod classMethod |
-	theRoot := self model entityNamed: #'Smalltalk::TheRoot'.
-	instanceMethod := self model entityNamed: #'Smalltalk::TheRoot.accessingClass()'.
-	classMethod := self model entityNamed: #'Smalltalk::TheRoot.classSend()'.
+	theRoot := self model entityNamed: #'Smalltalk.TheRoot'.
+	instanceMethod := self model entityNamed: #'Smalltalk.TheRoot.accessingClass()'.
+	classMethod := self model entityNamed: #'Smalltalk.TheRoot.classSend()'.
 	self deny: instanceMethod isClassSide.
 	self assert: classMethod isClassSide.
 	self assert: instanceMethod belongsTo equals: theRoot.
@@ -114,7 +114,7 @@ FamixReferenceModelMergingClassAndMetaclassImporterTest >> testMetaclassMethodHa
 { #category : #tests }
 FamixReferenceModelMergingClassAndMetaclassImporterTest >> testMethodInRoot [
 	| theRoot |
-	theRoot := self model entityNamed: #'Smalltalk::TheRoot'.
+	theRoot := self model entityNamed: #'Smalltalk.TheRoot'.
 	self assert: (theRoot methods inject: false into: [:bool : method | bool or: [method name = #classSend]]).
 	self assert: (theRoot methods inject: false into: [:bool : method | bool or: [method name = #singleSelfSendOnClassSide]]).
 	self assert: (theRoot methods inject: false into: [:bool : method | bool or: [method name = #returningSingleSelfSend]])
@@ -123,14 +123,14 @@ FamixReferenceModelMergingClassAndMetaclassImporterTest >> testMethodInRoot [
 { #category : #tests }
 FamixReferenceModelMergingClassAndMetaclassImporterTest >> testNumberOfStatementsWithNoErrors [
 	| classMethod |
-	classMethod := self model entityNamed: #'Smalltalk::TheRoot.classSend()'.
+	classMethod := self model entityNamed: #'Smalltalk.TheRoot.classSend()'.
 	self assert: classMethod numberOfStatements equals: 1
 ]
 
 { #category : #tests }
 FamixReferenceModelMergingClassAndMetaclassImporterTest >> testReferencesInRoot [
 	| theRoot |
-	theRoot := self model entityNamed: #'Smalltalk::TheRoot'.
+	theRoot := self model entityNamed: #'Smalltalk.TheRoot'.
 	self assert: (theRoot methods flatCollect: [ :each | each outgoingReferences ]) size equals: 6.
 	self assert: (theRoot methods flatCollect: [ :each | each outgoingReferences select: [ :access | access target name = #Object ] ]) size equals: 2
 ]
@@ -138,7 +138,7 @@ FamixReferenceModelMergingClassAndMetaclassImporterTest >> testReferencesInRoot 
 { #category : #tests }
 FamixReferenceModelMergingClassAndMetaclassImporterTest >> testSharedVariableReification [
 	| shared |
-	shared := self model entityNamed: #'Smalltalk::TheRoot.TheRootSharedVariable'.
+	shared := self model entityNamed: #'Smalltalk.TheRoot.TheRootSharedVariable'.
 	self assert: shared isClassSide.
 	self assert: shared isSharedVariable.
 	self assert: shared belongsTo equals: (self model entityNamed: TheRoot mooseName)
@@ -147,8 +147,8 @@ FamixReferenceModelMergingClassAndMetaclassImporterTest >> testSharedVariableRei
 { #category : #tests }
 FamixReferenceModelMergingClassAndMetaclassImporterTest >> testStubNotOverride [
 	| theRoot object |
-	theRoot := self model entityNamed: #'Smalltalk::TheRoot'.
-	object := self model entityNamed: #'Smalltalk::Object'.
+	theRoot := self model entityNamed: #'Smalltalk.TheRoot'.
+	object := self model entityNamed: #'Smalltalk.Object'.
 	self deny: theRoot isStub.
 	self assert: object isStub
 ]

--- a/src/Moose-SmalltalkImporter-KGB-Tests/AbstractFamixNavigationTest.class.st
+++ b/src/Moose-SmalltalkImporter-KGB-Tests/AbstractFamixNavigationTest.class.st
@@ -13,160 +13,160 @@ AbstractFamixNavigationTest class >> resources [
 AbstractFamixNavigationTest >> c10FullReferencerInSide [ 
 	 
 	^self model entityNamed: 
-			#'Model2FullReferee::M2P4C10FullReferencerInSide'
+			#'Model2FullReferee.M2P4C10FullReferencerInSide'
 ]
 
 { #category : #'helpers - classes' }
 AbstractFamixNavigationTest >> c11FullRefereeOutSide [ 
 	 
 	^self model entityNamed: 
-			#'Model2FullReferee::M2P5C11FullRefereeOutSide'
+			#'Model2FullReferee.M2P5C11FullRefereeOutSide'
 ]
 
 { #category : #'helpers - classes' }
 AbstractFamixNavigationTest >> c12FullReferencerInSide [ 
 	 
 	^self model entityNamed: 
-			#'Model2FullReferee::M2P6C12FullReferencerInSide'
+			#'Model2FullReferee.M2P6C12FullReferencerInSide'
 ]
 
 { #category : #'helpers - classes' }
 AbstractFamixNavigationTest >> c13FullRefereeInSideOutSide [ 
 	 
 	^self model entityNamed: 
-			#'Model2FullReferee::M2P6C13FullRefereeInSideOutSide'
+			#'Model2FullReferee.M2P6C13FullRefereeInSideOutSide'
 ]
 
 { #category : #'helpers - classes' }
 AbstractFamixNavigationTest >> c14ReferencerOutSideRefereeOutSide [ 
 	 
 	^self model entityNamed: 
-			#'Model3ReferencerReferee::M3P7C14ReferencerOutSideRefereeOutSide'
+			#'Model3ReferencerReferee.M3P7C14ReferencerOutSideRefereeOutSide'
 ]
 
 { #category : #'helpers - classes' }
 AbstractFamixNavigationTest >> c15FullReferencerOutSide [ 
 	 
 	^self model entityNamed: 
-			#'Model4FullReferencer::M4P8C15FullReferencerOutSide'
+			#'Model4FullReferencer.M4P8C15FullReferencerOutSide'
 ]
 
 { #category : #'helpers - classes' }
 AbstractFamixNavigationTest >> c16FullReferencerOutSideInSide [ 
 	 
 	^self model entityNamed: 
-			#'Model5InteractedReferencer::M5P9C16FullReferencerOutSideInSide'
+			#'Model5InteractedReferencer.M5P9C16FullReferencerOutSideInSide'
 ]
 
 { #category : #'helpers - classes' }
 AbstractFamixNavigationTest >> c17FullReferencerInSide [ 
 	 
 	^self model entityNamed: 
-			#'Model5InteractedReferencer::M5P10C17FullReferencerInSide'
+			#'Model5InteractedReferencer.M5P10C17FullReferencerInSide'
 ]
 
 { #category : #'helpers - classes' }
 AbstractFamixNavigationTest >> c18FullRefereeInSideOutSide [ 
 	 
 	^self model entityNamed: 
-			#'Model5InteractedReferencer::M5P10C18FullRefereeInSideOutSide'
+			#'Model5InteractedReferencer.M5P10C18FullRefereeInSideOutSide'
 ]
 
 { #category : #'helpers - classes' }
 AbstractFamixNavigationTest >> c19FullRefereeOutSide [ 
 	 
 	^self model entityNamed: 
-			#'Model6InteractedReferee::M6P11C19FullRefereeOutSide'
+			#'Model6InteractedReferee.M6P11C19FullRefereeOutSide'
 ]
 
 { #category : #'helpers - classes' }
 AbstractFamixNavigationTest >> c1FullReferencerOutSide [ 
 	 
 	^self model entityNamed: 
-			#'Model1InteractedReferencerReferee::M1P1C1FullReferencerOutSide'
+			#'Model1InteractedReferencerReferee.M1P1C1FullReferencerOutSide'
 ]
 
 { #category : #'helpers - classes' }
 AbstractFamixNavigationTest >> c20FullReferencerOutSide [ 
 	 
 	^self model entityNamed: 
-			#'Model6InteractedReferee::M6P12C20FullReferencerOutSide'
+			#'Model6InteractedReferee.M6P12C20FullReferencerOutSide'
 ]
 
 { #category : #'helpers - classes' }
 AbstractFamixNavigationTest >> c21FullReferencerOutSide [ 
 	 
 	^self model entityNamed: 
-			#'Model7FullInteracted::M7P13C21FullReferencerOutSide'
+			#'Model7FullInteracted.M7P13C21FullReferencerOutSide'
 ]
 
 { #category : #'helpers - classes' }
 AbstractFamixNavigationTest >> c22FullRefereeOutSide [ 
 	 
 	^self model entityNamed: 
-			#'Model7FullInteracted::M7P14C22FullRefereeOutSide'
+			#'Model7FullInteracted.M7P14C22FullRefereeOutSide'
 ]
 
 { #category : #'helpers - classes' }
 AbstractFamixNavigationTest >> c2ReferencerOutSideRefereeInSide [ 
 	 
 	^self model entityNamed: 
-			#'Model1InteractedReferencerReferee::M1P2C2ReferencerOutSideRefereeInSide'
+			#'Model1InteractedReferencerReferee.M1P2C2ReferencerOutSideRefereeInSide'
 ]
 
 { #category : #'helpers - classes' }
 AbstractFamixNavigationTest >> c3ReferencerInSideRefereeOutSide [ 
 	 
 	^self model entityNamed: 
-			#'Model1InteractedReferencerReferee::M1P2C3ReferencerInSideRefereeOutSide'
+			#'Model1InteractedReferencerReferee.M1P2C3ReferencerInSideRefereeOutSide'
 ]
 
 { #category : #'helpers - classes' }
 AbstractFamixNavigationTest >> c4FullRefereeInSide [ 
 	 
 	^self model entityNamed: 
-			#'Model1InteractedReferencerReferee::M1P2C4FullRefereeInSide'
+			#'Model1InteractedReferencerReferee.M1P2C4FullRefereeInSide'
 ]
 
 { #category : #'helpers - classes' }
 AbstractFamixNavigationTest >> c5ReferencerInSideRefereeInSide [ 
 	 
 	^self model entityNamed: 
-			#'Model1InteractedReferencerReferee::M1P3C5ReferencerInSideRefereeInSide'
+			#'Model1InteractedReferencerReferee.M1P3C5ReferencerInSideRefereeInSide'
 ]
 
 { #category : #'helpers - classes' }
 AbstractFamixNavigationTest >> c6FullReferencerInSideOutSide [ 
 	 
 	^self model entityNamed: 
-			#'Model1InteractedReferencerReferee::M1P3C6FullReferencerInSideOutSide'
+			#'Model1InteractedReferencerReferee.M1P3C6FullReferencerInSideOutSide'
 ]
 
 { #category : #'helpers - classes' }
 AbstractFamixNavigationTest >> c7FullRefereeInSide [ 
 	 
 	^self model entityNamed: 
-			#'Model1InteractedReferencerReferee::M1P3C7FullRefereeInSide'
+			#'Model1InteractedReferencerReferee.M1P3C7FullRefereeInSide'
 ]
 
 { #category : #'helpers - classes' }
 AbstractFamixNavigationTest >> c8FullReferencerInSide [ 
 	 
 	^self model entityNamed: 
-			#'Model1InteractedReferencerReferee::M1P3C8FullReferencerInSide'
+			#'Model1InteractedReferencerReferee.M1P3C8FullReferencerInSide'
 ]
 
 { #category : #'helpers - classes' }
 AbstractFamixNavigationTest >> c9FullRefereeInSide [ 
 	 
 	^self model entityNamed: 
-			#'Model2FullReferee::M2P4C9FullRefereeInSide'
+			#'Model2FullReferee.M2P4C9FullRefereeInSide'
 ]
 
 { #category : #'helpers - classes' }
 AbstractFamixNavigationTest >> cObject [ 
 	 
-	^self model entityNamed: #'Smalltalk::Object'
+	^self model entityNamed: #'Smalltalk.Object'
 ]
 
 { #category : #'helpers - utilites' }
@@ -181,14 +181,14 @@ AbstractFamixNavigationTest >> getMethod: methodNameString [
 AbstractFamixNavigationTest >> m1p2c2Mtd1 [  
 	 
 	^self model entityNamed: 
-			#'Model1InteractedReferencerReferee::M1P2C2ReferencerOutSideRefereeInSide.m1p2c2Mtd1()'
+			#'Model1InteractedReferencerReferee.M1P2C2ReferencerOutSideRefereeInSide.m1p2c2Mtd1()'
 ]
 
 { #category : #'helpers - classes' }
 AbstractFamixNavigationTest >> m1p2c2Mtd2 [ 
 	 
 	^self model entityNamed: 
-			#'Model1InteractedReferencerReferee::M1P2C2ReferencerOutSideRefereeInSide.m1p2c2Mtd2()'
+			#'Model1InteractedReferencerReferee.M1P2C2ReferencerOutSideRefereeInSide.m1p2c2Mtd2()'
 ]
 
 { #category : #'helpers - utilites' }

--- a/src/Moose-SmalltalkImporter-KGB-Tests/FamixInvocationNavigationTest.class.st
+++ b/src/Moose-SmalltalkImporter-KGB-Tests/FamixInvocationNavigationTest.class.st
@@ -18,7 +18,7 @@ FamixInvocationNavigationTest >> testIsASureInvocation [
 { #category : #tests }
 FamixInvocationNavigationTest >> testIsSurelyInvokedBy [
 	| method |
-	method := self model allMethods entityNamed: #'Model5InteractedReferencer::M5P10C17FullReferencerInSide.m5p10c17Mtd1()'.
+	method := self model allMethods entityNamed: #'Model5InteractedReferencer.M5P10C17FullReferencerInSide.m5p10c17Mtd1()'.
 
 	self assert: ((self getMethod: 'm5p10c18InstCreation()') isSurelyInvokedBy: method).
 	self deny: ((self getMethod: 'm5p10c18Mtd1()') isSurelyInvokedBy: method)

--- a/src/Moose-SmalltalkImporter-KGB-Tests/FamixPropertiesTest.class.st
+++ b/src/Moose-SmalltalkImporter-KGB-Tests/FamixPropertiesTest.class.st
@@ -7,47 +7,47 @@ Class {
 { #category : #tests }
 FamixPropertiesTest >> testMethodTimeStamp [
 	| method |
-	method := self model entityNamed: #'Model2FullReferee::M2P4C10FullReferencerInSide.m2p4c10Mtd1()'.
+	method := self model entityNamed: #'Model2FullReferee.M2P4C10FullReferencerInSide.m2p4c10Mtd1()'.
 	self
 		assert: (method propertyNamed: #timeStamp)
 		equals: (M2P4C10FullReferencerInSide compiledMethodAt: #m2p4c10Mtd1) timeStamp.
-	method := self model entityNamed: #'Model2FullReferee::M2P4C9FullRefereeInSide.m2p4c9Mtd1()'.
+	method := self model entityNamed: #'Model2FullReferee.M2P4C9FullRefereeInSide.m2p4c9Mtd1()'.
 	self
 		assert: (method propertyNamed: #timeStamp)
 		equals: (M2P4C9FullRefereeInSide compiledMethodAt: #m2p4c9Mtd1) timeStamp.
-	method := self model entityNamed: #'Model2FullReferee::M2P5C11FullRefereeOutSide.m2p5c11Mtd1()'.
+	method := self model entityNamed: #'Model2FullReferee.M2P5C11FullRefereeOutSide.m2p5c11Mtd1()'.
 	self
 		assert: (method propertyNamed: #timeStamp)
 		equals: (M2P5C11FullRefereeOutSide compiledMethodAt: #m2p5c11Mtd1) timeStamp.
-	method := self model entityNamed: #'Model2FullReferee::M2P5C11FullRefereeOutSide.m2p5c11Mtd2()'.
+	method := self model entityNamed: #'Model2FullReferee.M2P5C11FullRefereeOutSide.m2p5c11Mtd2()'.
 	self
 		assert: (method propertyNamed: #timeStamp)
 		equals: (M2P5C11FullRefereeOutSide compiledMethodAt: #m2p5c11Mtd2) timeStamp.
-	method := self model entityNamed: #'Model2FullReferee::M2P5C11FullRefereeOutSide.m2p5c11Mtd3()'.
+	method := self model entityNamed: #'Model2FullReferee.M2P5C11FullRefereeOutSide.m2p5c11Mtd3()'.
 	self
 		assert: (method propertyNamed: #timeStamp)
 		equals: (M2P5C11FullRefereeOutSide compiledMethodAt: #m2p5c11Mtd3) timeStamp.
-	method := self model entityNamed: #'Model2FullReferee::M2P5C11FullRefereeOutSide.m2p5c11Mtd4()'.
+	method := self model entityNamed: #'Model2FullReferee.M2P5C11FullRefereeOutSide.m2p5c11Mtd4()'.
 	self
 		assert: (method propertyNamed: #timeStamp)
 		equals: (M2P5C11FullRefereeOutSide compiledMethodAt: #m2p5c11Mtd4) timeStamp.
-	method := self model entityNamed: #'Model2FullReferee::M2P5C11FullRefereeOutSide.m2p5c11Mtd5()'.
+	method := self model entityNamed: #'Model2FullReferee.M2P5C11FullRefereeOutSide.m2p5c11Mtd5()'.
 	self
 		assert: (method propertyNamed: #timeStamp)
 		equals: (M2P5C11FullRefereeOutSide compiledMethodAt: #m2p5c11Mtd5) timeStamp.
-	method := self model entityNamed: #'Model3ReferencerReferee::M3P7C14ReferencerOutSideRefereeOutSide.m3p7c14Mtd1()'.
+	method := self model entityNamed: #'Model3ReferencerReferee.M3P7C14ReferencerOutSideRefereeOutSide.m3p7c14Mtd1()'.
 	self
 		assert: (method propertyNamed: #timeStamp)
 		equals: (M3P7C14ReferencerOutSideRefereeOutSide compiledMethodAt: #m3p7c14Mtd1) timeStamp.
-	method := self model entityNamed: #'Model3ReferencerReferee::M3P7C14ReferencerOutSideRefereeOutSide.m3p7c14Mtd2()'.
+	method := self model entityNamed: #'Model3ReferencerReferee.M3P7C14ReferencerOutSideRefereeOutSide.m3p7c14Mtd2()'.
 	self
 		assert: (method propertyNamed: #timeStamp)
 		equals: (M3P7C14ReferencerOutSideRefereeOutSide compiledMethodAt: #m3p7c14Mtd2) timeStamp.
-	method := self model entityNamed: #'Model3ReferencerReferee::M3P7C14ReferencerOutSideRefereeOutSide.m3p7c14Mtd3()'.
+	method := self model entityNamed: #'Model3ReferencerReferee.M3P7C14ReferencerOutSideRefereeOutSide.m3p7c14Mtd3()'.
 	self
 		assert: (method propertyNamed: #timeStamp)
 		equals: (M3P7C14ReferencerOutSideRefereeOutSide compiledMethodAt: #m3p7c14Mtd3) timeStamp.
-	method := self model entityNamed: #'Model3ReferencerReferee::M3P7C14ReferencerOutSideRefereeOutSide.m3p7c14Mtd4()'.
+	method := self model entityNamed: #'Model3ReferencerReferee.M3P7C14ReferencerOutSideRefereeOutSide.m3p7c14Mtd4()'.
 	self
 		assert: (method propertyNamed: #timeStamp)
 		equals: (M3P7C14ReferencerOutSideRefereeOutSide compiledMethodAt: #m3p7c14Mtd4) timeStamp

--- a/src/Moose-SmalltalkImporter-KGB-Tests/FamixStNavigationTestResource.class.st
+++ b/src/Moose-SmalltalkImporter-KGB-Tests/FamixStNavigationTestResource.class.st
@@ -42,6 +42,6 @@ FamixStNavigationTestResource >> importModel [
 		namespace := namespaces at: index.
 		classArray do: [ :each |
 			| class |
-			class := model entityNamed: 'Smalltalk::' , each.
+			class := model entityNamed: 'Smalltalk.' , each.
 			class typeContainer: namespace ] ]
 ]

--- a/src/Moose-SmalltalkImporter-LAN-Tests/FamixInvocationsTest.class.st
+++ b/src/Moose-SmalltalkImporter-LAN-Tests/FamixInvocationsTest.class.st
@@ -22,76 +22,76 @@ FamixInvocationsTest >> invocationFromOutputServerAcceptMethodTo: signature [
 { #category : #model }
 FamixInvocationsTest >> outputServerAcceptMethod [
 	^self model allMethods 
-		entityNamed: #'Smalltalk::LANOutputServer.accept:(Object)'
+		entityNamed: #'Smalltalk.LANOutputServer.accept:(Object)'
 ]
 
 { #category : #tests }
 FamixInvocationsTest >> testCandidateAbstractMethodWithTwoSubclasses [
 	| invocation |
-	invocation := self invocationFrom: #'Smalltalk::LANOutputServer.accept:(Object)' to: #'output:(Object)'.
+	invocation := self invocationFrom: #'Smalltalk.LANOutputServer.accept:(Object)' to: #'output:(Object)'.
 	self assert: invocation isNotNil.
 	self assert: invocation candidates size equals: 2.
-	self assert: (invocation candidates includes: (self model entityNamed: #'Smalltalk::LANFileServer.output:(Object)')).
-	self assert: (invocation candidates includes: (self model entityNamed: #'Smalltalk::LANPrintServer.output:(Object)'))
+	self assert: (invocation candidates includes: (self model entityNamed: #'Smalltalk.LANFileServer.output:(Object)')).
+	self assert: (invocation candidates includes: (self model entityNamed: #'Smalltalk.LANPrintServer.output:(Object)'))
 ]
 
 { #category : #tests }
 FamixInvocationsTest >> testCandidateInvocationsAbstractMethodWithTwoSubclasses [
 	| invocation |
-	invocation := self invocationFrom: #'Smalltalk::LANOutputServer.accept:(Object)' to: #'output:(Object)'.
+	invocation := self invocationFrom: #'Smalltalk.LANOutputServer.accept:(Object)' to: #'output:(Object)'.
 	self assert: invocation isNotNil.
 	self assert: invocation candidates size equals: 2.
-	self assert: (invocation candidates includes: (self model entityNamed: #'Smalltalk::LANFileServer.output:(Object)')).
-	self assert: (invocation candidates includes: (self model entityNamed: #'Smalltalk::LANPrintServer.output:(Object)'))	"	self assert: (invocation candidates includes: (self model entityNamed: #'Root::Smalltalk::LAN::OutputServer.output:(Object)'))."
+	self assert: (invocation candidates includes: (self model entityNamed: #'Smalltalk.LANFileServer.output:(Object)')).
+	self assert: (invocation candidates includes: (self model entityNamed: #'Smalltalk.LANPrintServer.output:(Object)'))	"	self assert: (invocation candidates includes: (self model entityNamed: #'Root::Smalltalk::LAN::OutputServer.output:(Object)'))."
 ]
 
 { #category : #tests }
 FamixInvocationsTest >> testCandidateInvocationsClassMethodsDefinedInSuperclass [
 	| invocation method |
-	invocation := self invocationFrom: #'Smalltalk::LANInterface.newWorkstation()' to: #'new()'.
+	invocation := self invocationFrom: #'Smalltalk.LANInterface.newWorkstation()' to: #'new()'.
 	self assert: invocation isNotNil.
-	self assert: invocation receiver equals: (self model entityNamed: #'Smalltalk::LANWorkStation_class').
+	self assert: invocation receiver equals: (self model entityNamed: #'Smalltalk.LANWorkStation_class').
 	self assert: invocation candidates size equals: 1.
-	method := self model entityNamed: #'Smalltalk::LANNode_class.new()'.
+	method := self model entityNamed: #'Smalltalk.LANNode_class.new()'.
 	self assert: (invocation candidates includes: method)
 ]
 
 { #category : #tests }
 FamixInvocationsTest >> testCandidateInvocationsOnlyDefinedInSuperclass [
 	| invocation |
-	invocation := self invocationFrom: #'Smalltalk::LANOutputServer.accept:(Object)' to: #'send:(Object)'.
+	invocation := self invocationFrom: #'Smalltalk.LANOutputServer.accept:(Object)' to: #'send:(Object)'.
 	self assert: invocation isNotNil.
 	self assert: invocation candidates size equals: 1.
-	self assert: (invocation candidates includes: (self model entityNamed: #'Smalltalk::LANNode.send:(Object)'))
+	self assert: (invocation candidates includes: (self model entityNamed: #'Smalltalk.LANNode.send:(Object)'))
 ]
 
 { #category : #tests }
 FamixInvocationsTest >> testCandidateInvocationsThree [
 	| invocation |
-	invocation := self invocationFrom: #'Smalltalk::LANSingleDestinationAddress.equalsSingle:(Object)' to: #'id()'.
+	invocation := self invocationFrom: #'Smalltalk.LANSingleDestinationAddress.equalsSingle:(Object)' to: #'id()'.
 	self assert: invocation isNotNil.
 	self assert: invocation candidates size equals: 1.
-	self assert: (invocation candidates includes: (self model entityNamed: #'Smalltalk::LANSingleDestinationAddress.id()'))
+	self assert: (invocation candidates includes: (self model entityNamed: #'Smalltalk.LANSingleDestinationAddress.id()'))
 ]
 
 { #category : #tests }
 FamixInvocationsTest >> testCandidateInvocationsTwo [
 	| invocation |
-	invocation := self invocationFrom: #'Smalltalk::LANInterface.originate()' to: #'originate:(Object)'.
+	invocation := self invocationFrom: #'Smalltalk.LANInterface.originate()' to: #'originate:(Object)'.
 	self assert: invocation isNotNil.
 	self assert: invocation candidates size equals: 1.
-	self assert: (invocation candidates includes: (self model entityNamed: #'Smalltalk::LANWorkStation.originate:(Object)'))
+	self assert: (invocation candidates includes: (self model entityNamed: #'Smalltalk.LANWorkStation.originate:(Object)'))
 ]
 
 { #category : #tests }
 FamixInvocationsTest >> testCandidateInvocationsUnknownReceiver [
 	| invocation |
-	invocation := self invocationFrom: #'Smalltalk::LANNode.send:(Object)' to: #'accept:(Object)'.
+	invocation := self invocationFrom: #'Smalltalk.LANNode.send:(Object)' to: #'accept:(Object)'.
 	self assert: invocation isNotNil.
 	self assert: invocation candidates size equals: 3.
-	self assert: (invocation candidates includes: (self model entityNamed: #'Smalltalk::LANNode.accept:(Object)')).
-	self assert: (invocation candidates includes: (self model entityNamed: #'Smalltalk::LANWorkStation.accept:(Object)')).
-	self assert: (invocation candidates includes: (self model entityNamed: #'Smalltalk::LANOutputServer.accept:(Object)'))
+	self assert: (invocation candidates includes: (self model entityNamed: #'Smalltalk.LANNode.accept:(Object)')).
+	self assert: (invocation candidates includes: (self model entityNamed: #'Smalltalk.LANWorkStation.accept:(Object)')).
+	self assert: (invocation candidates includes: (self model entityNamed: #'Smalltalk.LANOutputServer.accept:(Object)'))
 ]
 
 { #category : #tests }
@@ -106,7 +106,7 @@ FamixInvocationsTest >> testReceivingFormalParameter [
 { #category : #tests }
 FamixInvocationsTest >> testReceivingKnownClass [
 	| invocation |
-	invocation := self invocationFrom: #'Smalltalk::LANInterface.newNode()' to: #'new()'.
+	invocation := self invocationFrom: #'Smalltalk.LANInterface.newNode()' to: #'new()'.
 	self assert: invocation isNotNil.
 	self assert: invocation receiver mooseName equals: LANNode class mooseName
 ]
@@ -114,17 +114,17 @@ FamixInvocationsTest >> testReceivingKnownClass [
 { #category : #tests }
 FamixInvocationsTest >> testReceivingKnownClass2 [
 	| invocation |
-	invocation := self invocationFrom: #'Smalltalk::LANInterface.newWorkstation()' to: #'new()'.
+	invocation := self invocationFrom: #'Smalltalk.LANInterface.newWorkstation()' to: #'new()'.
 	self assert: invocation isNotNil.
-	self assert: invocation receiver mooseName equals: #'Smalltalk::LANWorkStation_class'
+	self assert: invocation receiver mooseName equals: #'Smalltalk.LANWorkStation_class'
 ]
 
 { #category : #tests }
 FamixInvocationsTest >> testReceivingKnownClass3 [
 	| invocation |
-	invocation := self invocationFrom: #'Smalltalk::LANInterface.newFileServer()' to: #'new()'.
+	invocation := self invocationFrom: #'Smalltalk.LANInterface.newFileServer()' to: #'new()'.
 	self assert: invocation isNotNil.
-	self assert: invocation receiver mooseName equals: #'Smalltalk::LANFileServer_class'
+	self assert: invocation receiver mooseName equals: #'Smalltalk.LANFileServer_class'
 ]
 
 { #category : #tests }
@@ -132,7 +132,7 @@ FamixInvocationsTest >> testReceivingSelf [
 	| invocation |
 	invocation := self invocationFromOutputServerAcceptMethodTo: #'output:(Object)'.
 	self assert: invocation isNotNil.
-	self assert: invocation receiver mooseName equals: #'Smalltalk::LANOutputServer.accept:(Object).self'
+	self assert: invocation receiver mooseName equals: #'Smalltalk.LANOutputServer.accept:(Object).self'
 ]
 
 { #category : #tests }
@@ -140,7 +140,7 @@ FamixInvocationsTest >> testReceivingSelf2 [
 	| invocation |
 	invocation := self invocationFromOutputServerAcceptMethodTo: #'name()'.
 	self assert: invocation isNotNil.
-	self assert: invocation receiver mooseName equals: #'Smalltalk::LANOutputServer.accept:(Object).self'
+	self assert: invocation receiver mooseName equals: #'Smalltalk.LANOutputServer.accept:(Object).self'
 ]
 
 { #category : #tests }
@@ -148,23 +148,23 @@ FamixInvocationsTest >> testReceivingSelf3 [
 	| invocation |
 	invocation := self invocationFromOutputServerAcceptMethodTo: #'send:(Object)'.
 	self assert: invocation isNotNil.
-	self assert: invocation receiver mooseName equals: #'Smalltalk::LANOutputServer.accept:(Object).self'
+	self assert: invocation receiver mooseName equals: #'Smalltalk.LANOutputServer.accept:(Object).self'
 ]
 
 { #category : #tests }
 FamixInvocationsTest >> testReceivingSelf9 [
 	| invocation |
-	invocation := self invocationFrom: #'Smalltalk::LANOutputServer.output:(Object)' to: #'subclassResponsibility()'.
+	invocation := self invocationFrom: #'Smalltalk.LANOutputServer.output:(Object)' to: #'subclassResponsibility()'.
 	self assert: invocation isNotNil.
-	self assert: invocation receiver mooseName equals: #'Smalltalk::LANOutputServer.output:(Object).self'
+	self assert: invocation receiver mooseName equals: #'Smalltalk.LANOutputServer.output:(Object).self'
 ]
 
 { #category : #tests }
 FamixInvocationsTest >> testReceivingSuper [
 	| invocation |
-	invocation := self invocationFrom: #'Smalltalk::LANInterface.initialize()' to: #'initialize()'.
+	invocation := self invocationFrom: #'Smalltalk.LANInterface.initialize()' to: #'initialize()'.
 	self assert: invocation isNotNil.
-	self assert: invocation receiver mooseName equals: #'Smalltalk::LANInterface.initialize().super'
+	self assert: invocation receiver mooseName equals: #'Smalltalk.LANInterface.initialize().super'
 ]
 
 { #category : #tests }
@@ -186,25 +186,25 @@ FamixInvocationsTest >> testReceivingSuper3 [
 { #category : #tests }
 FamixInvocationsTest >> testReceivingSuper4 [
 	| invocation |
-	invocation := self invocationFrom: #'Smalltalk::LANWorkStation.name()' to: #'name()'.
+	invocation := self invocationFrom: #'Smalltalk.LANWorkStation.name()' to: #'name()'.
 	self assert: invocation isNotNil.
-	self assert: invocation receiver mooseName equals: #'Smalltalk::LANWorkStation.name().super'
+	self assert: invocation receiver mooseName equals: #'Smalltalk.LANWorkStation.name().super'
 ]
 
 { #category : #tests }
 FamixInvocationsTest >> testReceivingSuper5 [
 	| invocation |
-	invocation := self invocationFrom: #'Smalltalk::LANFileServer.name()' to: #'name()'.
+	invocation := self invocationFrom: #'Smalltalk.LANFileServer.name()' to: #'name()'.
 	self assert: invocation isNotNil.
-	self assert: invocation receiver mooseName equals: #'Smalltalk::LANFileServer.name().super'
+	self assert: invocation receiver mooseName equals: #'Smalltalk.LANFileServer.name().super'
 ]
 
 { #category : #tests }
 FamixInvocationsTest >> testReceivingSuper6 [
 	| invocation |
-	invocation := self invocationFrom: #'Smalltalk::LANPacket.printOn:(Object)' to: #'printOn:(Object)'.
+	invocation := self invocationFrom: #'Smalltalk.LANPacket.printOn:(Object)' to: #'printOn:(Object)'.
 	self assert: invocation isNotNil.
-	self assert: invocation receiver mooseName equals: #'Smalltalk::LANPacket.printOn:(Object).super'
+	self assert: invocation receiver mooseName equals: #'Smalltalk.LANPacket.printOn:(Object).super'
 ]
 
 { #category : #tests }

--- a/src/Moose-SmalltalkImporter-LAN-Tests/FamixModelExtractionTest.class.st
+++ b/src/Moose-SmalltalkImporter-LAN-Tests/FamixModelExtractionTest.class.st
@@ -27,9 +27,9 @@ Class {
 
 { #category : #auxiliary }
 FamixModelExtractionTest >> assignAttributes [
-	nodeName := self model entityNamed: 'Smalltalk::LANNode.name'.
-	nextNode := self model entityNamed: 'Smalltalk::LANNode.nextNode'.
-	serverType := self model entityNamed: 'Smalltalk::LANOutputServer.serverType'
+	nodeName := self model entityNamed: 'Smalltalk.LANNode.name'.
+	nextNode := self model entityNamed: 'Smalltalk.LANNode.nextNode'.
+	serverType := self model entityNamed: 'Smalltalk.LANOutputServer.serverType'
 ]
 
 { #category : #auxiliary }
@@ -39,21 +39,21 @@ FamixModelExtractionTest >> assignClasses [
 
 { #category : #auxiliary }
 FamixModelExtractionTest >> assignMethods [
-	methodWithEmptyBodyNode := self model entityNamed: 'Smalltalk::LANNode.methodWithEmptyBody()'.
-	outputServer := self model entityNamed: 'Smalltalk::LANOutputServer.output:(Object)'.
-	acceptServer := self model entityNamed: 'Smalltalk::LANOutputServer.accept:(Object)'.
-	acceptNode := self model entityNamed: 'Smalltalk::LANNode.accept:(Object)'.
-	canOutputServer := self model entityNamed: 'Smalltalk::LANOutputServer.canOutput()'.
-	canOutputNode := self model entityNamed: 'Smalltalk::LANNode.canOutput()'.
-	nameNode := self model entityNamed: 'Smalltalk::LANNode.name()'.
-	nameNodeColon := self model entityNamed: 'Smalltalk::LANNode.name:(Object)'.
-	nextNodeMethod := self model entityNamed: 'Smalltalk::LANNode.nextNode()'.
-	nextNodeColon := self model entityNamed: 'Smalltalk::LANNode.nextNode:(Object)'.
-	initializeNode := self model entityNamed: 'Smalltalk::LANNode.initialize()'.
-	printOnNode := self model entityNamed: 'Smalltalk::LANNode.printOn:(Object)'.
-	sendNode := self model entityNamed: 'Smalltalk::LANNode.send:(Object)'.
-	canOriginateNode := self model entityNamed: 'Smalltalk::LANNode.canOriginate()'.
-	newNodeClass := self model entityNamed: 'Smalltalk::LANNode.new()'
+	methodWithEmptyBodyNode := self model entityNamed: 'Smalltalk.LANNode.methodWithEmptyBody()'.
+	outputServer := self model entityNamed: 'Smalltalk.LANOutputServer.output:(Object)'.
+	acceptServer := self model entityNamed: 'Smalltalk.LANOutputServer.accept:(Object)'.
+	acceptNode := self model entityNamed: 'Smalltalk.LANNode.accept:(Object)'.
+	canOutputServer := self model entityNamed: 'Smalltalk.LANOutputServer.canOutput()'.
+	canOutputNode := self model entityNamed: 'Smalltalk.LANNode.canOutput()'.
+	nameNode := self model entityNamed: 'Smalltalk.LANNode.name()'.
+	nameNodeColon := self model entityNamed: 'Smalltalk.LANNode.name:(Object)'.
+	nextNodeMethod := self model entityNamed: 'Smalltalk.LANNode.nextNode()'.
+	nextNodeColon := self model entityNamed: 'Smalltalk.LANNode.nextNode:(Object)'.
+	initializeNode := self model entityNamed: 'Smalltalk.LANNode.initialize()'.
+	printOnNode := self model entityNamed: 'Smalltalk.LANNode.printOn:(Object)'.
+	sendNode := self model entityNamed: 'Smalltalk.LANNode.send:(Object)'.
+	canOriginateNode := self model entityNamed: 'Smalltalk.LANNode.canOriginate()'.
+	newNodeClass := self model entityNamed: 'Smalltalk.LANNode.new()'
 ]
 
 { #category : #running }
@@ -243,7 +243,7 @@ FamixModelExtractionTest >> testModelDoesNotContainDuplicateSharedVars [
 { #category : #tests }
 FamixModelExtractionTest >> testNameAndUniqueNameForNotNamed [
 	| mseMethod |
-	mseMethod := self model entityNamed: 'Smalltalk::LANNode.printOn:(Object)'.
+	mseMethod := self model entityNamed: 'Smalltalk.LANNode.printOn:(Object)'.
 	self assert: (mseMethod outgoingInvocations anySatisfy: [:each | each signature = #'printString()'])
 ]
 

--- a/src/Moose-SmalltalkImporter-LAN-Tests/FamixStepwiseImporterTest.class.st
+++ b/src/Moose-SmalltalkImporter-LAN-Tests/FamixStepwiseImporterTest.class.st
@@ -34,7 +34,7 @@ FamixStepwiseImporterTest >> testCheckFormalParameterIsCreated [
 		addClass: LANNode;
 		model: model;
 		run.
-	mseFormalParameter := model entityNamed: #'Smalltalk::LANNode.nextNode:(Object).aNode'.
+	mseFormalParameter := model entityNamed: #'Smalltalk.LANNode.nextNode:(Object).aNode'.
 	self assert: mseFormalParameter name equals: #aNode
 ]
 
@@ -53,7 +53,7 @@ FamixStepwiseImporterTest >> testCheckSelfIsCreated [
 		addClass: LANNode;
 		model: model;
 		run.
-	mseSelf := model entityNamed: #'Smalltalk::LANNode.send:(Object).self'.
+	mseSelf := model entityNamed: #'Smalltalk.LANNode.send:(Object).self'.
 	self assert: mseSelf name equals: 'self' "mseMethod :=  model entityNamed:  #'Smalltalk::Node.send:(Object)'." "apparently I cannot access #'Smalltalk::Node.send:(Object).self'" "self assert: (mseMethod outgoingAccesses byName: 'Smalltalk::Node.self' ifAbsent: [] ) notEmpty."
 ]
 
@@ -163,7 +163,7 @@ FamixStepwiseImporterTest >> testImportLANPackage [
 		yourself.
 	self denyEmpty: model allPackages.
 	package := model entityNamed: #'Moose-TestResources-LAN'.
-	class := model entityNamed: #'Smalltalk::LANNode'.
+	class := model entityNamed: #'Smalltalk.LANNode'.
 	self assert: class parentPackage identicalTo: package
 ]
 
@@ -212,7 +212,7 @@ FamixStepwiseImporterTest >> testImportMethodBody [
 	nextNodeMethod := famixClassNode methods detect: [ :fm | fm name == #nextNode ].
 	self assertEmpty: nextNodeMethod parameters.
 	self assert: nextNodeMethod signature identicalTo: #'nextNode()'.
-	self assert: nextNodeMethod mooseName identicalTo: #'Smalltalk::LANNode.nextNode()'.
+	self assert: nextNodeMethod mooseName identicalTo: #'Smalltalk.LANNode.nextNode()'.
 	nameMethod := famixClassNode methods detect: [ :fm | fm name == #name: ].
 	self assert: nameMethod parameters size equals: 1.
 	xFormalParameter := nameMethod parameters at: 1.

--- a/src/Moose-SmalltalkImporter-LAN-Tests/ImportStubMethodSpecialTest.class.st
+++ b/src/Moose-SmalltalkImporter-LAN-Tests/ImportStubMethodSpecialTest.class.st
@@ -34,7 +34,7 @@ ImportStubMethodSpecialTest >> testStubMethodCreation [
 ImportStubMethodSpecialTest >> testStubParentsAreInMooseModel [
 
 	| method class |
-	method := model entityNamed: #'Smalltalk::False.ifTrue:(Object)'.
+	method := model entityNamed: #'Smalltalk.False.ifTrue:(Object)'.
 	self assert: method mooseModel isNotNil.
 	self assert: method isStub.
 

--- a/src/Moose-SmalltalkImporter-LAN-Tests/LANFamixPropertiesTest.class.st
+++ b/src/Moose-SmalltalkImporter-LAN-Tests/LANFamixPropertiesTest.class.st
@@ -6,7 +6,7 @@ Class {
 
 { #category : #testing }
 LANFamixPropertiesTest >> lanInterfaceOriginateMethod [
-	^self model entityNamed: #'Smalltalk::LANInterface.originate()'
+	^self model entityNamed: #'Smalltalk.LANInterface.originate()'
 ]
 
 { #category : #testing }
@@ -17,8 +17,8 @@ LANFamixPropertiesTest >> nodeClass [
 { #category : #testing }
 LANFamixPropertiesTest >> testAttributeMetrics [
 	| attribute1 attribute2 |
-	attribute1 := self model entityNamed: #'Smalltalk::LANInterface.nextNode'.
-	attribute2 := self model entityNamed: #'Smalltalk::LANOutputServer.serverType'.
+	attribute1 := self model entityNamed: #'Smalltalk.LANInterface.nextNode'.
+	attribute2 := self model entityNamed: #'Smalltalk.LANOutputServer.serverType'.
 	self assert: (attribute1 propertyNamed: #numberOfAccesses) equals: 3.
 	self assert: attribute1 numberOfAccesses equals: 3.
 	self assert: (attribute1 propertyNamed: #hierarchyNestingLevel) equals: 1.
@@ -102,7 +102,7 @@ LANFamixPropertiesTest >> testClassInvocations [
 LANFamixPropertiesTest >> testClassIsAbstract [
 	^ self
 		assert:
-			(self model entityNamed: #'Smalltalk::LANAbstractDestinationAddress')
+			(self model entityNamed: #'Smalltalk.LANAbstractDestinationAddress')
 				isAbstract
 ]
 
@@ -156,7 +156,7 @@ LANFamixPropertiesTest >> testMethodAccesses [
 	self
 		assert: self lanInterfaceOriginateMethod numberOfAccesses
 		equals: (self lanInterfaceOriginateMethod propertyNamed: #numberOfAccesses).
-	self assert: (self model entityNamed: #'Smalltalk::LANInterface.originator()') numberOfAccesses equals: 3
+	self assert: (self model entityNamed: #'Smalltalk.LANInterface.originator()') numberOfAccesses equals: 3
 ]
 
 { #category : #testing }
@@ -177,14 +177,14 @@ LANFamixPropertiesTest >> testMethodHierarchyNesting [
 LANFamixPropertiesTest >> testMethodInvocations [
 	self assert: (self lanInterfaceOriginateMethod propertyNamed: #numberOfOutgoingInvocations) equals: 22.
 	self assert: self lanInterfaceOriginateMethod numberOfOutgoingInvocations equals: 22.
-	self assert: (self model entityNamed: #'Smalltalk::LANInterface.initialize()') numberOfOutgoingInvocations equals: 2
+	self assert: (self model entityNamed: #'Smalltalk.LANInterface.initialize()') numberOfOutgoingInvocations equals: 2
 ]
 
 { #category : #testing }
 LANFamixPropertiesTest >> testMethodInvocationsWithoutCascading [
-	self assert: (self model entityNamed: #'Smalltalk::LANInterface.remove()') numberOfOutgoingInvocations equals: 6.
+	self assert: (self model entityNamed: #'Smalltalk.LANInterface.remove()') numberOfOutgoingInvocations equals: 6.
 	self
-		assert: (self model entityNamed: #'Smalltalk::LANInterface.newWorkstation()') numberOfOutgoingInvocations
+		assert: (self model entityNamed: #'Smalltalk.LANInterface.newWorkstation()') numberOfOutgoingInvocations
 		equals: 4
 ]
 
@@ -227,38 +227,38 @@ LANFamixPropertiesTest >> testMethodSmalltalkStatements [
 { #category : #testing }
 LANFamixPropertiesTest >> testMethodTimeStamp [
 	| method |
-	method := self model entityNamed: #'Smalltalk::LANInterface.initialize()'.
+	method := self model entityNamed: #'Smalltalk.LANInterface.initialize()'.
 	self assert: (method propertyNamed: #timeStamp) equals: (LANInterface compiledMethodAt: #initialize) timeStamp.
-	method := self model entityNamed: #'Smalltalk::LANInterface.originate()'.
+	method := self model entityNamed: #'Smalltalk.LANInterface.originate()'.
 	self assert: (method propertyNamed: #timeStamp) equals: (LANInterface compiledMethodAt: #originate) timeStamp.
-	method := self model entityNamed: #'Smalltalk::LANInterface.nodeList()'.
+	method := self model entityNamed: #'Smalltalk.LANInterface.nodeList()'.
 	self assert: (method propertyNamed: #timeStamp) equals: (LANInterface compiledMethodAt: #nodeList) timeStamp.
-	method := self model entityNamed: #'Smalltalk::LANNode.canOriginate()'.
+	method := self model entityNamed: #'Smalltalk.LANNode.canOriginate()'.
 	self assert: (method propertyNamed: #timeStamp) equals: (LANNode compiledMethodAt: #canOriginate) timeStamp.
-	method := self model entityNamed: #'Smalltalk::LANNode.canOutput()'.
+	method := self model entityNamed: #'Smalltalk.LANNode.canOutput()'.
 	self assert: (method propertyNamed: #timeStamp) equals: (LANNode compiledMethodAt: #canOutput) timeStamp.
-	method := self model entityNamed: #'Smalltalk::LANNode.nextNode()'.
+	method := self model entityNamed: #'Smalltalk.LANNode.nextNode()'.
 	self assert: (method propertyNamed: #timeStamp) equals: (LANNode compiledMethodAt: #nextNode) timeStamp.
-	method := self model entityNamed: #'Smalltalk::LANFileServer.name()'.
+	method := self model entityNamed: #'Smalltalk.LANFileServer.name()'.
 	self assert: (method propertyNamed: #timeStamp) equals: (LANFileServer compiledMethodAt: #name) timeStamp.
-	method := self model entityNamed: #'Smalltalk::LANFileServer.setServerType()'.
+	method := self model entityNamed: #'Smalltalk.LANFileServer.setServerType()'.
 	self assert: (method propertyNamed: #timeStamp) equals: (LANFileServer compiledMethodAt: #setServerType) timeStamp
 ]
 
 { #category : #testing }
 LANFamixPropertiesTest >> testMethodsSimpleProperties [
 	| method |
-	method := self model entityNamed: #'Smalltalk::LANInterface.initialize()'.
+	method := self model entityNamed: #'Smalltalk.LANInterface.initialize()'.
 	self assert: method isInitializer.
 	self deny: method isInternalImplementation.
 	self deny: method isPureAccessor.
 
-	method := self model entityNamed: #'Smalltalk::LANInterface.originate()'.
+	method := self model entityNamed: #'Smalltalk.LANInterface.originate()'.
 	self deny: method isInitializer.
 	self deny: method isInternalImplementation.
 	self deny: method isPureAccessor.
 
-	method := self model entityNamed: #'Smalltalk::LANInterface.nodeList()'.
+	method := self model entityNamed: #'Smalltalk.LANInterface.nodeList()'.
 	self deny: method isInitializer.
 	self assert: method isInternalImplementation.
 	self deny: method isPureAccessor.
@@ -266,14 +266,14 @@ LANFamixPropertiesTest >> testMethodsSimpleProperties [
 
 { #category : #testing }
 LANFamixPropertiesTest >> testNoDuplicatesOfClassVariables [
-	self assert: ((self model entityNamed: #'Smalltalk::LANAbstractDestinationAddress') attributes contains: [ :each | each name = #MySharedVariable ]).
-	self assert: (self model entityNamed: #'Smalltalk::LANAbstractDestinationAddress') attributes first identicalTo: (self model entityNamed: #'Smalltalk::LANAbstractDestinationAddress') attributes last.
-	self assert: (self model entityNamed: #'Smalltalk::LANAbstractDestinationAddress') attributes size equals: 1
+	self assert: ((self model entityNamed: #'Smalltalk.LANAbstractDestinationAddress') attributes contains: [ :each | each name = #MySharedVariable ]).
+	self assert: (self model entityNamed: #'Smalltalk.LANAbstractDestinationAddress') attributes first identicalTo: (self model entityNamed: #'Smalltalk.LANAbstractDestinationAddress') attributes last.
+	self assert: (self model entityNamed: #'Smalltalk.LANAbstractDestinationAddress') attributes size equals: 1
 ]
 
 { #category : #testing }
 LANFamixPropertiesTest >> testOverriddenMethods [
-	self assert: (self model entityNamed: #Smalltalk::LANOutputServer) numberOfMethodsOverridden equals: 2
+	self assert: (self model entityNamed: #'Smalltalk.LANOutputServer') numberOfMethodsOverridden equals: 2
 ]
 
 { #category : #testing }
@@ -284,5 +284,5 @@ LANFamixPropertiesTest >> testPropertyNamed [
 
 { #category : #testing }
 LANFamixPropertiesTest >> workstationClass [
-	^self model entityNamed: #'Smalltalk::LANWorkStation'
+	^self model entityNamed: #'Smalltalk.LANWorkStation'
 ]

--- a/src/Moose-SmalltalkImporter-LAN-Tests/LANImporterTest.class.st
+++ b/src/Moose-SmalltalkImporter-LAN-Tests/LANImporterTest.class.st
@@ -21,7 +21,7 @@ LANImporterTest >> testAccessToPoolVariable [
 	self assert: group size equals: 1.
 	lanEditorAccess := group first.
 	self assert: lanEditorAccess accessor name equals: #accessPoolVariable.
-	self assert: lanEditorAccess accessor mooseName equals: #'Smalltalk::LANNode.accessPoolVariable()'
+	self assert: lanEditorAccess accessor mooseName equals: #'Smalltalk.LANNode.accessPoolVariable()'
 ]
 
 { #category : #tests }
@@ -40,10 +40,10 @@ LANImporterTest >> testAllImplicitVariablesAreStoredInTheModel [
 LANImporterTest >> testClassIsAbstract [ 
 	self
 		assert:
-			(self model entityNamed: #'Smalltalk::LANAbstractDestinationAddress')
+			(self model entityNamed: #'Smalltalk.LANAbstractDestinationAddress')
 				isAbstract.
 	self
-		deny: (self model entityNamed: #'Smalltalk::LANPacket') isAbstract
+		deny: (self model entityNamed: #'Smalltalk.LANPacket') isAbstract
 ]
 
 { #category : #tests }
@@ -56,7 +56,7 @@ LANImporterTest >> testClassNameAndUniqueName [
 	| mseClass |
 	mseClass := self model entityNamed: LANNode mooseName.
 	self assert: mseClass name equals: #LANNode.
-	self assert: mseClass mooseName equals: 'Smalltalk::LANNode'.
+	self assert: mseClass mooseName equals: 'Smalltalk.LANNode'.
 	self assert: mseClass mooseName equals: LANNode mooseName
 ]
 
@@ -134,22 +134,22 @@ LANImporterTest >> testHierarchyRoot [
 
 { #category : #tests }
 LANImporterTest >> testImportCategory [
-	self assert: (self model entityNamed: #'Smalltalk::LANInterface.cancel()') protocol equals: #actions.
-	self assert: (self model entityNamed: #'Smalltalk::LANInterface.addressee()') protocol equals: #aspects
+	self assert: (self model entityNamed: #'Smalltalk.LANInterface.cancel()') protocol equals: #actions.
+	self assert: (self model entityNamed: #'Smalltalk.LANInterface.addressee()') protocol equals: #aspects
 ]
 
 { #category : #tests }
 LANImporterTest >> testImportClassComments [
 	self denyEmpty: (self model allComments select: [ :each | each belongsTo isClass ]).
 	self denyEmpty: (self model allClasses reject: [ :each | each comments isEmpty ]).
-	self denyEmpty: (self model entityNamed: #'Smalltalk::LANInterface') comments
+	self denyEmpty: (self model entityNamed: #'Smalltalk.LANInterface') comments
 ]
 
 { #category : #tests }
 LANImporterTest >> testImportMethodComments [
 	self model allComments do: [ :eachComment | self assert: (self model entityNamed: eachComment belongsTo mooseName) isNotNil ].
-	self assert: (self model entityNamed: #'Smalltalk::LANInterface.accept()') comments size equals: 1.
-	self assert: (self model entityNamed: #'Smalltalk::LANInterface.originate()') comments size equals: 6
+	self assert: (self model entityNamed: #'Smalltalk.LANInterface.accept()') comments size equals: 1.
+	self assert: (self model entityNamed: #'Smalltalk.LANInterface.originate()') comments size equals: 6
 ]
 
 { #category : #tests }
@@ -179,17 +179,17 @@ LANImporterTest >> testInheritsFrom [
 	 
 	self 
 		assert: 
-			((self model entityNamed: #'Smalltalk::LANPrintServer') 
+			((self model entityNamed: #'Smalltalk.LANPrintServer') 
 				inheritsFrom: (self model entityNamed: LANNode mooseName)). 
 	self 
 		assert: 
-			((self model entityNamed: #'Smalltalk::LANPrintServer') 
+			((self model entityNamed: #'Smalltalk.LANPrintServer') 
 				inheritsFrom: 
-					(self model entityNamed: #'Smalltalk::LANOutputServer')). 
+					(self model entityNamed: #'Smalltalk.LANOutputServer')). 
 	self 
 		assert: 
-			((self model entityNamed: #'Smalltalk::LANPrintServer') 
-				inheritsFrom: (self model entityNamed: #'Smalltalk::Model'))
+			((self model entityNamed: #'Smalltalk.LANPrintServer') 
+				inheritsFrom: (self model entityNamed: #'Smalltalk.Model'))
 ]
 
 { #category : #tests }
@@ -214,11 +214,11 @@ LANImporterTest >> testLonely [
 LANImporterTest >> testMethodIsAbstract [
 	self
 		assert:
-			(self model entityNamed: #'Smalltalk::LANOutputServer.output:(Object)')
+			(self model entityNamed: #'Smalltalk.LANOutputServer.output:(Object)')
 				isAbstract.
 	self
 		deny:
-			(self model entityNamed: #'Smalltalk::LANWorkStation.canOriginate()')
+			(self model entityNamed: #'Smalltalk.LANWorkStation.canOriginate()')
 				isAbstract
 ]
 
@@ -239,9 +239,9 @@ LANImporterTest >> testMinimalStateofEntity [
 
 { #category : #tests }
 LANImporterTest >> testMooseName [
-	self assert: LANNode mooseName equals: #Smalltalk::LANNode.
-	self assert: 'Smalltalk::LANNode' mooseName equals: #Smalltalk::LANNode.
-	self assert: LANNode class mooseName equals: #Smalltalk::LANNode_class	"we could also  test here that all the famix entities  understand mooseName but for that we should create model so
+	self assert: LANNode mooseName equals: #'Smalltalk.LANNode'.
+	self assert: 'Smalltalk.LANNode' mooseName equals: #'Smalltalk.LANNode'.
+	self assert: LANNode class mooseName equals: 'Smalltalk.LANNode_class'	"we could also  test here that all the famix entities  understand mooseName but for that we should create model so
 	this is done in LANTest "
 ]
 
@@ -250,11 +250,11 @@ LANImporterTest >> testNameAndUniqueName [
 	| mseClass mseMethod mseAttribute mseGlobalVar mseImplicitVar mseLocalVariable mseFormalParameter transcriptName |
 	mseClass := self model entityNamed: LANNode mooseName.
 	self assert: mseClass name identicalTo: #LANNode.
-	self assert: mseClass mooseName identicalTo: #'Smalltalk::LANNode'.
+	self assert: mseClass mooseName identicalTo: #'Smalltalk.LANNode'.
 	self assert: mseClass mooseName identicalTo: LANNode mooseName.
-	mseMethod := self model entityNamed: #'Smalltalk::LANPacket.printOn:(Object)'.
+	mseMethod := self model entityNamed: #'Smalltalk.LANPacket.printOn:(Object)'.
 	self assert: mseMethod name identicalTo: #printOn:.
-	self assert: mseMethod mooseName identicalTo: #'Smalltalk::LANPacket.printOn:(Object)'.
+	self assert: mseMethod mooseName identicalTo: #'Smalltalk.LANPacket.printOn:(Object)'.
 	self assert: mseMethod signature identicalTo: #'printOn:(Object)'.
 	mseAttribute := self model entityNamed: (LANNode mooseNameOf: 'name') asSymbol.
 	self assert: mseAttribute mooseName identicalTo: (LANNode mooseNameOf: 'name').
@@ -269,9 +269,9 @@ LANImporterTest >> testNameAndUniqueName [
 	mseImplicitVar := self model entityNamed: LANNode mooseName , '.printOn:(Object).super'.
 	self assert: mseImplicitVar name identicalTo: #super.
 	self assert: mseImplicitVar mooseName identicalTo: (LANNode mooseName , '.printOn:(Object).super') asSymbol.
-	mseLocalVariable := self model entityNamed: #'Smalltalk::LANInterface.originate().packet'.
+	mseLocalVariable := self model entityNamed: #'Smalltalk.LANInterface.originate().packet'.
 	self assert: mseLocalVariable name identicalTo: #packet.
-	self assert: mseLocalVariable mooseName identicalTo: #'Smalltalk::LANInterface.originate().packet'.
+	self assert: mseLocalVariable mooseName identicalTo: #'Smalltalk.LANInterface.originate().packet'.
 	mseFormalParameter := self model entityNamed: (LANNode mooseNameOf: 'nextNode:(Object).aNode').
 	self assert: mseFormalParameter name identicalTo: #aNode.
 	self assert: mseFormalParameter mooseName identicalTo: (LANNode mooseNameOf: 'nextNode:(Object).aNode')	"self assert: mseFormalParameter position = 1"
@@ -313,7 +313,7 @@ LANImporterTest >> testPackageReification [
 { #category : #tests }
 LANImporterTest >> testPoolVariablesAreReified [
 	| poolVar |
-	poolVar := self model entityNamed: #'Smalltalk::LANPool.LANEditor'.
+	poolVar := self model entityNamed: #'Smalltalk.LANPool.LANEditor'.
 	self assert: poolVar parentType name equals: #LANPool
 ]
 
@@ -325,8 +325,8 @@ LANImporterTest >> testReferenceModelInEntities [
 { #category : #tests }
 LANImporterTest >> testStubClassesCreation [
 	self deny: (self model entityNamed: LANNode mooseName) isStub.
-	self assert: (self model entityNamed: #'Smalltalk::Object') isStub.
-	self deny: (self model entityNamed: #'Smalltalk::LANFileServer_class') isStub.
+	self assert: (self model entityNamed: #'Smalltalk.Object') isStub.
+	self deny: (self model entityNamed: #'Smalltalk.LANFileServer_class') isStub.
 	self assert: (self model allClasses reject: [ :each | each isStub ]) size equals: 22
 ]
 
@@ -338,5 +338,5 @@ LANImporterTest >> testSubClassHierarchy [
 
 { #category : #tests }
 LANImporterTest >> testSuperClassHierarchy [
-	self assert: (self model entityNamed: #Smalltalk::LANPrintServer) superclassHierarchy size equals: 5
+	self assert: (self model entityNamed: #'Smalltalk.LANPrintServer') superclassHierarchy size equals: 5
 ]

--- a/src/Moose-SmalltalkImporter-LAN-Tests/LANMooseGroupTest.class.st
+++ b/src/Moose-SmalltalkImporter-LAN-Tests/LANMooseGroupTest.class.st
@@ -147,7 +147,7 @@ LANMooseGroupTest >> testIncludesAllOf [
 
 { #category : #tests }
 LANMooseGroupTest >> testMax [
-	self assert: (self model allClasses detectMax: #numberOfMethods) equals: (self model entityNamed: #Smalltalk::LANInterface_class)
+	self assert: (self model allClasses detectMax: #numberOfMethods) equals: (self model entityNamed: #'Smalltalk.LANInterface_class')
 ]
 
 { #category : #tests }

--- a/src/Moose-SmalltalkImporter-LAN-Tests/LANSmalltalkAccessTest.class.st
+++ b/src/Moose-SmalltalkImporter-LAN-Tests/LANSmalltalkAccessTest.class.st
@@ -41,8 +41,8 @@ LANSmalltalkAccessTest >> testWhenMergingClassAndMetaclassAccessWorks [
 	self assert: (model entityNamed: (LANNode >> #accept:) mooseName) compiledMethod equals: LANNode >> #accept:.
 	self assert: (model entityNamed: LANNode mooseName) isInstanceSide.
 	self deny: (model entityNamed: (LANNode >> #accept:) mooseName) isClassSide.
-	self assert: (model entityNamed: #'Smalltalk::LANNode.new()') isClassSide.
+	self assert: (model entityNamed: #'Smalltalk.LANNode.new()') isClassSide.
 	self assert: (model entityNamed: (LANNode >> #accept:) mooseName) smalltalkClass equals: LANNode.
-	self assert: (model entityNamed: #'Smalltalk::LANNode.new()') smalltalkClass equals: LANNode class.
-	self assert: (model entityNamed: #'Smalltalk::LANNode.new()') compiledMethod equals: LANNode class >> #new
+	self assert: (model entityNamed: #'Smalltalk.LANNode.new()') smalltalkClass equals: LANNode class.
+	self assert: (model entityNamed: #'Smalltalk.LANNode.new()') compiledMethod equals: LANNode class >> #new
 ]


### PR DESCRIPTION
Fix #917