### PR TITLE
Add #asJSONString

### DIFF
--- a/src/Moose-Core-Tests/MooseModelTest.class.st
+++ b/src/Moose-Core-Tests/MooseModelTest.class.st
@@ -31,6 +31,22 @@ MooseModelTest >> testAddAnnouncement [
 ]
 
 { #category : 'tests' }
+MooseModelTest >> testAsJSONString [
+
+	self assert: MooseModel new asJSONString equals: '[
+]'.
+	self
+		assert: (MooseModel new
+				 add: MooseEntity new;
+				 asJSONString)
+		equals: '[{
+	"FM3":"Moose.Entity",
+	"id":1
+	}
+]'
+]
+
+{ #category : 'tests' }
 MooseModelTest >> testAsMSEString [
 	self assert: MooseModel new asMSEString equals: '()'.
 	self

--- a/src/Moose-Core/MooseGroupStorage.class.st
+++ b/src/Moose-Core/MooseGroupStorage.class.st
@@ -77,7 +77,6 @@ MooseGroupStorage >> allEntityTypes [
 	^ byType keys
 ]
 
-
 { #category : 'iterators' }
 MooseGroupStorage >> basicIterator [
 	^ self elements basicIterator

--- a/src/Moose-Core/MooseModel.class.st
+++ b/src/Moose-Core/MooseModel.class.st
@@ -350,6 +350,12 @@ MooseModel >> allRootContainers [
 ]
 
 { #category : 'import-export' }
+MooseModel >> asJSONString [
+
+	^ String streamContents: [ :stream | self exportToJSONStream: stream ]
+]
+
+{ #category : 'import-export' }
 MooseModel >> asMSEString [
 
 	^ String streamContents: [ :stream | self exportToMSEStream: stream ]


### PR DESCRIPTION
Add #asJSONString. 
I think we should start to deprecate export to MSE soon