### PR TITLE
Improve implicit variables handling

### DIFF
--- a/src/Famix-Java-Entities/FamixJavaImplicitVariable.class.st
+++ b/src/Famix-Java-Entities/FamixJavaImplicitVariable.class.st
@@ -58,6 +58,12 @@ FamixJavaImplicitVariable >> accept: aVisitor [
 	^ aVisitor visitFamixJavaImplicitVariable: self
 ]
 
+{ #category : 'testing' }
+FamixJavaImplicitVariable >> isSelf [
+
+	^ self name = 'this'
+]
+
 { #category : 'printing' }
 FamixJavaImplicitVariable >> mooseNameOn: stream [ 
 	| parent |

--- a/src/Famix-Java-Entities/FamixJavaInvocation.class.st
+++ b/src/Famix-Java-Entities/FamixJavaInvocation.class.st
@@ -62,38 +62,6 @@ FamixJavaInvocation >> initialize [
 	signature := 'nosignature'.
 ]
 
-{ #category : 'testing' }
-FamixJavaInvocation >> isAPotentialInvocation [
-	"test if the sender is a potential invocation"
-	| invokedMtdSignature invoRVar invokedMtd |
-	invokedMtdSignature := self signature.
-	invokedMtdSignature ifNil:[^false].
-	invoRVar := self receiver.
-			
-	invoRVar ifNil:[^true].
-	
-	(invoRVar isImplicitVariable or: [invoRVar class = FamixJavaClass]) ifFalse:[^true].
-	
-	(invoRVar isImplicitVariable 
-	 and: [(invoRVar isSelf or: [invoRVar isSuper]) not]) ifTrue:[^true].
-		 
-	(invoRVar isImplicitVariable 
-	 	and: [(invokedMtd := self getReceivingFAMIXClass lookUp: invokedMtdSignature) isNil 
-					or: [invokedMtd isAbstract]]) ifTrue:[^true].
-
-	^false
-	
-]
-
-{ #category : 'testing' }
-FamixJavaInvocation >> isASureInvocation [
-	"Test if the receiver (an invocation) is sure (i.e. we know for sure the class of the invocation's receiver)"
-
-	| invoRVar |
-	invoRVar := self receiver.
-	^ invoRVar isNotNil and: [ invoRVar class = FamixJavaClass or: [ invoRVar isImplicitVariable and: [ invoRVar isSelf or: [ invoRVar isSuper ] ] ] ]
-]
-
 { #category : 'printing' }
 FamixJavaInvocation >> printOn: aStream [
 	super printOn: aStream.

--- a/src/Famix-Java-Tests/FamixJavaImplicitVariableTest.class.st
+++ b/src/Famix-Java-Tests/FamixJavaImplicitVariableTest.class.st
@@ -1,0 +1,36 @@
+Class {
+	#name : 'FamixJavaImplicitVariableTest',
+	#superclass : 'TestCase',
+	#category : 'Famix-Java-Tests',
+	#package : 'Famix-Java-Tests'
+}
+
+{ #category : 'tests' }
+FamixJavaImplicitVariableTest >> testIsSelf [
+
+	| variable |
+	variable := FamixJavaImplicitVariable named: 'this'.
+
+	self assert: variable isSelf.
+
+	variable := FamixJavaImplicitVariable named: 'super'.
+
+	self deny: variable isSelf.
+
+	variable := FamixJavaImplicitVariable named: 'self'.
+
+	self deny: variable isSelf
+]
+
+{ #category : 'tests' }
+FamixJavaImplicitVariableTest >> testIsSuper [
+
+	| variable |
+	variable := FamixJavaImplicitVariable named: 'super'.
+
+	self assert: variable isSuper.
+
+	variable := FamixJavaImplicitVariable named: 'this'.
+
+	self deny: variable isSuper
+]

--- a/src/Famix-PharoSmalltalk-Entities/FamixStImplicitVariable.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStImplicitVariable.class.st
@@ -53,8 +53,9 @@ FamixStImplicitVariable class >> annotation [
 ]
 
 { #category : 'testing' }
-FamixStImplicitVariable >> isSuper [
-	^ self name == #super
+FamixStImplicitVariable >> isSelf [
+
+	^ self name = 'self'
 ]
 
 { #category : 'printing' }

--- a/src/Famix-PharoSmalltalk-Entities/FamixStInvocation.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStInvocation.class.st
@@ -54,12 +54,3 @@ FamixStInvocation >> initialize [
 	super initialize.
 	signature := 'nosignature'.
 ]
-
-{ #category : 'instance creation' }
-FamixStInvocation >> isASureInvocation [
-	"Test if the receiver (an invocation) is sure (i.e. we know for sure the class of the invocation's receiver)"
-
-	| invoRVar |
-	invoRVar := self receiver.
-	^ invoRVar isNotNil and: [ invoRVar class = FamixStClass or: [ invoRVar isImplicitVariable and: [ invoRVar isSelf or: [ invoRVar isSuper ] ] ] ]
-]

--- a/src/Famix-PharoSmalltalk-Tests/FamixStImplicitVariableTest.class.st
+++ b/src/Famix-PharoSmalltalk-Tests/FamixStImplicitVariableTest.class.st
@@ -1,0 +1,36 @@
+Class {
+	#name : 'FamixStImplicitVariableTest',
+	#superclass : 'TestCase',
+	#category : 'Famix-PharoSmalltalk-Tests',
+	#package : 'Famix-PharoSmalltalk-Tests'
+}
+
+{ #category : 'tests' }
+FamixStImplicitVariableTest >> testIsSelf [
+
+	| variable |
+	variable := FamixStImplicitVariable named: 'self'.
+
+	self assert: variable isSelf.
+
+	variable := FamixStImplicitVariable named: 'super'.
+
+	self deny: variable isSelf.
+
+	variable := FamixStImplicitVariable named: 'this'.
+
+	self deny: variable isSelf
+]
+
+{ #category : 'tests' }
+FamixStImplicitVariableTest >> testIsSuper [
+
+	| variable |
+	variable := FamixStImplicitVariable named: 'super'.
+
+	self assert: variable isSuper.
+
+	variable := FamixStImplicitVariable named: 'self'.
+
+	self deny: variable isSuper
+]

--- a/src/Famix-Traits/FamixTImplicitVariable.trait.st
+++ b/src/Famix-Traits/FamixTImplicitVariable.trait.st
@@ -62,6 +62,22 @@ FamixTImplicitVariable >> accept: aVisitor [
 	^ aVisitor visitFamixTImplicitVariable: self
 ]
 
+{ #category : 'accessing' }
+FamixTImplicitVariable >> declaredType [
+	"If we have a declared type, we return it. Else, we check if the implicit variable is self or super to determine the declared type."
+
+	self typing ifNotNil: [ :t | t declaredType ifNotNil: [ :type | ^ type ] ].
+
+	[
+		self isSelf ifTrue: [ ^ (self query ancestors ofType: FamixTClass) anyOne ].
+
+		self isSuper ifTrue: [ ^ (self query ancestors ofType: FamixTClass) anyOne superclass ] ]
+		on: Error
+		do: [ "Nothing. If we cannot determine the type, just return nil." ].
+
+	^ nil
+]
+
 { #category : 'testing' }
 FamixTImplicitVariable >> isImplicitVariable [
 
@@ -72,7 +88,13 @@ FamixTImplicitVariable >> isImplicitVariable [
 { #category : 'testing' }
 FamixTImplicitVariable >> isSelf [
 
-	^ self name = 'self'
+	^ self shouldBeImplemented
+]
+
+{ #category : 'testing' }
+FamixTImplicitVariable >> isSuper [
+
+	^ self name = 'super'
 ]
 
 { #category : 'accessing' }

--- a/src/Famix-Traits/FamixTInvocation.trait.st
+++ b/src/Famix-Traits/FamixTInvocation.trait.st
@@ -139,36 +139,6 @@ FamixTInvocation >> displayStringOn: aStream [
 		ifNil: [ aStream nextPutAll: ' ? ' ]
 ]
 
-{ #category : 'instance creation' }
-FamixTInvocation >> getReceivingFAMIXClass [
-
-	self
-		deprecated: 'Please use getReceivingFamixClass instead'
-		transformWith: '`@receiver getReceivingFAMIXClass'
-			-> '`@receiver getReceivingFamixClass'.
-	^ self getReceivingFamixClass
-]
-
-{ #category : 'instance creation' }
-FamixTInvocation >> getReceivingFamixClass [
-
-	"Returns the Famix class of the receiver. If the receiver is a Famix class, this one is returned. 
-	If it is self or super, the corresponding Famix class is returned. 
-	The receiver may not be nil"
-
-	| tmpReceiver |
-	tmpReceiver := self receiver.
-
-	tmpReceiver isImplicitVariable
-		ifTrue: [ 
-			| belongsTo |
-			belongsTo := tmpReceiver belongsTo parentType.
-			tmpReceiver isSelf ifTrue: [ ^ belongsTo ].
-			tmpReceiver isSuper ifTrue: [ 
-				^ belongsTo superclass ifNil: [ belongsTo ] ] ]
-		ifFalse: [ ^ tmpReceiver ]
-]
-
 { #category : 'accessing' }
 FamixTInvocation >> invokedEntity [
 	"This method returns only one candidate if there is one, or raises an error if there is more or less than one candidate."


### PR DESCRIPTION
- #isSelf should now be implemented on each MM
- #isSuper move from FamixSTImplicitVariable to FamixTImplicitVariable
- Add tests
- Improve FamixTImplicitVariable>>declaredType to return the parent type when it is self, or the superclass of the parent type if it represents super
- Remove some dead code that has problems inside

Do not merge before we fix VerveineJ to generate some implicit variables named this instead of self