### PR TITLE
Add #isEmptyOrNil to MooseAbstractGroup.

### DIFF
--- a/src/Moose-Core/MooseAbstractGroup.class.st
+++ b/src/Moose-Core/MooseAbstractGroup.class.st
@@ -595,6 +595,12 @@ MooseAbstractGroup >> isEmpty [
 ]
 
 { #category : 'testing' }
+MooseAbstractGroup >> isEmptyOrNil [
+
+	^ self entityStorage isEmptyOrNil
+]
+
+{ #category : 'testing' }
 MooseAbstractGroup >> isNotEmpty [
 	"Answer whether the receiver contains any elements."
 


### PR DESCRIPTION
Used in MooseIDE when receiving an unknown MooseObject.