### PR TITLE
Fix Moose #2556. Issue in Tree InspectorTab

### DIFF
--- a/src/Moose-Query/TEntityMetaLevelDependency.trait.st
+++ b/src/Moose-Query/TEntityMetaLevelDependency.trait.st
@@ -741,7 +741,7 @@ TEntityMetaLevelDependency >> miInspectionTree: aBuilder [
 						    yourself);
 				   addColumn: (SpStringTableColumn evaluated: #name);
 				   yourself);
-		  children: [ :aClass | aClass children ];
+		  children: [ :aClass | aClass children asArray ];
 		  beMultipleSelection;
 		  roots: { self };
 		  beResizable


### PR DESCRIPTION
The way we get childrenin the tree should always return a sequenceable collection.

Fix https://github.com/moosetechnology/Moose/issues/2556 