### PR TITLE
Generators: Ban hierarchy definition of remote entities

### DIFF
--- a/src/Famix-MetamodelBuilder-Core/FmxMBBehavior.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxMBBehavior.class.st
@@ -244,9 +244,14 @@ FmxMBBehavior >> fullName [
 
 { #category : #accessing }
 FmxMBBehavior >> generalization: anObject [
+
+	self isRemote ifTrue: [ self error: 'It is not possible to add a generalization to a remote entity.' ].
 	^ anObject isSymbol
-		ifTrue: [ self addTraitGeneralization: (self builder getTraitNamed: anObject) ]
-		ifFalse: [ anObject isMetamodelTrait ifTrue: [ self addTraitGeneralization: anObject ] ifFalse: [ self classGeneralization: anObject ] ]
+		  ifTrue: [ self addTraitGeneralization: (self builder getTraitNamed: anObject) ]
+		  ifFalse: [
+				  anObject isMetamodelTrait
+					  ifTrue: [ self addTraitGeneralization: anObject ]
+					  ifFalse: [ self classGeneralization: anObject ] ]
 ]
 
 { #category : #generating }


### PR DESCRIPTION
This change make a generator raise an error if we try to add a trait or a superclass to a remote entity since it is not something possible to do.