### PR TITLE
Fix bug in generation of testing methods in remote entities

### DIFF
--- a/src/Famix-MetamodelBuilder-Core/FamixMetamodelBuilder.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FamixMetamodelBuilder.class.st
@@ -278,11 +278,12 @@ FamixMetamodelBuilder >> generateTestingMethodsOfRemoteEntities [
 					(entitiesWithRemoteSuperclasses includes: class) ifTrue: [
 							(self shouldGeneratorTestingMethodsOf: class) ifTrue: [
 									selectors do: [ :selector |
-											(class classGeneralization realClass includesSelector: selector) ifFalse: [
-													self environment
-														compile: ('{1}\\	<generated>\	^ false' withCRs format: { selector })
-														in: class classGeneralization realClass
-														classified: '*' , self configuration packageName ] ] ] ] ] ]
+											class classGeneralization ifNotNil: [ :super |
+													(super realClass includesSelector: selector) ifFalse: [
+															self environment
+																compile: ('{1}\\	<generated>\	^ false' withCRs format: { selector })
+																in: class classGeneralization realClass
+																classified: '*' , self configuration packageName ] ] ] ] ] ] ]
 ]
 
 { #category : #accessing }

--- a/src/Famix-MetamodelBuilder-Core/FamixMetamodelBuilder.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FamixMetamodelBuilder.class.st
@@ -95,7 +95,11 @@ FamixMetamodelBuilder >> allSubBuilders [
 { #category : #accessing }
 FamixMetamodelBuilder >> apply [
 
-	self environment apply
+	self environment apply.
+
+	"This next line should not be here... 
+	This feature should fill a ring model that should be manipulate by the apply above to check if we need the code, to be able to clean it and other mechanisms. But we do not yet support to create extension methods like this and I don't have the time to implement it for now. So, breaking layers we generate the extensions after we generated everything else in the 'right' way."
+	self generateTestingMethodsOfRemoteEntities
 ]
 
 { #category : #accessing }
@@ -261,6 +265,24 @@ FamixMetamodelBuilder >> generateRemotes [
 	self classes do: [ :each | each generateRemotes ].
 
 	self apply
+]
+
+{ #category : #generating }
+FamixMetamodelBuilder >> generateTestingMethodsOfRemoteEntities [
+
+	| entitiesWithRemoteSuperclasses |
+	entitiesWithRemoteSuperclasses := self classes reject: [ :class | self classes includes: class classGeneralization ].
+
+	self testingSelectorsMapping keysAndValuesDo: [ :class :selectors |
+			selectors ifNotEmpty: [
+					(entitiesWithRemoteSuperclasses includes: class) ifTrue: [
+							(self shouldGeneratorTestingMethodsOf: class) ifTrue: [
+									selectors do: [ :selector |
+											(class classGeneralization realClass includesSelector: selector) ifFalse: [
+													self environment
+														compile: ('{1}\\	<generated>\	^ false' withCRs format: { selector })
+														in: class classGeneralization realClass
+														classified: '*' , self configuration packageName ] ] ] ] ] ]
 ]
 
 { #category : #accessing }
@@ -554,6 +576,15 @@ FamixMetamodelBuilder >> shouldGenerateModel [
 
 	^ self behaviorsCount > 0 or: [
 		  self relations isNotEmpty or: [ self subBuilders isNotEmpty ] ]
+]
+
+{ #category : #asserting }
+FamixMetamodelBuilder >> shouldGeneratorTestingMethodsOf: aClass [
+	"In case a testing selector is relatif to a Trait that is not used in the current MM, then we do not need to generate the testing selector."
+
+	aClass isMetamodelTrait ifFalse: [ ^ true ].
+
+	^ self classes anySatisfy: [ :class | class allTransitiveTraits includes: aClass ]
 ]
 
 { #category : #accessing }

--- a/src/Famix-MetamodelBuilder-Core/FmxMBClass.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxMBClass.class.st
@@ -197,16 +197,15 @@ FmxMBClass >> generateRootMetamodelMethodIn: aClass [
 
 { #category : #'generating-methods' }
 FmxMBClass >> generateTestingMethodsIn: aClass [
-	self isRoot
-		ifTrue: [ builder testingSelectorsMapping
-				keysAndValuesDo: [ :concernedClass :selectors | 
-					"In case a testing selector is relatif to a Trait that is not used in the current MM, then we do not need to generate the testing selector."
-					(concernedClass isMetamodelTrait and: [ builder classes noneSatisfy: [ :class | class allTransitiveTraits includes: concernedClass ] ])
-						ifFalse: [ selectors
-								do: [ :sel | 
+
+	self isRoot ifTrue: [
+			builder testingSelectorsMapping keysAndValuesDo: [ :concernedClass :selectors |
+					(builder shouldGeneratorTestingMethodsOf: concernedClass) ifTrue: [
+							selectors do: [ :sel |
 									| selectorsFromTraits |
 									selectorsFromTraits := self traitGeneralizations flatCollect: #testingSelectors.
-									(selectorsFromTraits includes: sel) ifFalse: [ aClass instanceSide compile: ('{1}\\	<generated>\	^ false' withCRs format: {sel}) classified: #testing ] ] ] ] ].
+									(selectorsFromTraits includes: sel) ifFalse: [
+										aClass instanceSide compile: ('{1}\\	<generated>\	^ false' withCRs format: { sel }) classified: #testing ] ] ] ] ].
 
 	super generateTestingMethodsIn: aClass
 ]

--- a/src/Famix-MetamodelBuilder-Tests/FamixGenerateRemoteAccessorTestResource.class.st
+++ b/src/Famix-MetamodelBuilder-Tests/FamixGenerateRemoteAccessorTestResource.class.st
@@ -22,7 +22,7 @@ Class {
 		'entityA',
 		'entityB'
 	],
-	#category : #'Famix-MetamodelBuilder-Tests'
+	#category : #'Famix-MetamodelBuilder-Tests-Helpers'
 }
 
 { #category : #running }

--- a/src/Famix-MetamodelBuilder-Tests/FamixGeneratorRootEntityTest.class.st
+++ b/src/Famix-MetamodelBuilder-Tests/FamixGeneratorRootEntityTest.class.st
@@ -1,0 +1,81 @@
+"
+I am testing how a generator behave when we redefine the root entity.
+
+We have 3 generators:
+- A with an EntityA inheriting from FmxRootEntityAEntity
+- B with an EntityB inheriting from FmxRootEntityBEntity
+- C with EntityC inheriting from FmxRootEntityAEntity and EntityD inheriting from FmxRootEntityBEntity
+
+The generator C will not have a FmxRootEntityCEntity and testing methods should go on FmxRootEntityAEntity and FmxRootEntityBEntity as extensions.
+"
+Class {
+	#name : #FamixGeneratorRootEntityTest,
+	#superclass : #TestCase,
+	#category : #'Famix-MetamodelBuilder-Tests-Tests'
+}
+
+{ #category : #accessing }
+FamixGeneratorRootEntityTest >> classNamed: aSymbol [
+
+	^ self class environment at: aSymbol ifAbsent: [ self fail: 'The class ' , aSymbol , ' does not exist in the system.' ]
+]
+
+{ #category : #helpers }
+FamixGeneratorRootEntityTest >> generators [
+
+	^ {
+		  FamixRemoteRootEntityGeneratorA.
+		  FamixRemoteRootEntityGeneratorB.
+		  FamixRemoteRootEntityGeneratorC }
+]
+
+{ #category : #running }
+FamixGeneratorRootEntityTest >> setUp [
+	super setUp.
+	self generators do: #generate
+]
+
+{ #category : #running }
+FamixGeneratorRootEntityTest >> tearDown [
+
+	self generators do: [ :generator | self packageOrganizer removePackage: generator packageName ].
+	super tearDown
+]
+
+{ #category : #tests }
+FamixGeneratorRootEntityTest >> testEntityClasses [
+
+	self assert: (self classNamed: #FmxRootEntityAEntity) isNotNil.
+	self assert: (self classNamed: #FmxRootEntityBEntity) isNotNil.
+	self class environment
+		at: #FmxRootEntityCEntity
+		ifPresent: [ self fail: 'We should not have an entity class for the Generator C because all concrete classes inherit from remote entities.' ]
+]
+
+{ #category : #tests }
+FamixGeneratorRootEntityTest >> testTestingMethodsOfGeneratorAAndB [
+
+	self assert: ((self classNamed: #FmxRootEntityAEntity) includesSelector: #isEntityA).
+	self deny: (self classNamed: #FmxRootEntityAEntity) new isEntityA.
+	self assert: ((self classNamed: #FmxRootEntityAEntityA) includesSelector: #isEntityA).
+	self assert: (self classNamed: #FmxRootEntityAEntityA) new isEntityA.
+
+	self assert: ((self classNamed: #FmxRootEntityBEntity) includesSelector: #isEntityB).
+	self deny: (self classNamed: #FmxRootEntityBEntity) new isEntityB.
+	self assert: ((self classNamed: #FmxRootEntityBEntityB) includesSelector: #isEntityB).
+	self assert: (self classNamed: #FmxRootEntityBEntityB) new isEntityB
+]
+
+{ #category : #tests }
+FamixGeneratorRootEntityTest >> testTestingMethodsOfGeneratorC [
+
+	self assert: ((self classNamed: #FmxRootEntityAEntity) includesSelector: #isEntityC).
+	self deny: ((self classNamed: #FmxRootEntityAEntity) includesSelector: #isEntityD).
+	self deny: ((self classNamed: #FmxRootEntityBEntity) includesSelector: #isEntityC).
+	self assert: ((self classNamed: #FmxRootEntityBEntity) includesSelector: #isEntityD).
+
+	self assert: ((self classNamed: #FmxRootEntityAEntity) >> #isEntityC) isExtension.
+	self assert: ((self classNamed: #FmxRootEntityAEntity) >> #isEntityC) package name equals: 'Famix-MetamodelBuilder-Tests-RootEntityC'.
+	self assert: ((self classNamed: #FmxRootEntityBEntity) >> #isEntityD) isExtension.
+	self assert: ((self classNamed: #FmxRootEntityBEntity) >> #isEntityD) package name equals: 'Famix-MetamodelBuilder-Tests-RootEntityC'
+]

--- a/src/Famix-MetamodelBuilder-Tests/FamixMetamodelCleaningStrategiesTestGenerator.class.st
+++ b/src/Famix-MetamodelBuilder-Tests/FamixMetamodelCleaningStrategiesTestGenerator.class.st
@@ -1,6 +1,6 @@
 Class {
 	#name : #FamixMetamodelCleaningStrategiesTestGenerator,
-	#superclass : #FamixMetamodelGenerator,
+	#superclass : #FamixTestGenerator,
 	#instVars : [
 		'fmx',
 		'tOneTrait',
@@ -10,11 +10,6 @@ Class {
 	],
 	#category : #'Famix-MetamodelBuilder-Tests-Helpers'
 }
-
-{ #category : #testing }
-FamixMetamodelCleaningStrategiesTestGenerator class >> isRealMetamodel [
-	^ false
-]
 
 { #category : #accessing }
 FamixMetamodelCleaningStrategiesTestGenerator class >> packageName [

--- a/src/Famix-MetamodelBuilder-Tests/FamixMetamodelGenerateRemoteAccessorTestGeneratorA.class.st
+++ b/src/Famix-MetamodelBuilder-Tests/FamixMetamodelGenerateRemoteAccessorTestGeneratorA.class.st
@@ -1,16 +1,11 @@
 Class {
 	#name : #FamixMetamodelGenerateRemoteAccessorTestGeneratorA,
-	#superclass : #FamixMetamodelGenerator,
+	#superclass : #FamixTestGenerator,
 	#instVars : [
 		'fmx'
 	],
 	#category : #'Famix-MetamodelBuilder-Tests-GeneratorRessources'
 }
-
-{ #category : #testing }
-FamixMetamodelGenerateRemoteAccessorTestGeneratorA class >> isRealMetamodel [
-	^ false
-]
 
 { #category : #accessing }
 FamixMetamodelGenerateRemoteAccessorTestGeneratorA class >> packageName [

--- a/src/Famix-MetamodelBuilder-Tests/FamixMetamodelGenerateRemoteAccessorTestGeneratorAB.class.st
+++ b/src/Famix-MetamodelBuilder-Tests/FamixMetamodelGenerateRemoteAccessorTestGeneratorAB.class.st
@@ -1,17 +1,12 @@
 Class {
 	#name : #FamixMetamodelGenerateRemoteAccessorTestGeneratorAB,
-	#superclass : #FamixMetamodelGenerator,
+	#superclass : #FamixTestGenerator,
 	#instVars : [
 		'entityA',
 		'entityB'
 	],
 	#category : #'Famix-MetamodelBuilder-Tests-GeneratorRessources'
 }
-
-{ #category : #testing }
-FamixMetamodelGenerateRemoteAccessorTestGeneratorAB class >> isRealMetamodel [
-	^ false
-]
 
 { #category : #accessing }
 FamixMetamodelGenerateRemoteAccessorTestGeneratorAB class >> packageName [

--- a/src/Famix-MetamodelBuilder-Tests/FamixMetamodelGenerateRemoteAccessorTestGeneratorB.class.st
+++ b/src/Famix-MetamodelBuilder-Tests/FamixMetamodelGenerateRemoteAccessorTestGeneratorB.class.st
@@ -1,16 +1,11 @@
 Class {
 	#name : #FamixMetamodelGenerateRemoteAccessorTestGeneratorB,
-	#superclass : #FamixMetamodelGenerator,
+	#superclass : #FamixTestGenerator,
 	#instVars : [
 		'fmx'
 	],
 	#category : #'Famix-MetamodelBuilder-Tests-GeneratorRessources'
 }
-
-{ #category : #testing }
-FamixMetamodelGenerateRemoteAccessorTestGeneratorB class >> isRealMetamodel [
-	^ false
-]
 
 { #category : #accessing }
 FamixMetamodelGenerateRemoteAccessorTestGeneratorB class >> packageName [

--- a/src/Famix-MetamodelBuilder-Tests/FamixMetamodelGenerateRemoteAccessorTraitTestGeneratorA.class.st
+++ b/src/Famix-MetamodelBuilder-Tests/FamixMetamodelGenerateRemoteAccessorTraitTestGeneratorA.class.st
@@ -1,16 +1,11 @@
 Class {
 	#name : #FamixMetamodelGenerateRemoteAccessorTraitTestGeneratorA,
-	#superclass : #FamixMetamodelGenerator,
+	#superclass : #FamixTestGenerator,
 	#instVars : [
 		'fmx'
 	],
 	#category : #'Famix-MetamodelBuilder-Tests-GeneratorRessources'
 }
-
-{ #category : #testing }
-FamixMetamodelGenerateRemoteAccessorTraitTestGeneratorA class >> isRealMetamodel [
-	^ false
-]
 
 { #category : #accessing }
 FamixMetamodelGenerateRemoteAccessorTraitTestGeneratorA class >> packageName [

--- a/src/Famix-MetamodelBuilder-Tests/FamixMetamodelGenerateRemoteAccessorTraitTestGeneratorB.class.st
+++ b/src/Famix-MetamodelBuilder-Tests/FamixMetamodelGenerateRemoteAccessorTraitTestGeneratorB.class.st
@@ -1,6 +1,6 @@
 Class {
 	#name : #FamixMetamodelGenerateRemoteAccessorTraitTestGeneratorB,
-	#superclass : #FamixMetamodelGenerator,
+	#superclass : #FamixTestGenerator,
 	#instVars : [
 		'traitB',
 		'traitA',
@@ -9,11 +9,6 @@ Class {
 	],
 	#category : #'Famix-MetamodelBuilder-Tests-GeneratorRessources'
 }
-
-{ #category : #testing }
-FamixMetamodelGenerateRemoteAccessorTraitTestGeneratorB class >> isRealMetamodel [
-	^ false
-]
 
 { #category : #accessing }
 FamixMetamodelGenerateRemoteAccessorTraitTestGeneratorB class >> packageName [

--- a/src/Famix-MetamodelBuilder-Tests/FamixRemoteRootEntityGeneratorA.class.st
+++ b/src/Famix-MetamodelBuilder-Tests/FamixRemoteRootEntityGeneratorA.class.st
@@ -1,0 +1,30 @@
+Class {
+	#name : #FamixRemoteRootEntityGeneratorA,
+	#superclass : #FamixTestGenerator,
+	#instVars : [
+		'fmx'
+	],
+	#category : #'Famix-MetamodelBuilder-Tests-GeneratorRessources'
+}
+
+{ #category : #accessing }
+FamixRemoteRootEntityGeneratorA class >> packageName [
+
+	<ignoreForCoverage>
+	^ 'Famix-MetamodelBuilder-Tests-RootEntityA'
+]
+
+{ #category : #accessing }
+FamixRemoteRootEntityGeneratorA class >> prefix [
+
+	<ignoreForCoverage>
+	^ #FmxRootEntityA
+]
+
+{ #category : #definition }
+FamixRemoteRootEntityGeneratorA >> defineClasses [
+
+	super defineClasses.
+	fmx := builder newClassNamed: #EntityA.
+	fmx withTesting
+]

--- a/src/Famix-MetamodelBuilder-Tests/FamixRemoteRootEntityGeneratorB.class.st
+++ b/src/Famix-MetamodelBuilder-Tests/FamixRemoteRootEntityGeneratorB.class.st
@@ -1,0 +1,30 @@
+Class {
+	#name : #FamixRemoteRootEntityGeneratorB,
+	#superclass : #FamixTestGenerator,
+	#instVars : [
+		'fmx'
+	],
+	#category : #'Famix-MetamodelBuilder-Tests-GeneratorRessources'
+}
+
+{ #category : #accessing }
+FamixRemoteRootEntityGeneratorB class >> packageName [
+
+	<ignoreForCoverage>
+	^ 'Famix-MetamodelBuilder-Tests-RootEntityB'
+]
+
+{ #category : #accessing }
+FamixRemoteRootEntityGeneratorB class >> prefix [
+
+	<ignoreForCoverage>
+	^ #FmxRootEntityB
+]
+
+{ #category : #definition }
+FamixRemoteRootEntityGeneratorB >> defineClasses [
+
+	super defineClasses.
+	fmx := builder newClassNamed: #EntityB.
+	fmx withTesting
+]

--- a/src/Famix-MetamodelBuilder-Tests/FamixRemoteRootEntityGeneratorC.class.st
+++ b/src/Famix-MetamodelBuilder-Tests/FamixRemoteRootEntityGeneratorC.class.st
@@ -1,0 +1,54 @@
+Class {
+	#name : #FamixRemoteRootEntityGeneratorC,
+	#superclass : #FamixTestGenerator,
+	#instVars : [
+		'fmx',
+		'fmx2',
+		'entityA',
+		'entityB'
+	],
+	#category : #'Famix-MetamodelBuilder-Tests-GeneratorRessources'
+}
+
+{ #category : #accessing }
+FamixRemoteRootEntityGeneratorC class >> packageName [
+
+	<ignoreForCoverage>
+	^ 'Famix-MetamodelBuilder-Tests-RootEntityC'
+]
+
+{ #category : #accessing }
+FamixRemoteRootEntityGeneratorC class >> prefix [
+
+	<ignoreForCoverage>
+	^ #FmxRootEntityC
+]
+
+{ #category : #accessing }
+FamixRemoteRootEntityGeneratorC class >> submetamodels [
+
+	^ {
+		  FamixRemoteRootEntityGeneratorA.
+		  FamixRemoteRootEntityGeneratorB }
+]
+
+{ #category : #definition }
+FamixRemoteRootEntityGeneratorC >> defineClasses [
+	super defineClasses.
+	fmx := builder newClassNamed: #EntityC.
+	fmx withTesting.
+	fmx2 := builder newClassNamed: #EntityD.
+	fmx2 withTesting.
+	
+	entityA := self remoteEntity: #Entity withPrefix: #FmxRootEntityA.
+	entityB := self remoteEntity: #Entity withPrefix: #FmxRootEntityB.
+]
+
+{ #category : #definition }
+FamixRemoteRootEntityGeneratorC >> defineHierarchy [
+
+	super defineHierarchy.
+
+	fmx --|> entityA.
+	fmx2 --|> entityB
+]

--- a/src/Famix-MetamodelBuilder-Tests/FamixTestGenerator.class.st
+++ b/src/Famix-MetamodelBuilder-Tests/FamixTestGenerator.class.st
@@ -1,0 +1,16 @@
+Class {
+	#name : #FamixTestGenerator,
+	#superclass : #FamixMetamodelGenerator,
+	#category : #'Famix-MetamodelBuilder-Tests-GeneratorRessources'
+}
+
+{ #category : #testing }
+FamixTestGenerator class >> isAbstract [
+
+	^ self = FamixTestGenerator
+]
+
+{ #category : #testing }
+FamixTestGenerator class >> isRealMetamodel [
+	^ false
+]

--- a/src/Famix-MetamodelBuilder-Tests/FmxMBBehaviorTest.class.st
+++ b/src/Famix-MetamodelBuilder-Tests/FmxMBBehaviorTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #FmxMBBehaviorTest,
 	#superclass : #FmxMBTestCase,
-	#category : #'Famix-MetamodelBuilder-Tests'
+	#category : #'Famix-MetamodelBuilder-Tests-Tests'
 }
 
 { #category : #testing }

--- a/src/Famix-MetamodelBuilder-Tests/FmxMBBuilderRelationTest.class.st
+++ b/src/Famix-MetamodelBuilder-Tests/FmxMBBuilderRelationTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #FmxMBBuilderRelationTest,
 	#superclass : #FmxMBTestCase,
-	#category : #'Famix-MetamodelBuilder-Tests'
+	#category : #'Famix-MetamodelBuilder-Tests-Tests'
 }
 
 { #category : #initialization }

--- a/src/Famix-MetamodelBuilder-Tests/FmxMBBuilderTest.class.st
+++ b/src/Famix-MetamodelBuilder-Tests/FmxMBBuilderTest.class.st
@@ -12,7 +12,7 @@ testRunner collectCoverageFor: (methods collect: #asRingDefinition)
 Class {
 	#name : #FmxMBBuilderTest,
 	#superclass : #FmxMBTestCase,
-	#category : #'Famix-MetamodelBuilder-Tests'
+	#category : #'Famix-MetamodelBuilder-Tests-Tests'
 }
 
 { #category : #tests }

--- a/src/Famix-MetamodelBuilder-Tests/FmxMBClassGeneralizationsTest.class.st
+++ b/src/Famix-MetamodelBuilder-Tests/FmxMBClassGeneralizationsTest.class.st
@@ -6,7 +6,7 @@ Class {
 		'behavior',
 		'class'
 	],
-	#category : #'Famix-MetamodelBuilder-Tests'
+	#category : #'Famix-MetamodelBuilder-Tests-Tests'
 }
 
 { #category : #running }

--- a/src/Famix-MetamodelBuilder-Tests/FmxMBClassTest.class.st
+++ b/src/Famix-MetamodelBuilder-Tests/FmxMBClassTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #FmxMBClassTest,
 	#superclass : #FmxMBBehaviorTest,
-	#category : #'Famix-MetamodelBuilder-Tests'
+	#category : #'Famix-MetamodelBuilder-Tests-Tests'
 }
 
 { #category : #accessing }

--- a/src/Famix-MetamodelBuilder-Tests/FmxMBConfigurationTest.class.st
+++ b/src/Famix-MetamodelBuilder-Tests/FmxMBConfigurationTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #FmxMBConfigurationTest,
 	#superclass : #FmxMBTestCase,
-	#category : #'Famix-MetamodelBuilder-Tests'
+	#category : #'Famix-MetamodelBuilder-Tests-Tests'
 }
 
 { #category : #tests }

--- a/src/Famix-MetamodelBuilder-Tests/FmxMBGeneratorCleaningStrategyTest.class.st
+++ b/src/Famix-MetamodelBuilder-Tests/FmxMBGeneratorCleaningStrategyTest.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'generator'
 	],
-	#category : #'Famix-MetamodelBuilder-Tests'
+	#category : #'Famix-MetamodelBuilder-Tests-Tests'
 }
 
 { #category : #accessing }

--- a/src/Famix-MetamodelBuilder-Tests/FmxMBGeneratorRemoteAccessorTest.class.st
+++ b/src/Famix-MetamodelBuilder-Tests/FmxMBGeneratorRemoteAccessorTest.class.st
@@ -6,7 +6,7 @@ Class {
 		'entityA',
 		'entityB'
 	],
-	#category : #'Famix-MetamodelBuilder-Tests'
+	#category : #'Famix-MetamodelBuilder-Tests-Tests'
 }
 
 { #category : #accessing }

--- a/src/Famix-MetamodelBuilder-Tests/FmxMBGeneratorTest.class.st
+++ b/src/Famix-MetamodelBuilder-Tests/FmxMBGeneratorTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #FmxMBGeneratorTest,
 	#superclass : #FmxMBTestCase,
-	#category : #'Famix-MetamodelBuilder-Tests'
+	#category : #'Famix-MetamodelBuilder-Tests-Tests'
 }
 
 { #category : #tests }

--- a/src/Famix-MetamodelBuilder-Tests/FmxMBImportingContextTest.class.st
+++ b/src/Famix-MetamodelBuilder-Tests/FmxMBImportingContextTest.class.st
@@ -10,7 +10,7 @@ Class {
 		'method',
 		'generatedContext'
 	],
-	#category : #'Famix-MetamodelBuilder-Tests'
+	#category : #'Famix-MetamodelBuilder-Tests-Tests'
 }
 
 { #category : #running }

--- a/src/Famix-MetamodelBuilder-Tests/FmxMBNavigationGroupTest.class.st
+++ b/src/Famix-MetamodelBuilder-Tests/FmxMBNavigationGroupTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #FmxMBNavigationGroupTest,
 	#superclass : #FmxMBTestCase,
-	#category : #'Famix-MetamodelBuilder-Tests'
+	#category : #'Famix-MetamodelBuilder-Tests-Tests'
 }
 
 { #category : #tests }

--- a/src/Famix-MetamodelBuilder-Tests/FmxMBPropertyTest.class.st
+++ b/src/Famix-MetamodelBuilder-Tests/FmxMBPropertyTest.class.st
@@ -1,5 +1,5 @@
 Class {
 	#name : #FmxMBPropertyTest,
 	#superclass : #FmxMBTestCase,
-	#category : #'Famix-MetamodelBuilder-Tests'
+	#category : #'Famix-MetamodelBuilder-Tests-Tests'
 }

--- a/src/Famix-MetamodelBuilder-Tests/FmxMBRelationSideTest.class.st
+++ b/src/Famix-MetamodelBuilder-Tests/FmxMBRelationSideTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #FmxMBRelationSideTest,
 	#superclass : #FmxMBPropertyTest,
-	#category : #'Famix-MetamodelBuilder-Tests'
+	#category : #'Famix-MetamodelBuilder-Tests-Tests'
 }
 
 { #category : #tests }

--- a/src/Famix-MetamodelBuilder-Tests/FmxMBRelationSidesCombinationsTest.class.st
+++ b/src/Famix-MetamodelBuilder-Tests/FmxMBRelationSidesCombinationsTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #FmxMBRelationSidesCombinationsTest,
 	#superclass : #FmxMBTestCase,
-	#category : #'Famix-MetamodelBuilder-Tests'
+	#category : #'Famix-MetamodelBuilder-Tests-Tests'
 }
 
 { #category : #tests }

--- a/src/Famix-MetamodelBuilder-Tests/FmxMBRelationTest.class.st
+++ b/src/Famix-MetamodelBuilder-Tests/FmxMBRelationTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #FmxMBRelationTest,
 	#superclass : #FmxMBPropertyTest,
-	#category : #'Famix-MetamodelBuilder-Tests'
+	#category : #'Famix-MetamodelBuilder-Tests-Tests'
 }
 
 { #category : #tests }

--- a/src/Famix-MetamodelBuilder-Tests/FmxMBRelationsGenerationTest.class.st
+++ b/src/Famix-MetamodelBuilder-Tests/FmxMBRelationsGenerationTest.class.st
@@ -7,7 +7,7 @@ Class {
 		'generatedAccess',
 		'generatedVariable'
 	],
-	#category : #'Famix-MetamodelBuilder-Tests'
+	#category : #'Famix-MetamodelBuilder-Tests-Tests'
 }
 
 { #category : #utilities }

--- a/src/Famix-MetamodelBuilder-Tests/FmxMBTestCase.class.st
+++ b/src/Famix-MetamodelBuilder-Tests/FmxMBTestCase.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'builder'
 	],
-	#category : #'Famix-MetamodelBuilder-Tests'
+	#category : #'Famix-MetamodelBuilder-Tests-Tests'
 }
 
 { #category : #running }

--- a/src/Famix-MetamodelBuilder-Tests/FmxMBTestingMethodsTest.class.st
+++ b/src/Famix-MetamodelBuilder-Tests/FmxMBTestingMethodsTest.class.st
@@ -13,7 +13,7 @@ Class {
 		'traitedRoot',
 		'generatedTraitedRoot'
 	],
-	#category : #'Famix-MetamodelBuilder-Tests'
+	#category : #'Famix-MetamodelBuilder-Tests-Tests'
 }
 
 { #category : #running }

--- a/src/Famix-MetamodelBuilder-Tests/FmxMBTraitTest.class.st
+++ b/src/Famix-MetamodelBuilder-Tests/FmxMBTraitTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #FmxMBTraitTest,
 	#superclass : #FmxMBBehaviorTest,
-	#category : #'Famix-MetamodelBuilder-Tests'
+	#category : #'Famix-MetamodelBuilder-Tests-Tests'
 }
 
 { #category : #accessing }

--- a/src/Famix-MetamodelBuilder-Tests/FmxMBTypedPropertyTest.class.st
+++ b/src/Famix-MetamodelBuilder-Tests/FmxMBTypedPropertyTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #FmxMBTypedPropertyTest,
 	#superclass : #FmxMBPropertyTest,
-	#category : #'Famix-MetamodelBuilder-Tests'
+	#category : #'Famix-MetamodelBuilder-Tests-Tests'
 }
 
 { #category : #tests }


### PR DESCRIPTION
It is possible in a MM to inherit from a remote entity. If that is the case, the testing methods are not generated.

This adds tests for this scenario and is proposing a fix.

The fix is not clean. It breaks the layers of generation. 
We should configure a builder that generates a ring environment. This environment produces a list of changes that we use for example to clean the code, avoid recompilations and other features. And the changes are producing the real actions on the system.

But this system does not yet support extension methods on other MM. So extensions are added "manually" from the builder to the real model. This bypasses all other features of the builder. So we should fix this in the future