### PR TITLE
Fix #numberOfConditionals

### DIFF
--- a/src/Famix-Java-Entities/FamixJavaMethod.class.st
+++ b/src/Famix-Java-Entities/FamixJavaMethod.class.st
@@ -283,21 +283,6 @@ FamixJavaMethod >> numberOfAccesses [
 		computedAs: [ self accesses size ]
 ]
 
-{ #category : 'Famix-Extensions-private' }
-FamixJavaMethod >> numberOfConditionals [
-	<FMProperty: #numberOfConditionals type: #Number>
-	<FMComment: 'The number of conditionals in a method'>
-	^ self
-		lookUpPropertyNamed: #numberOfConditionals
-		computedAs: [ 
-			self notExistentMetricValue ] 
-]
-
-{ #category : 'Famix-Extensions-private' }
-FamixJavaMethod >> numberOfConditionals: aNumber [
-	self cacheAt: #numberOfConditionals put: aNumber
-]
-
 { #category : 'Famix-Extensions' }
 FamixJavaMethod >> numberOfInvokedMethods [
 	<FMProperty: #numberOfInvokedMethods type: #Number>

--- a/src/Famix-PharoSmalltalk-Entities/FamixStMethod.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStMethod.class.st
@@ -222,6 +222,14 @@ FamixStMethod >> numberOfAccesses [
 		computedAs: [ self accesses size ]
 ]
 
+{ #category : 'metrics' }
+FamixStMethod >> numberOfConditionals [
+
+	<FMProperty: #numberOfConditionals type: #Number>
+	<FMComment: 'The number of conditionals in a method'>
+	^ self lookUpPropertyNamed: #numberOfConditionals computedAs: [ self computeNumberOfConditionals ]
+]
+
 { #category : 'Famix-Extensions-private' }
 FamixStMethod >> numberOfMessageSends [
 	<FMProperty: #numberOfMessageSends type: #Number>

--- a/src/Famix-PharoSmalltalk-Entities/FamixStMethod.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStMethod.class.st
@@ -223,20 +223,6 @@ FamixStMethod >> numberOfAccesses [
 ]
 
 { #category : 'Famix-Extensions-private' }
-FamixStMethod >> numberOfConditionals [
-	<FMProperty: #numberOfConditionals type: #Number>
-	<FMComment: 'The number of conditionals in a method'>
-	^ self
-		lookUpPropertyNamed: #numberOfConditionals
-		computedAs: [ self computeNumberOfConditionals ]
-]
-
-{ #category : 'Famix-Extensions-private' }
-FamixStMethod >> numberOfConditionals: aNumber [
-	self cacheAt: #numberOfConditionals put: aNumber
-]
-
-{ #category : 'Famix-Extensions-private' }
 FamixStMethod >> numberOfMessageSends [
 	<FMProperty: #numberOfMessageSends type: #Number>
 	<derived>

--- a/src/Famix-Traits/FamixTMethod.trait.st
+++ b/src/Famix-Traits/FamixTMethod.trait.st
@@ -144,6 +144,20 @@ FamixTMethod >> mooseNameOn: stream [
 		ifNil: [ self name ifNotNil: [ :aName | stream nextPutAll: aName ] ]
 ]
 
+{ #category : 'metrics' }
+FamixTMethod >> numberOfConditionals [
+
+	<FMProperty: #numberOfConditionals type: #Number>
+	<FMComment: 'The number of conditionals in a method'>
+	^ self attributeAt: #numberOfConditionals ifAbsent: [ self notExistentMetricValue ]
+]
+
+{ #category : 'metrics' }
+FamixTMethod >> numberOfConditionals: aNumber [
+
+	self attributeAt: #numberOfConditionals put: aNumber
+]
+
 { #category : 'testing' }
 FamixTMethod >> overridingMethods [
 


### PR DESCRIPTION
- This method was duplicated on multiple #FamixTMethod users so I moved it to the trait.
- This method was putting the value in a cache that can be flushed while we cannot recompute it