### PR TITLE
Remove some deprecated methods

### DIFF
--- a/src/Moose-Query-Extensions/TEntityMetaLevelDependency.extension.st
+++ b/src/Moose-Query-Extensions/TEntityMetaLevelDependency.extension.st
@@ -1,36 +1,8 @@
 Extension { #name : #TEntityMetaLevelDependency }
 
 { #category : #'*Moose-Query-Extensions' }
-TEntityMetaLevelDependency >> queryAllIncomingAssociations [
-
-	"Be careful while using me. I hardcode the associations I should query. Users can override me if they want to query only certain types of association for performance reasons. If you prefere to be sure of your results you should use #queryAllIncoming instead."
-
-	self
-		deprecated: 'Use #queryAllOutgoing instead'
-		transformWith:'``@object queryAllIncomingAssociations' -> '``@object queryAllIncoming'.
-
-	^ self queryStaticIncomingAssociations
-		  addAll: self queryAllIncomingInvocations;
-		  yourself
-]
-
-{ #category : #'*Moose-Query-Extensions' }
 TEntityMetaLevelDependency >> queryAllIncomingInvocations [
 	^ self queryIncoming: FamixTInvocation
-]
-
-{ #category : #'*Moose-Query-Extensions' }
-TEntityMetaLevelDependency >> queryAllOutgoingAssociations [
-
-	"Be careful while using me. I hardcode the associations I should query. Users can override me if they want to query only certain types of association for performance reasons. If you prefere to be sure of your results you should use #queryAllOutgoing instead."
-
-	self
-		deprecated: 'Use #queryAllOutgoing instead'
-		transformWith:'``@object queryAllOutgoingAssociations' -> '``@object queryAllOutgoing'.
-
-	^ self queryStaticOutgoingAssociations
-		  addAll: self queryAllOutgoingInvocations;
-		  yourself
 ]
 
 { #category : #'*Moose-Query-Extensions' }
@@ -69,52 +41,8 @@ TEntityMetaLevelDependency >> queryOutgoingReferences [
 ]
 
 { #category : #'*Moose-Query-Extensions' }
-TEntityMetaLevelDependency >> queryStaticIncomingAssociations [
-self
-		deprecated: 'Use #queryAllIncoming instead'
-		transformWith:'``@object queryStaticIncomingAssociations' -> '``@object queryAllIncoming'.
-	^ self queryIncomingAccesses
-		addAll: self queryIncomingReferences;
-		yourself
-]
-
-{ #category : #'*Moose-Query-Extensions' }
-TEntityMetaLevelDependency >> queryStaticOutgoingAssociations [
-
-	self
-		deprecated: 'Use #queryAllOutgoing instead'
-		transformWith:'``@object queryStaticOutgoingAssociations' -> '``@object queryAllOutgoing'.
-		
-	^ self queryOutgoingAccesses
-		addAll: self queryOutgoingReferences;
-		yourself
-]
-
-{ #category : #'*Moose-Query-Extensions' }
-TEntityMetaLevelDependency >> querySureIncomingAssociations [
-self
-		deprecated: 'Use #queryAllOutgoing instead'
-		transformWith:'``@object querySureIncomingAssociations' -> '``@object queryAllIncoming'.
-	^ self queryStaticIncomingAssociations
-		addAll: self querySureIncomingInvocations;
-		yourself
-]
-
-{ #category : #'*Moose-Query-Extensions' }
 TEntityMetaLevelDependency >> querySureIncomingInvocations [
 	^ self queryAllIncomingInvocations select: [ :invo | invo isASureInvocation ]
-]
-
-{ #category : #'*Moose-Query-Extensions' }
-TEntityMetaLevelDependency >> querySureOutgoingAssociations [
-
-	self
-		deprecated: 'Use #queryAllOutgoing instead'
-		transformWith: '``@object querySureOutgoingAssociations'
-			-> '``@object queryAllOutgoing'.
-	^ self queryAllOutgoing
-		  addAll: self querySureOutgoingInvocations;
-		  yourself
 ]
 
 { #category : #'*Moose-Query-Extensions' }


### PR DESCRIPTION
Some deprecated methods were not added to the deprecated package and are here since a long time. 

Since we marked the released commit of Moose 12 I propose to remove them during the early Moose 13