### PR TITLE
Removing the use of TSourceAnchor trait by StPharoEntitySourceAnchor.

### DIFF
--- a/src/Famix-PharoSmalltalk-Entities/FamixStPharoEntitySourceAnchor.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStPharoEntitySourceAnchor.class.st
@@ -13,8 +13,6 @@
 Class {
 	#name : #FamixStPharoEntitySourceAnchor,
 	#superclass : #FamixStSourceAnchor,
-	#traits : 'FamixTSourceAnchor',
-	#classTraits : 'FamixTSourceAnchor classTrait',
 	#instVars : [
 		'#pharoEntity => WeakSlot'
 	],

--- a/src/Famix-PharoSmalltalk-Generator/FamixPharoSmalltalkGenerator.class.st
+++ b/src/Famix-PharoSmalltalk-Generator/FamixPharoSmalltalkGenerator.class.st
@@ -147,7 +147,7 @@ FamixPharoSmalltalkGenerator >> defineHierarchy [
 	reference --|> #TReference.
 
 	pharoEntitySourceAnchor --|> sourceAnchor.
-	pharoEntitySourceAnchor --|> #TSourceAnchor.
+
 
 	unknownVariable --|> namedEntity.
 	unknownVariable --|> #TUnknownVariable.


### PR DESCRIPTION
Fix #833