### PR TITLE
Fix #numberOfAnnotationInstances

### DIFF
--- a/src/Famix-Traits/FamixTMethodMetrics.trait.st
+++ b/src/Famix-Traits/FamixTMethodMetrics.trait.st
@@ -48,19 +48,3 @@ FamixTMethodMetrics >> hierarchyNestingLevel [
 FamixTMethodMetrics >> hierarchyNestingLevel: aNumber [
 	self cacheAt: #hierarchyNestingLevel put: aNumber
 ]
-
-{ #category : 'Famix-Extensions-metrics-support' }
-FamixTMethodMetrics >> numberOfAnnotationInstances [
-	<FMProperty: #numberOfAnnotationInstances type: #Number>
-	<derived>
-	<FMComment: 'The number of annotation instances defined in the method'>
-
-	^self
-		lookUpPropertyNamed: #numberOfAnnotationInstances
-		computedAs: [self annotationInstances size]
-]
-
-{ #category : 'metrics' }
-FamixTMethodMetrics >> numberOfAnnotationInstances: aNumber [
-	self cacheAt: #numberOfAnnotationInstances put: aNumber
-]

--- a/src/Famix-Traits/FamixTWithAnnotationInstances.trait.st
+++ b/src/Famix-Traits/FamixTWithAnnotationInstances.trait.st
@@ -99,14 +99,15 @@ FamixTWithAnnotationInstances >> isAnnotatedWith: anAnnotationName [
 
 { #category : 'metrics' }
 FamixTWithAnnotationInstances >> numberOfAnnotationInstances [
+
 	<FMProperty: #numberOfAnnotationInstances type: #Number>
 	<derived>
 	<FMComment: 'The number of annotation instances defined in the class or in any of its methods'>
-
-	^self
-		lookUpPropertyNamed: #numberOfAnnotationInstances
-		computedAs: [
-			self annotationInstances size + (self children inject: 0 into: [:sum :each | sum + each numberOfAnnotationInstances])]
+	^ self lookUpPropertyNamed: #numberOfAnnotationInstances computedAs: [
+			  self annotationInstances size + (self children inject: 0 into: [ :sum :each |
+					   (each isOfType: FamixTWithAnnotationInstances)
+						   ifTrue: [ sum + each numberOfAnnotationInstances ]
+						   ifFalse: [ sum ] ]) ]
 ]
 
 { #category : 'metrics' }


### PR DESCRIPTION
- It is duplicated between TMethodMetrics and TWithAnnotationInstances
- It causes trait conflicts
- Its implementation can send an unknown message to some entities

In this change I:
- Remove it from MethodMetrics because all languages do not always have annotation instances
- Ask the number of annotation instances only to children that can have some
- Fix trait conflict