### PR TITLE
Remove #numberOfAccessorMethods

### DIFF
--- a/src/Famix-Java-Entities/FamixJavaTClassMetrics.trait.st
+++ b/src/Famix-Java-Entities/FamixJavaTClassMetrics.trait.st
@@ -22,26 +22,6 @@ FamixJavaTClassMetrics >> accept: aVisitor [
 ]
 
 { #category : 'metrics' }
-FamixJavaTClassMetrics >> numberOfAccessorMethods [
-	<FMProperty: #numberOfAccessorMethods type: #Number>
-	<derived>
-	<FMComment: 'The number of accessor methods in a class'>
-	^ self
-		lookUpPropertyNamed: #numberOfAccessorMethods
-		computedAs: [ | noa |
-			noa := 0.
-			self methods
-				do:
-					[ :method | method isPureAccessor ifNotNil: [ (method isPureAccessor or: [ (method propertyNamed: #AccessorMethod) isNotNil ]) ifTrue: [ noa := noa + 1 ] ] ].
-			noa ]
-]
-
-{ #category : 'metrics' }
-FamixJavaTClassMetrics >> numberOfAccessorMethods: aNumber [
-	self cacheAt: #numberOfAccessorMethods put: aNumber
-]
-
-{ #category : 'metrics' }
 FamixJavaTClassMetrics >> numberOfConstructorMethods [
 	<FMProperty: #numberOfConstructorMethods type: #Number>
 	<derived>

--- a/src/Famix-Java-Tests/FamixJavaClassTest.class.st
+++ b/src/Famix-Java-Tests/FamixJavaClassTest.class.st
@@ -51,21 +51,6 @@ FamixJavaClassTest >> testIsJUnit40TestCase [
 ]
 
 { #category : 'tests' }
-FamixJavaClassTest >> testNumberOfAccessorMethods [
-
-	| model c1 m1 |
-	model := FamixJavaModel new.
-	c1 := FamixJavaClass named: 'Class1' model: model.
-	m1 := FamixJavaMethod named: 'method1' model: model.
-	m1 parentType: c1.
-	m1 beGetter.
-
-	self assert: c1 numberOfAccessorMethods equals: 1.
-	c1 numberOfAccessorMethods: 100.
-	self assert: c1 numberOfAccessorMethods equals: 100
-]
-
-{ #category : 'tests' }
 FamixJavaClassTest >> testNumberOfConstructorMethods [
 
 	| m1 c1 model |


### PR DESCRIPTION
This has multiple problems. 
- It uses #ifNotNil: on the result of a method that will never be nil, but a boolean
- It access a property never witten so it cannot work
- It sends a #isNotNil on a method that will either return a boolean or raise an exception