### PR TITLE
Deprecate properties API

### DIFF
--- a/src/Famix-Deprecated/MooseObject.extension.st
+++ b/src/Famix-Deprecated/MooseObject.extension.st
@@ -18,6 +18,15 @@ MooseObject >> propertyNamed: name ifAbsentPut: value [
 ]
 
 { #category : '*Famix-Deprecated' }
+MooseObject >> propertyNamed: propertyName ifNil: aBlock [
+	"Return the value of the property named propertyName, evaluate aBlock if the property does not exist"
+
+	self deprecated: 'Use #cacheAt:ifAbsent: instead.' transformWith: '`@rcv propertyNamed: `@arg1 ifNil: `@arg2' -> '`@rcv cacheAt: `@arg1 ifAbsent: `@arg2'.
+
+	^ self cacheAt: propertyName asSymbol ifAbsent: [ aBlock value ]
+]
+
+{ #category : '*Famix-Deprecated' }
 MooseObject >> propertyNamed: name put: value [
 
 	self deprecated: 'Use #cacheAt:put: instead.' transformWith: '`@rcv propertyNamed: `@arg1 put: `@arg2' -> '`@rcv cacheAt: `@arg1 put: `@arg2'.

--- a/src/Famix-Deprecated/MooseObject.extension.st
+++ b/src/Famix-Deprecated/MooseObject.extension.st
@@ -1,6 +1,15 @@
 Extension { #name : 'MooseObject' }
 
 { #category : '*Famix-Deprecated' }
+MooseObject >> propertyNamed: name ifAbsentPut: value [
+
+	self
+		deprecated: 'Use #cacheAt:ifAbsentPut: instead.'
+		transformWith: '`@rcv propertyNamed: `@arg1 ifAbsentPut: `@arg2' -> '`@rcv cacheAt: `@arg1 ifAbsentPut: `@arg2'.
+	^ self cacheAt: name ifAbsentPut: value
+]
+
+{ #category : '*Famix-Deprecated' }
 MooseObject >> propertyNamed: name put: value [
 
 	self deprecated: 'Use #cacheAt:put: instead.' transformWith: '`@rcv propertyNamed: `@arg1 put: `@arg2' -> '`@rcv cacheAt: `@arg1 put: `@arg2'.

--- a/src/Famix-Deprecated/MooseObject.extension.st
+++ b/src/Famix-Deprecated/MooseObject.extension.st
@@ -1,6 +1,15 @@
 Extension { #name : 'MooseObject' }
 
 { #category : '*Famix-Deprecated' }
+MooseObject >> lookUpPropertyNamed: selector computedAs: aBlock [
+
+	self
+		deprecated: 'Use #cacheAt:ifAbsent: instead.'
+		transformWith: '`@rcv lookUpPropertyNamed: `@arg1 computedAs: `@arg2' -> '`@rcv cacheAt: `@arg1 ifAbsent: `@arg2'.
+	^ self cacheAt: selector ifAbsentPut: aBlock
+]
+
+{ #category : '*Famix-Deprecated' }
 MooseObject >> propertyNamed: propertyName ifAbsent: aBlock [
 	"Return the value of the property named propertyName, evaluate aBlock if the property does not exist"
 

--- a/src/Famix-Deprecated/MooseObject.extension.st
+++ b/src/Famix-Deprecated/MooseObject.extension.st
@@ -1,6 +1,14 @@
 Extension { #name : 'MooseObject' }
 
 { #category : '*Famix-Deprecated' }
+MooseObject >> propertyNamed: propertyName ifAbsent: aBlock [
+	"Return the value of the property named propertyName, evaluate aBlock if the property does not exist"
+
+	self deprecated: 'Use #cacheAt:ifAbsent: instead.' transformWith: '`@rcv propertyNamed: `@arg1 ifAbsent: `@arg2' -> '`@rcv cacheAt: `@arg1 ifAbsent: `@arg2'.
+	^ self cacheAt: propertyName asSymbol ifAbsent: [ aBlock value ]
+]
+
+{ #category : '*Famix-Deprecated' }
 MooseObject >> propertyNamed: name ifAbsentPut: value [
 
 	self

--- a/src/Famix-Deprecated/MooseObject.extension.st
+++ b/src/Famix-Deprecated/MooseObject.extension.st
@@ -10,6 +10,13 @@ MooseObject >> lookUpPropertyNamed: selector computedAs: aBlock [
 ]
 
 { #category : '*Famix-Deprecated' }
+MooseObject >> properties [
+
+	self deprecated: 'Use #allCachedValues' transformWith: '`@rcv properties' -> '`@rcv allCachedValues'.
+	^ self allCachedValues
+]
+
+{ #category : '*Famix-Deprecated' }
 MooseObject >> propertyNamed: propertyName [
 	"Returns the value of the property named propertyName, raises an error if the property does not exist"
 

--- a/src/Famix-Deprecated/MooseObject.extension.st
+++ b/src/Famix-Deprecated/MooseObject.extension.st
@@ -10,6 +10,15 @@ MooseObject >> lookUpPropertyNamed: selector computedAs: aBlock [
 ]
 
 { #category : '*Famix-Deprecated' }
+MooseObject >> propertyNamed: propertyName [
+	"Returns the value of the property named propertyName, raises an error if the property does not exist"
+
+	self deprecated: 'Use #cacheAt: instead.' transformWith: '`@rcv propertyNamed: `@arg1' -> '`@rcv cacheAt: `@arg1'.
+
+	^ self cacheAt: propertyName ifAbsent: [ NotFound signalFor: 'Property named ' , propertyName ]
+]
+
+{ #category : '*Famix-Deprecated' }
 MooseObject >> propertyNamed: propertyName ifAbsent: aBlock [
 	"Return the value of the property named propertyName, evaluate aBlock if the property does not exist"
 

--- a/src/Famix-Deprecated/MooseObject.extension.st
+++ b/src/Famix-Deprecated/MooseObject.extension.st
@@ -1,0 +1,8 @@
+Extension { #name : 'MooseObject' }
+
+{ #category : '*Famix-Deprecated' }
+MooseObject >> propertyNamed: name put: value [
+
+	self deprecated: 'Use #cacheAt:put: instead.' transformWith: '`@rcv propertyNamed: `@arg1 put: `@arg2' -> '`@rcv cacheAt: `@arg1 put: `@arg2'.
+	^ self cacheAt: name put: value
+]

--- a/src/Famix-Java-Entities/FamixJavaMethod.class.st
+++ b/src/Famix-Java-Entities/FamixJavaMethod.class.st
@@ -274,13 +274,11 @@ FamixJavaMethod >> isSetter [
 
 { #category : 'accessing' }
 FamixJavaMethod >> numberOfAccesses [
+
 	<FMProperty: #numberOfAccesses type: #Number>
 	<derived>
 	<FMComment: 'The number of accesses from a method'>
-	
-	^ self 
-		lookUpPropertyNamed: #numberOfAccesses
-		computedAs: [ self accesses size ]
+	^ self cacheAt: #numberOfAccesses ifAbsentPut: [ self accesses size ]
 ]
 
 { #category : 'Famix-Extensions' }

--- a/src/Famix-Java-Entities/FamixJavaPackage.class.st
+++ b/src/Famix-Java-Entities/FamixJavaPackage.class.st
@@ -255,12 +255,11 @@ FamixJavaPackage >> mooseNameOn: stream [
 
 { #category : 'accessing' }
 FamixJavaPackage >> numberOfMethods [
+
 	<FMProperty: #numberOfMethods type: #Number>
 	<FMComment: 'The number of methods in a package'>
 	<derived>
-	^ self
-		lookUpPropertyNamed: #numberOfMethods
-		computedAs: [ self types inject: 0 into: [ :sum :each | sum + each numberOfMethods ] ]
+	^ self cacheAt: #numberOfMethods ifAbsentPut: [ self types inject: 0 into: [ :sum :each | sum + each numberOfMethods ] ]
 ]
 
 { #category : 'accessing' }

--- a/src/Famix-Java-Entities/FamixJavaTClassMetrics.trait.st
+++ b/src/Famix-Java-Entities/FamixJavaTClassMetrics.trait.st
@@ -23,17 +23,16 @@ FamixJavaTClassMetrics >> accept: aVisitor [
 
 { #category : 'metrics' }
 FamixJavaTClassMetrics >> numberOfAccessorMethods [
+
 	<FMProperty: #numberOfAccessorMethods type: #Number>
 	<derived>
 	<FMComment: 'The number of accessor methods in a class'>
-	^ self
-		lookUpPropertyNamed: #numberOfAccessorMethods
-		computedAs: [ | noa |
-			noa := 0.
-			self methods
-				do:
-					[ :method | method isPureAccessor ifNotNil: [ (method isPureAccessor or: [ (method propertyNamed: #AccessorMethod) isNotNil ]) ifTrue: [ noa := noa + 1 ] ] ].
-			noa ]
+	^ self cacheAt: #numberOfAccessorMethods ifAbsent: [
+			  | noa |
+			  noa := 0.
+			  self methods do: [ :method |
+				  method isPureAccessor ifNotNil: [ (method isPureAccessor or: [ (method propertyNamed: #AccessorMethod) isNotNil ]) ifTrue: [ noa := noa + 1 ] ] ].
+			  noa ]
 ]
 
 { #category : 'metrics' }
@@ -43,21 +42,15 @@ FamixJavaTClassMetrics >> numberOfAccessorMethods: aNumber [
 
 { #category : 'metrics' }
 FamixJavaTClassMetrics >> numberOfConstructorMethods [
+
 	<FMProperty: #numberOfConstructorMethods type: #Number>
 	<derived>
 	<FMComment: 'The number of constructor methods in a class'>
-	^ self
-		lookUpPropertyNamed: #numberOfConstructorMethods
-		computedAs: [ 
-			| nc |
-			nc := 0.
-			self methods
-				do: [ :method | 
-					method isConstructor
-						ifNotNil: [ 
-							method isConstructor
-								ifTrue: [ nc := 1 ] ] ].
-			nc ]
+	^ self cacheAt: #numberOfConstructorMethods ifAbsent: [
+			  | nc |
+			  nc := 0.
+			  self methods do: [ :method | method isConstructor ifNotNil: [ method isConstructor ifTrue: [ nc := 1 ] ] ].
+			  nc ]
 ]
 
 { #category : 'metrics' }
@@ -67,13 +60,11 @@ FamixJavaTClassMetrics >> numberOfConstructorMethods: aNumber [
 
 { #category : 'metrics' }
 FamixJavaTClassMetrics >> numberOfPrivateMethods [
+
 	<FMProperty: #numberOfPrivateMethods type: #Number>
 	<derived>
 	<FMComment: 'The number of private methods in a class'>
-			
-	^self
-		lookUpPropertyNamed: #numberOfPrivateMethods
-		computedAs: [(self methods select: [:each | each isPrivate]) size]
+	^ self cacheAt: #numberOfPrivateMethods ifAbsentPut: [ (self methods select: [ :each | each isPrivate ]) size ]
 ]
 
 { #category : 'metrics' }
@@ -83,13 +74,11 @@ FamixJavaTClassMetrics >> numberOfPrivateMethods: aNumber [
 
 { #category : 'metrics' }
 FamixJavaTClassMetrics >> numberOfProtectedMethods [
+
 	<FMProperty: #numberOfProtectedMethods type: #Number>
 	<derived>
-	<FMComment: 'The number of protected methods in a class'>		
-	
-	^self
-		lookUpPropertyNamed: #numberOfProtectedMethods
-		computedAs: [(self methods select: [:each | each isProtected]) size]
+	<FMComment: 'The number of protected methods in a class'>
+	^ self cacheAt: #numberOfProtectedMethods ifAbsentPut: [ (self methods select: [ :each | each isProtected ]) size ]
 ]
 
 { #category : 'metrics' }
@@ -99,13 +88,11 @@ FamixJavaTClassMetrics >> numberOfProtectedMethods: aNumber [
 
 { #category : 'metrics' }
 FamixJavaTClassMetrics >> numberOfPublicMethods [
+
 	<FMProperty: #numberOfPublicMethods type: #Number>
 	<derived>
-	<FMComment: 'The number of public methods in a class'>		
-		
-	^self
-		lookUpPropertyNamed: #numberOfPublicMethods
-		computedAs: [(self methods select: [:each | each isPublic]) size]
+	<FMComment: 'The number of public methods in a class'>
+	^ self cacheAt: #numberOfPublicMethods ifAbsentPut: [ (self methods select: [ :each | each isPublic ]) size ]
 ]
 
 { #category : 'metrics' }

--- a/src/Famix-PharoSmalltalk-Entities/FamixStClass.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStClass.class.st
@@ -189,13 +189,11 @@ FamixStClass >> methodsWithoutSutbsAndConstructors [
 
 { #category : 'metrics' }
 FamixStClass >> numberOfMessageSends [
+
 	<FMProperty: #numberOfMessageSends type: #Number>
 	<derived>
 	<FMComment: 'The number of message sends from a class'>
-	
-	^self
-		lookUpPropertyNamed: #numberOfMessageSends
-		computedAs: [self methodsGroup sumNumbers: #numberOfMessageSends]
+	^ self cacheAt: #numberOfMessageSends ifAbsent: [ self methodsGroup sumNumbers: #numberOfMessageSends ]
 ]
 
 { #category : 'as yet unclassified' }
@@ -205,10 +203,11 @@ FamixStClass >> numberOfMessageSends: aNumber [
 
 { #category : 'metrics' }
 FamixStClass >> numberOfMethodProtocols [
+
 	<FMProperty: #numberOfMethodProtocols type: #Number>
 	<derived>
 	<FMComment: 'The number of method protocols in a class'>
-	^ self lookUpPropertyNamed: #numberOfMethodProtocols computedAs: [ ((self methods collect: [ :each | each protocol ]) reject: #isNil) asSet size ]
+	^ self cacheAt: #numberOfMethodProtocols ifAbsent: [ ((self methods collect: [ :each | each protocol ]) reject: #isNil) asSet size ]
 ]
 
 { #category : 'metrics' }

--- a/src/Famix-PharoSmalltalk-Entities/FamixStMethod.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStMethod.class.st
@@ -213,13 +213,11 @@ FamixStMethod >> isOverriding [
 
 { #category : 'Famix-Extensions-private' }
 FamixStMethod >> numberOfAccesses [
+
 	<FMProperty: #numberOfAccesses type: #Number>
 	<derived>
 	<FMComment: 'The number of accesses from a method'>
-	
-	^ self 
-		lookUpPropertyNamed: #numberOfAccesses
-		computedAs: [ self accesses size ]
+	^ self cacheAt: #numberOfAccesses ifAbsent: [ self accesses size ]
 ]
 
 { #category : 'metrics' }
@@ -227,17 +225,16 @@ FamixStMethod >> numberOfConditionals [
 
 	<FMProperty: #numberOfConditionals type: #Number>
 	<FMComment: 'The number of conditionals in a method'>
-	^ self lookUpPropertyNamed: #numberOfConditionals computedAs: [ self computeNumberOfConditionals ]
+	^ self cacheAt: #numberOfConditionals ifAbsentPut: [ self computeNumberOfConditionals ]
 ]
 
 { #category : 'Famix-Extensions-private' }
 FamixStMethod >> numberOfMessageSends [
+
 	<FMProperty: #numberOfMessageSends type: #Number>
 	<derived>
 	<FMComment: 'The number of message from a method'>
-	^ self
-		lookUpPropertyNamed: #numberOfMessageSends
-		computedAs: [ self computeNumberOfMessageSends ]
+	^ self cacheAt: #numberOfMessageSends ifAbsent: [ self computeNumberOfMessageSends ]
 ]
 
 { #category : 'Famix-Extensions-private' }
@@ -247,11 +244,10 @@ FamixStMethod >> numberOfMessageSends: aNumber [
 
 { #category : 'Famix-Extensions-private' }
 FamixStMethod >> numberOfStatements [
+
 	<FMProperty: #numberOfStatements type: #Number>
 	<FMComment: 'The number of statements in a method'>
-	^ self
-		lookUpPropertyNamed: #numberOfStatements
-		computedAs: [ self computeNumberOfStatements ]
+	^ self cacheAt: #numberOfStatements ifAbsent: [ self computeNumberOfStatements ]
 ]
 
 { #category : 'protocol' }

--- a/src/Famix-PharoSmalltalk-Entities/FamixStNamespace.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStNamespace.class.st
@@ -83,13 +83,11 @@ FamixStNamespace >> numberOfClasses: aNumber [
 
 { #category : 'Famix-Extensions' }
 FamixStNamespace >> numberOfMethods [
+
 	<FMProperty: #numberOfMethods type: #Number>
 	<derived>
 	<FMComment: 'The number of methods in a namespace'>
-	
-	^self
-		lookUpPropertyNamed: #numberOfMethods
-		computedAs: [self types inject: 0 into: [ :sum :each | sum + each numberOfMethods ]]
+	^ self cacheAt: #numberOfMethods ifAbsentPut: [ self types inject: 0 into: [ :sum :each | sum + each numberOfMethods ] ]
 ]
 
 { #category : 'Famix-Extensions' }

--- a/src/Famix-Traits/FamixMethodGroup.class.st
+++ b/src/Famix-Traits/FamixMethodGroup.class.st
@@ -39,30 +39,24 @@ FamixMethodGroup >> allPackages [
 
 { #category : 'metrics' }
 FamixMethodGroup >> averageNumberOfInvocations [
+
 	<FMProperty: #averageNumberOfInvocations type: #Number>
 	<FMComment: 'Average number of invocations per methods'>
-
-	^self
-		lookUpPropertyNamed: #averageNumberOfInvocations
-		computedAs: [self average: [:each | each numberOfOutgoingInvocations ]]
+	^ self cacheAt: #averageNumberOfInvocations ifAbsentPut: [ self average: [ :each | each numberOfOutgoingInvocations ] ]
 ]
 
 { #category : 'metrics' }
 FamixMethodGroup >> averageNumberOfLinesOfCode [
+
 	<FMProperty: #averageNumberOfLinesOfCode type: #Number>
 	<FMComment: 'Average number of lines of code per methods'>
-
-	^self
-		lookUpPropertyNamed: #averageNumberOfLinesOfCode
-		computedAs: [self average: [:each | each numberOfLinesOfCode ]]
+	^ self cacheAt: #averageNumberOfLinesOfCode ifAbsentPut: [ self average: [ :each | each numberOfLinesOfCode ] ]
 ]
 
 { #category : 'metrics' }
 FamixMethodGroup >> averageNumberOfParameters [
+
 	<FMProperty: #averageNumberOfParameters type: #Number>
 	<FMComment: 'Average number of parameters per methods'>
-	
-	^self
-		lookUpPropertyNamed: #averageNumberOfParameters
-		computedAs: [self average: [:each | each numberOfParameters]]
+	^ self cacheAt: #averageNumberOfParameters ifAbsentPut: [ self average: [ :each | each numberOfParameters ] ]
 ]

--- a/src/Famix-Traits/FamixTAccessible.trait.st
+++ b/src/Famix-Traits/FamixTAccessible.trait.st
@@ -109,57 +109,47 @@ FamixTAccessible >> localAccesses [
 
 { #category : 'accessing' }
 FamixTAccessible >> numberOfAccesses [
+
 	<FMProperty: #numberOfAccesses type: #Number>
 	<derived>
 	<FMComment: 'The number of accesses of an attribute.'>
-
-	^self
-		lookUpPropertyNamed: #numberOfAccesses
-		computedAs: [self incomingAccesses size]
+	^ self cacheAt: #numberOfAccesses ifAbsent: [ self incomingAccesses size ]
 ]
 
 { #category : 'accessing' }
 FamixTAccessible >> numberOfAccessingClasses [
+
 	<FMProperty: #numberOfAccessingClasses type: #Number>
 	<derived>
 	<FMComment: 'The number of classes from which at least one method accesses an attribute.'>
-
-	^self
-		lookUpPropertyNamed: #numberOfAccessingClasses
-		computedAs: [self accessingClasses size]
+	^ self cacheAt: #numberOfAccessingClasses ifAbsent: [ self accessingClasses size ]
 ]
 
 { #category : 'accessing' }
 FamixTAccessible >> numberOfAccessingMethods [
+
 	<FMProperty: #numberOfAccessingMethods type: #Number>
 	<derived>
-	<FMComment: 'The number of methods accessing an attribute.'>				
-	
-	^self
-		lookUpPropertyNamed: #numberOfAccessingMethods
-		computedAs: [self accessingMethods size]
+	<FMComment: 'The number of methods accessing an attribute.'>
+	^ self cacheAt: #numberOfAccessingMethods ifAbsent: [ self accessingMethods size ]
 ]
 
 { #category : 'accessing' }
 FamixTAccessible >> numberOfGlobalAccesses [
+
 	<FMProperty: #numberOfGlobalAccesses type: #Number>
 	<derived>
-	<FMComment: 'The number of accesses to an attribute from outside the class defining the attribute.'>	
-
-	^self
-		lookUpPropertyNamed: #numberOfGlobalAccesses
-		computedAs: [self globalAccesses size]
+	<FMComment: 'The number of accesses to an attribute from outside the class defining the attribute.'>
+	^ self cacheAt: #numberOfGlobalAccesses ifAbsent: [ self globalAccesses size ]
 ]
 
 { #category : 'accessing' }
 FamixTAccessible >> numberOfLocalAccesses [
+
 	<FMProperty: #numberOfLocalAccesses type: #Number>
 	<derived>
 	<FMComment: 'The number of accesses to an attribute from inside the class defining the attribute.'>
-		
-	^self
-		lookUpPropertyNamed: #numberOfLocalAccesses
-		computedAs: [self localAccesses size]
+	^ self cacheAt: #numberOfLocalAccesses ifAbsent: [ self localAccesses size ]
 ]
 
 { #category : 'accessing' }

--- a/src/Famix-Traits/FamixTAttribute.trait.st
+++ b/src/Famix-Traits/FamixTAttribute.trait.st
@@ -72,13 +72,11 @@ FamixTAttribute >> accessorMethods [
 
 { #category : 'metrics' }
 FamixTAttribute >> hierarchyNestingLevel [
+
 	<FMProperty: #hierarchyNestingLevel type: #Number>
 	<derived>
 	<FMComment: 'Attribute hierarchy nesting level'>
-		
-	^self
-		lookUpPropertyNamed: #hierarchyNestingLevel
-		computedAs: [self parentType hierarchyNestingLevel]
+	^ self cacheAt: #hierarchyNestingLevel ifAbsent: [ self parentType hierarchyNestingLevel ]
 ]
 
 { #category : 'metrics' }

--- a/src/Famix-Traits/FamixTClassMetrics.trait.st
+++ b/src/Famix-Traits/FamixTClassMetrics.trait.st
@@ -23,13 +23,11 @@ FamixTClassMetrics >> accept: aVisitor [
 
 { #category : 'metrics' }
 FamixTClassMetrics >> numberOfAttributesInherited [
+
 	<FMProperty: #numberOfAttributesInherited type: #Number>
 	<derived>
-	<FMComment: 'The number of attributes in a class inherited from super classes'>	
-	
-	^self
-		lookUpPropertyNamed: #numberOfAttributesInherited
-		computedAs: [self inheritedAttributes size]
+	<FMComment: 'The number of attributes in a class inherited from super classes'>
+	^ self cacheAt: #numberOfAttributesInherited ifAbsent: [ self inheritedAttributes size ]
 ]
 
 { #category : 'metrics' }
@@ -42,11 +40,8 @@ FamixTClassMetrics >> numberOfLocallyDefinedMethods [
 
 	<FMProperty: #numberOfLocallyDefinedMethods type: #Number>
 	<derived>
-	<FMComment:
-	'The number of methods in a class added with respect to super classes'>
-	^ self
-		  lookUpPropertyNamed: #numberOfLocallyDefinedMethods
-		  computedAs: [ self addedMethods size ]
+	<FMComment: 'The number of methods in a class added with respect to super classes'>
+	^ self cacheAt: #numberOfLocallyDefinedMethods ifAbsent: [ self addedMethods size ]
 ]
 
 { #category : 'metrics' }
@@ -95,13 +90,11 @@ FamixTClassMetrics >> numberOfMethodsInHierarchy: aNumber [
 
 { #category : 'metrics' }
 FamixTClassMetrics >> numberOfMethodsInherited [
+
 	<FMProperty: #numberOfMethodsInherited type: #Number>
 	<derived>
-	<FMComment: 'The number of methods in a class inherited from super classes'>	
-
-	^self
-		lookUpPropertyNamed: #numberOfMethodsInherited
-		computedAs: [self inheritedMethods size]
+	<FMComment: 'The number of methods in a class inherited from super classes'>
+	^ self cacheAt: #numberOfMethodsInherited ifAbsent: [ self inheritedMethods size ]
 ]
 
 { #category : 'metrics' }
@@ -114,12 +107,8 @@ FamixTClassMetrics >> numberOfMethodsOverridden [
 
 	<FMProperty: #numberOfMethodsOverridden type: #Number>
 	<derived>
-	<FMComment:
-	'The number of methods in a class overridden with respect to super classes'>
-	^ self
-		  lookUpPropertyNamed: #numberOfMethodsOverridden
-		  computedAs: [ 
-		  self numberOfMethods - self numberOfLocallyDefinedMethods ]
+	<FMComment: 'The number of methods in a class overridden with respect to super classes'>
+	^ self cacheAt: #numberOfMethodsOverridden ifAbsent: [ self numberOfMethods - self numberOfLocallyDefinedMethods ]
 ]
 
 { #category : 'metrics' }
@@ -129,10 +118,11 @@ FamixTClassMetrics >> numberOfMethodsOverridden: aNumber [
 
 { #category : 'metrics' }
 FamixTClassMetrics >> totalNumberOfSubclasses [
+
 	<FMProperty: #totalNumberOfSubclasses type: #Number>
 	<derived>
 	<FMComment: 'The total number of subclasses of a class'>
-	^ self lookUpPropertyNamed: #totalNumberOfSubclasses computedAs: [ self subclassHierarchyGroup size ]
+	^ self cacheAt: #totalNumberOfSubclasses ifAbsent: [ self subclassHierarchyGroup size ]
 ]
 
 { #category : 'metrics' }

--- a/src/Famix-Traits/FamixTFile.trait.st
+++ b/src/Famix-Traits/FamixTFile.trait.st
@@ -65,14 +65,14 @@ FamixTFile >> addEntity: famixEntity [
 
 { #category : 'accessing' }
 FamixTFile >> averageNumberOfCharactersPerLine [
+
 	<FMProperty: #averageNumberOfCharactersPerLine type: #Number>
 	<FMComment: 'Average number of characters per line of text in a file.'>
 	<derived>
-	^ self
-		lookUpPropertyNamed: #averageNumberOfCharactersPerLine
-		computedAs: [ self numberOfLinesOfText isZero
-			ifFalse: [ (self numberOfCharacters / self numberOfLinesOfText) asFloat ]
-			ifTrue: [ 0 ] ]
+	^ self cacheAt: #averageNumberOfCharactersPerLine ifAbsentPut: [
+			  self numberOfLinesOfText isZero
+				  ifFalse: [ (self numberOfCharacters / self numberOfLinesOfText) asFloat ]
+				  ifTrue: [ 0 ] ]
 ]
 
 { #category : 'accessing' }
@@ -118,42 +118,44 @@ FamixTFile >> ifFileExistsDo: aBlock [
 
 { #category : 'properties' }
 FamixTFile >> numberOfBytes [
+
 	<FMProperty: #numberOfBytes type: #Number>
 	<FMComment: 'Number of bytes in a file.'>
 	<derived>
-	^ self
-		lookUpPropertyNamed: #numberOfBytes
-		computedAs: [ self fileExists
-				ifTrue: [ self fileReference size ]
-				ifFalse: [ 0 ] ]
+	^ self cacheAt: #numberOfBytes ifAbsentPut: [
+			  self fileExists
+				  ifTrue: [ self fileReference size ]
+				  ifFalse: [ 0 ] ]
 ]
 
 { #category : 'properties' }
 FamixTFile >> numberOfCharacters [
+
 	<FMProperty: #numberOfCharacters type: #Number>
 	<FMComment: 'Number of characters in a file.'>
 	<derived>
-	^ self lookUpPropertyNamed: #numberOfCharacters computedAs: [ self sourceText size ]
+	^ self cacheAt: #numberOfCharacters ifAbsentPut: [ self sourceText size ]
 ]
 
 { #category : 'properties' }
 FamixTFile >> numberOfEmptyLinesOfText [
+
 	<FMProperty: #numberOfEmptyLinesOfText type: #Number>
 	<FMComment: 'Number of empty lines of text'>
 	<derived>
-	^ self
-		lookUpPropertyNamed: #numberOfEmptyLinesOfText
-		computedAs: [ self fileExists
-				ifTrue: [ (self sourceText lines select: #isEmpty) size ]
-				ifFalse: [ 0 ] ]
+	^ self cacheAt: #numberOfEmptyLinesOfText ifAbsentPut: [
+			  self fileExists
+				  ifTrue: [ (self sourceText lines select: #isEmpty) size ]
+				  ifFalse: [ 0 ] ]
 ]
 
 { #category : 'properties' }
 FamixTFile >> numberOfKiloBytes [
+
 	<FMProperty: #numberOfKiloBytes type: #Number>
 	<FMComment: 'Number of kilo bytes in a file.'>
 	<derived>
-	^ self lookUpPropertyNamed: #numberOfKiloBytes computedAs: [ (self numberOfBytes / 1024) asFloat ]
+	^ self cacheAt: #numberOfKiloBytes ifAbsentPut: [ (self numberOfBytes / 1024) asFloat ]
 ]
 
 { #category : 'properties' }
@@ -163,11 +165,11 @@ FamixTFile >> readStream [
 
 { #category : 'accessing' }
 FamixTFile >> sourceText [
-	^ self
-		lookUpPropertyNamed: #sourceText
-		computedAs: [ self fileExists
-				ifTrue: [ self fileReference contents ]
-				ifFalse: [ '' ] ]
+
+	^ self cacheAt: #sourceText ifAbsentPut: [
+			  self fileExists
+				  ifTrue: [ self fileReference contents ]
+				  ifFalse: [ '' ] ]
 ]
 
 { #category : 'accessing' }
@@ -178,14 +180,15 @@ FamixTFile >> sourceText: aString [
 
 { #category : 'properties' }
 FamixTFile >> totalNumberOfLinesOfText [
+
 	<FMProperty: #totalNumberOfLinesOfText type: #Number>
 	<FMComment: 'Number of lines of text'>
 	<derived>
-	^ self
-		lookUpPropertyNamed: #totalNumberOfLinesOfText
-		computedAs: [ self sourceText
-				ifEmpty: [ (self name isNotNil and: [ self exists ])
-						ifTrue: [ (self sourceText select: [ :each | each = Character cr ]) size + 1 ]
-						ifFalse: [ 0 ] ]
-				ifNotEmpty: [ self sourceText lineCount ] ]
+	^ self cacheAt: #totalNumberOfLinesOfText ifAbsentPut: [
+			  self sourceText
+				  ifEmpty: [
+						  (self name isNotNil and: [ self exists ])
+							  ifTrue: [ (self sourceText select: [ :each | each = Character cr ]) size + 1 ]
+							  ifFalse: [ 0 ] ]
+				  ifNotEmpty: [ self sourceText lineCount ] ]
 ]

--- a/src/Famix-Traits/FamixTFile.trait.st
+++ b/src/Famix-Traits/FamixTFile.trait.st
@@ -172,7 +172,8 @@ FamixTFile >> sourceText [
 
 { #category : 'accessing' }
 FamixTFile >> sourceText: aString [
-	^ self propertyNamed: #sourceText put: aString
+
+	^ self cacheAt: #sourceText put: aString
 ]
 
 { #category : 'properties' }

--- a/src/Famix-Traits/FamixTFileNavigation.trait.st
+++ b/src/Famix-Traits/FamixTFileNavigation.trait.st
@@ -99,13 +99,14 @@ FamixTFileNavigation >> endLine: anObject [
 
 { #category : 'accessing' }
 FamixTFileNavigation >> endPos [
-	^ [ self
-		lookUpPropertyNamed: #endPos
-		computedAs: [ | text |
-			((text := self completeText) intervalOfLine: self endLine - 1) last
-				+ (self endColumn ifNil: [ (text lines at: self endLine) size	"In case I do not have any endcolumn." ]) ] ]
-		on: SubscriptOutOfBounds
-		do: [ :err | 0 ]
+
+	^ [
+		  self cacheAt: #endPos ifAbsentPut: [
+				  | text |
+				  ((text := self completeText) intervalOfLine: self endLine - 1) last
+				  + (self endColumn ifNil: [ (text lines at: self endLine) size "In case I do not have any endcolumn." ]) ] ]
+		  on: SubscriptOutOfBounds
+		  do: [ :err | 0 ]
 ]
 
 { #category : 'testing' }
@@ -211,13 +212,11 @@ FamixTFileNavigation >> startLine: anObject [
 
 { #category : 'accessing' }
 FamixTFileNavigation >> startPos [
-	^ self
-		lookUpPropertyNamed: #startPos
-		computedAs: [ (self completeText
-				intervalOfLine:
-					(self startLine
-						ifNil: [ 1 ]
-						ifNotNil: [ :start | start - 1 ])) last + (self startColumn ifNil: [ 0 ]) ]
+
+	^ self cacheAt: #startPos ifAbsentPut: [
+			  (self completeText intervalOfLine: (self startLine
+					    ifNil: [ 1 ]
+					    ifNotNil: [ :start | start - 1 ])) last + (self startColumn ifNil: [ 0 ]) ]
 ]
 
 { #category : 'testing' }

--- a/src/Famix-Traits/FamixTFileSystemEntity.trait.st
+++ b/src/Famix-Traits/FamixTFileSystemEntity.trait.st
@@ -118,10 +118,11 @@ FamixTFileSystemEntity >> numberOfEmptyLinesOfText [
 
 { #category : 'accessing' }
 FamixTFileSystemEntity >> numberOfLinesOfText [
+
 	<FMProperty: #numberOfLinesOfText type: #Number>
 	<FMComment: 'Number of lines of text which are not empty in a file'>
 	<derived>
-	^ self lookUpPropertyNamed: #numberOfLinesOfText computedAs: [ self totalNumberOfLinesOfText - self numberOfEmptyLinesOfText ]
+	^ self cacheAt: #numberOfLinesOfText ifAbsentPut: [ self totalNumberOfLinesOfText - self numberOfEmptyLinesOfText ]
 ]
 
 { #category : 'accessing' }

--- a/src/Famix-Traits/FamixTFolder.trait.st
+++ b/src/Famix-Traits/FamixTFolder.trait.st
@@ -131,42 +131,38 @@ FamixTFolder >> isFolder [
 
 { #category : 'properties' }
 FamixTFolder >> numberOfEmptyLinesOfText [
+
 	<FMProperty: #numberOfEmptyLinesOfText type: #Number>
 	<FMComment: 'Number of empty lines of text'>
 	<derived>
-	^ self lookUpPropertyNamed: #numberOfEmptyLinesOfText computedAs: [ 
-		self files, self folders sumNumbers: #numberOfEmptyLinesOfText
-	]
+	^ self cacheAt: #numberOfEmptyLinesOfText ifAbsentPut: [ self files , self folders sumNumbers: #numberOfEmptyLinesOfText ]
 ]
 
 { #category : 'properties' }
 FamixTFolder >> numberOfFiles [
+
 	<FMProperty: #numberOfFiles type: #Number>
 	<FMComment: 'The number of files in a folder'>
 	<derived>
-	^self
-		lookUpPropertyNamed: #numberOfFiles
-		computedAs: [self files size]
+	^ self cacheAt: #numberOfFiles ifAbsentPut: [ self files size ]
 ]
 
 { #category : 'properties' }
 FamixTFolder >> numberOfFolders [
+
 	<FMProperty: #numberOfFolders type: #Number>
 	<FMComment: 'The number of folders in a folder'>
 	<derived>
-	^self
-		lookUpPropertyNamed: #numberOfFolders
-		computedAs: [self folders size]
+	^ self cacheAt: #numberOfFolders ifAbsentPut: [ self folders size ]
 ]
 
 { #category : 'properties' }
 FamixTFolder >> totalNumberOfLinesOfText [
+
 	<FMProperty: #totalNumberOfLinesOfText type: #Number>
 	<FMComment: 'Number of lines of text'>
 	<derived>
-	^ self
-		lookUpPropertyNamed: #totalNumberOfLinesOfText
-		computedAs: [ self files , self folders sumNumbers: #totalNumberOfLinesOfText ]
+	^ self cacheAt: #totalNumberOfLinesOfText ifAbsentPut: [ self files , self folders sumNumbers: #totalNumberOfLinesOfText ]
 ]
 
 { #category : 'properties' }

--- a/src/Famix-Traits/FamixTLCOMMetrics.trait.st
+++ b/src/Famix-Traits/FamixTLCOMMetrics.trait.st
@@ -78,10 +78,7 @@ FamixTLCOMMetrics >> lcom2 [
 	<FMProperty: #lcom2 type: #Number>
 	<FMComment: 'lack of cohesion in methods 2 (lcom2)'>
 	<derived>
-
-	^ self
-		lookUpPropertyNamed: #lcom2
-		computedAs: [self calculateLCOM2]
+	^ self cacheAt: #lcom2 ifAbsentPut: [ self calculateLCOM2 ]
 ]
 
 { #category : 'Famix-Extensions-metrics-support' }
@@ -90,8 +87,5 @@ FamixTLCOMMetrics >> lcom3 [
 	<FMProperty: #lcom3 type: #Number>
 	<FMComment: 'lack of cohesion in methods 3 (lcom3)'>
 	<derived>
-
-	^ self
-		lookUpPropertyNamed: #lcom3
-		computedAs: [self calculateLCOM3]
+	^ self cacheAt: #lcom3 ifAbsentPut: [ self calculateLCOM3 ]
 ]

--- a/src/Famix-Traits/FamixTMethodMetrics.trait.st
+++ b/src/Famix-Traits/FamixTMethodMetrics.trait.st
@@ -23,9 +23,10 @@ FamixTMethodMetrics >> accept: aVisitor [
 
 { #category : 'metrics' }
 FamixTMethodMetrics >> cyclomaticComplexity [
+
 	<FMProperty: #cyclomaticComplexity type: #Number>
 	<FMComment: 'The number of linear-independent paths through a method.'>
-	^ self lookUpPropertyNamed: #cyclomaticComplexity computedAs: [ self computeCyclomaticComplexity ]
+	^ self cacheAt: #cyclomaticComplexity ifAbsent: [ self computeCyclomaticComplexity ]
 ]
 
 { #category : 'metrics' }
@@ -35,13 +36,11 @@ FamixTMethodMetrics >> cyclomaticComplexity: aNumber [
 
 { #category : 'metrics' }
 FamixTMethodMetrics >> hierarchyNestingLevel [
+
 	<FMProperty: #hierarchyNestingLevel type: #Number>
 	<derived>
 	<FMComment: 'The nesting level in the hierarchy'>
-	
-	^self
-		lookUpPropertyNamed: #hierarchyNestingLevel
-		computedAs: [ self parentType hierarchyNestingLevel]
+	^ self cacheAt: #hierarchyNestingLevel ifAbsent: [ self parentType hierarchyNestingLevel ]
 ]
 
 { #category : 'metrics' }

--- a/src/Famix-Traits/FamixTMultipleFileAnchor.trait.st
+++ b/src/Famix-Traits/FamixTMultipleFileAnchor.trait.st
@@ -73,9 +73,11 @@ FamixTMultipleFileAnchor >> allSourceAnchorsDo: aBlock [
 
 { #category : 'accessing' }
 FamixTMultipleFileAnchor >> containerFiles [
-	^ self
-		propertyNamed: #containerFiles
-		ifAbsentPut: [ self fileAnchors collect: #correspondingFile thenReject: #isNil ]
+
+	^ self cacheAt: #containerFiles ifAbsentPut: [
+			  self fileAnchors
+				  collect: #correspondingFile
+				  thenReject: #isNil ]
 ]
 
 { #category : 'adding' }

--- a/src/Famix-Traits/FamixTPackage.trait.st
+++ b/src/Famix-Traits/FamixTPackage.trait.st
@@ -117,8 +117,5 @@ FamixTPackage >> weightedMethodCount [
 	<FMProperty: #weightedMethodCount type: #Number>
 	<FMComment: 'The sum of the complexity in a package'>
 	<derived>
-	^ self
-		  lookUpPropertyNamed: #WMC
-		  computedAs: [ 
-		  (self toScope: FamixTWithMethods) sum: #weightedMethodCount ]
+	^ self cacheAt: #WMC ifAbsentPut: [ (self toScope: FamixTWithMethods) sum: #weightedMethodCount ]
 ]

--- a/src/Famix-Traits/FamixTSourceEntity.trait.st
+++ b/src/Famix-Traits/FamixTSourceEntity.trait.st
@@ -110,9 +110,10 @@ FamixTSourceEntity >> notExistentMetricValue [
 
 { #category : 'metrics' }
 FamixTSourceEntity >> numberOfLinesOfCode [
+
 	<FMProperty: #numberOfLinesOfCode type: #Number>
 	<FMComment: 'The number of lines of code in a method.'>
-	^ self lookUpPropertyNamed: #numberOfLinesOfCode computedAs: [ self computeNumberOfLinesOfCode ]
+	^ self cacheAt: #numberOfLinesOfCode ifAbsent: [ self computeNumberOfLinesOfCode ]
 ]
 
 { #category : 'metrics' }
@@ -122,18 +123,16 @@ FamixTSourceEntity >> numberOfLinesOfCode: aNumber [
 
 { #category : 'metrics' }
 FamixTSourceEntity >> numberOfLinesOfCodeWithMoreThanOneCharacter [
+
 	<FMProperty: #numberOfLinesOfCodeWithMoreThanOneCharacter type: #Number>
 	<derived>
-	<FMComment:
-		'This metric is essentially similar to the numberOfLinesOfCode one, 
+	<FMComment: 'This metric is essentially similar to the numberOfLinesOfCode one, 
 	the difference being that it only counts the lines with more than one non-whitespace characters.
 	This metric is particularly useful for comparing the density of other metrics on a line of code.
 	For example, depending on the formatting style chosen a Java curly brace, or a Smalltalk block 
 	can appear inline or on a separate line. For normalization purposes, these commonly appearing 
 	cases can be ruled out through the present metric.'>
-	^ self
-		lookUpPropertyNamed: #numberOfLinesOfCodeWithMoreThanOneCharacter
-		computedAs: [ (self sourceText lines select: [ :line | line trimBoth size > 1 ]) size ]
+	^ self cacheAt: #numberOfLinesOfCodeWithMoreThanOneCharacter ifAbsentPut: [ (self sourceText lines select: [ :line | line trimBoth size > 1 ]) size ]
 ]
 
 { #category : 'metrics' }

--- a/src/Famix-Traits/FamixTType.trait.st
+++ b/src/Famix-Traits/FamixTType.trait.st
@@ -123,11 +123,8 @@ FamixTType >> mooseNameOn: aStream [
 { #category : 'metrics' }
 FamixTType >> numberOfAccessesToForeignData [
 
-	self deprecated:
-		'This method will be removed in the nex version of Moose'.
-	^ self
-		  lookUpPropertyNamed: #numberOfAccessesToForeignData
-		  computedAs: [ self notExistentMetricValue ]
+	self deprecated: 'This method will be removed in the nex version of Moose'.
+	^ self cacheAt: #numberOfAccessesToForeignData ifAbsentPut: [ self notExistentMetricValue ]
 ]
 
 { #category : 'metrics' }

--- a/src/Famix-Traits/FamixTWithAnnotationInstances.trait.st
+++ b/src/Famix-Traits/FamixTWithAnnotationInstances.trait.st
@@ -103,7 +103,7 @@ FamixTWithAnnotationInstances >> numberOfAnnotationInstances [
 	<FMProperty: #numberOfAnnotationInstances type: #Number>
 	<derived>
 	<FMComment: 'The number of annotation instances defined in the class or in any of its methods'>
-	^ self lookUpPropertyNamed: #numberOfAnnotationInstances computedAs: [
+	^ self cacheAt: #numberOfAnnotationInstances ifAbsentPut: [
 			  self annotationInstances size + (self children inject: 0 into: [ :sum :each |
 					   (each isOfType: FamixTWithAnnotationInstances)
 						   ifTrue: [ sum + each numberOfAnnotationInstances ]

--- a/src/Famix-Traits/FamixTWithAttributes.trait.st
+++ b/src/Famix-Traits/FamixTWithAttributes.trait.st
@@ -60,13 +60,11 @@ FamixTWithAttributes >> attributes: anObject [
 
 { #category : 'Famix-Extensions' }
 FamixTWithAttributes >> numberOfAttributes [
+
 	<FMProperty: #numberOfAttributes type: #Number>
 	<derived>
 	<FMComment: 'The number of attributes in the class'>
-	
-	^self
-		lookUpPropertyNamed: #numberOfAttributes
-		computedAs: [self attributes size]
+	^ self cacheAt: #numberOfAttributes ifAbsent: [ self attributes size ]
 ]
 
 { #category : 'Famix-Extensions' }

--- a/src/Famix-Traits/FamixTWithComments.trait.st
+++ b/src/Famix-Traits/FamixTWithComments.trait.st
@@ -73,8 +73,9 @@ FamixTWithComments >> numberOfComments [
 
 	<FMProperty: #numberOfComments type: #Number>
 	<derived>
-	<FMComment: 'The number of comments in the entity. Does not count comments of children entities (for example, for a class, I will count the comments associated to the class and not the methods or arguments.'>
-	^ self lookUpPropertyNamed: #numberOfComments computedAs: [ self comments size ]
+	<FMComment:
+	'The number of comments in the entity. Does not count comments of children entities (for example, for a class, I will count the comments associated to the class and not the methods or arguments.'>
+	^ self cacheAt: #numberOfComments ifAbsent: [ self comments size ]
 ]
 
 { #category : 'accessing' }

--- a/src/Famix-Traits/FamixTWithInheritances.trait.st
+++ b/src/Famix-Traits/FamixTWithInheritances.trait.st
@@ -84,17 +84,18 @@ FamixTWithInheritances >> directSuperclasses [
 
 { #category : 'metrics' }
 FamixTWithInheritances >> hierarchyNestingLevel [
+
 	<FMProperty: #hierarchyNestingLevel type: #Number>
 	<derived>
 	<FMComment: 'The nesting of a class inside the hierarchy'>
-	^ self
-		lookUpPropertyNamed: #hierarchyNestingLevel
-		computedAs: [ | currentMaxDepth |
-			(self directSuperclasses isEmpty or: [ self isStub ])
-				ifTrue: [ 0 ]
-				ifFalse: [ currentMaxDepth := 0.
-					self allSuperclassesDo: [ :aClass | currentMaxDepth := currentMaxDepth max: aClass hierarchyNestingLevel ].
-					currentMaxDepth + 1 ] ]
+	^ self cacheAt: #hierarchyNestingLevel ifAbsent: [
+			  | currentMaxDepth |
+			  (self directSuperclasses isEmpty or: [ self isStub ])
+				  ifTrue: [ 0 ]
+				  ifFalse: [
+						  currentMaxDepth := 0.
+						  self allSuperclassesDo: [ :aClass | currentMaxDepth := currentMaxDepth max: aClass hierarchyNestingLevel ].
+						  currentMaxDepth + 1 ] ]
 ]
 
 { #category : 'metrics' }
@@ -133,10 +134,11 @@ FamixTWithInheritances >> numberOfDirectSubclasses: aNumber [
 
 { #category : 'metrics' }
 FamixTWithInheritances >> numberOfSubclasses [
+
 	<FMProperty: #numberOfSubclasses type: #Number>
 	<derived>
 	<FMComment: 'The number of subclasses of a class'>
-	^ self lookUpPropertyNamed: #numberOfSubclasses computedAs: [ self subInheritances size ]
+	^ self cacheAt: #numberOfSubclasses ifAbsent: [ self subInheritances size ]
 ]
 
 { #category : 'metrics' }

--- a/src/Famix-Traits/FamixTWithInvocations.trait.st
+++ b/src/Famix-Traits/FamixTWithInvocations.trait.st
@@ -47,9 +47,7 @@ FamixTWithInvocations >> numberOfOutgoingInvocations [
 	<FMProperty: #numberOfOutgoingInvocations type: #Number>
 	<derived>
 	<FMComment: 'The number of invocations in a method'>
-	^ self
-		  lookUpPropertyNamed: #numberOfOutgoingInvocations
-		  computedAs: [ self outgoingInvocations size ]
+	^ self cacheAt: #numberOfOutgoingInvocations ifAbsent: [ self outgoingInvocations size ]
 ]
 
 { #category : 'accessing' }

--- a/src/Famix-Traits/FamixTWithMethods.trait.st
+++ b/src/Famix-Traits/FamixTWithMethods.trait.st
@@ -75,10 +75,11 @@ FamixTWithMethods >> methodsGroup [
 
 { #category : 'metrics' }
 FamixTWithMethods >> numberOfAbstractMethods [
+
 	<FMProperty: #numberOfAbstractMethods type: #Number>
 	<derived>
 	<FMComment: 'The number of abstract methods in the class'>
-	^ self lookUpPropertyNamed: #numberOfAbstractMethods computedAs: [ self methodsGroup count: [ :each | each isAbstract ] ]
+	^ self cacheAt: #numberOfAbstractMethods ifAbsentPut: [ self methodsGroup count: [ :each | each isAbstract ] ]
 ]
 
 { #category : 'metrics' }
@@ -88,13 +89,11 @@ FamixTWithMethods >> numberOfAbstractMethods: aNumber [
 
 { #category : 'accessing' }
 FamixTWithMethods >> numberOfMethods [
+
 	<FMProperty: #numberOfMethods type: #Number>
 	<derived>
 	<FMComment: 'The number of methods in a class'>
-
-	^self
-		lookUpPropertyNamed: #numberOfMethods
-		computedAs: [self methods size]
+	^ self cacheAt: #numberOfMethods ifAbsent: [ self methods size ]
 ]
 
 { #category : 'accessing' }
@@ -104,37 +103,36 @@ FamixTWithMethods >> numberOfMethods: aNumber [
 
 { #category : 'metrics' }
 FamixTWithMethods >> tightClassCohesion [
+
 	<FMProperty: #tightClassCohesion type: #Number>
 	<derived>
 	<FMComment: 'Tight class cohesion of a class'>
 	self flag: #TODO.
-	^ self
-		lookUpPropertyNamed: #tightClassCohesion
-		computedAs: [ | tcc accessDictionary nom |
-			tcc := 0.
-			accessDictionary := Dictionary new.
-			self methods
-				do: [ :eachMethod | 
-					eachMethod accesses
-						do: [ :eachAccess | 
-							| var |
-							var := eachAccess variable.
-							var isAttribute
-								ifTrue: [ | varName accessedFrom |
-									varName := var name.
-									accessedFrom := accessDictionary at: varName ifAbsent: [  ].
-									accessedFrom
-										ifNil: [ accessedFrom := Set new.
-											accessDictionary at: varName put: accessedFrom ].
-									accessedFrom add: eachMethod name ] ] ].
-			accessDictionary values
-				do: [ :each | 
-					| size |
-					size := each size.
-					tcc := tcc + (size * (size - 1) / 2) ].
-			nom := self numberOfMethods.
-			tcc := (nom = 0 or: [ nom = 1 ]) ifFalse: [ tcc / (nom * (nom - 1) / 2) ] ifTrue: [ 0 ].
-			tcc asFloat ]
+	^ self cacheAt: #tightClassCohesion ifAbsentPut: [
+			  | tcc accessDictionary nom |
+			  tcc := 0.
+			  accessDictionary := Dictionary new.
+			  self methods do: [ :eachMethod |
+					  eachMethod accesses do: [ :eachAccess |
+							  | var |
+							  var := eachAccess variable.
+							  var isAttribute ifTrue: [
+									  | varName accessedFrom |
+									  varName := var name.
+									  accessedFrom := accessDictionary at: varName ifAbsent: [ ].
+									  accessedFrom ifNil: [
+											  accessedFrom := Set new.
+											  accessDictionary at: varName put: accessedFrom ].
+									  accessedFrom add: eachMethod name ] ] ].
+			  accessDictionary values do: [ :each |
+					  | size |
+					  size := each size.
+					  tcc := tcc + (size * (size - 1) / 2) ].
+			  nom := self numberOfMethods.
+			  tcc := (nom = 0 or: [ nom = 1 ])
+				         ifFalse: [ tcc / (nom * (nom - 1) / 2) ]
+				         ifTrue: [ 0 ].
+			  tcc asFloat ]
 ]
 
 { #category : 'metrics' }
@@ -144,13 +142,11 @@ FamixTWithMethods >> tightClassCohesion: aNumber [
 
 { #category : 'metrics' }
 FamixTWithMethods >> weightedMethodCount [
+
 	<FMProperty: #weightedMethodCount type: #Number>
 	<derived>
 	<FMComment: 'The sum of the complexity in a class'>
-			
-	^self
-		lookUpPropertyNamed: #weightedMethodCount
-		computedAs: [self methodsGroup sumNumbers: #cyclomaticComplexity]
+	^ self cacheAt: #weightedMethodCount ifAbsent: [ self methodsGroup sumNumbers: #cyclomaticComplexity ]
 ]
 
 { #category : 'metrics' }

--- a/src/Famix-Traits/FamixTWithParameters.trait.st
+++ b/src/Famix-Traits/FamixTWithParameters.trait.st
@@ -43,10 +43,11 @@ FamixTWithParameters >> addParameter: aParameter [
 
 { #category : 'accessing' }
 FamixTWithParameters >> numberOfParameters [
+
 	<FMProperty: #numberOfParameters type: #Number>
 	<FMComment: 'The number of parameters in a method'>
 	<derived>
-	^ self lookUpPropertyNamed: #numberOfParameters computedAs: [ self parameters size ]
+	^ self cacheAt: #numberOfParameters ifAbsent: [ self parameters size ]
 ]
 
 { #category : 'accessing' }

--- a/src/Famix-Traits/FamixTWithStatements.trait.st
+++ b/src/Famix-Traits/FamixTWithStatements.trait.st
@@ -63,11 +63,8 @@ FamixTWithStatements >> isBehavioural [
 { #category : 'as yet unclassified' }
 FamixTWithStatements >> numberOfLinesOfDeadCode [
 
-	self deprecated:
-		'This method will be removed in the next version of Moose'.
-	^ self
-		  lookUpPropertyNamed: #numberOflinesOfDeadCode
-		  computedAs: [ self deadChildren sumNumbers: #numberOfLinesOfCode ]
+	self deprecated: 'This method will be removed in the next version of Moose'.
+	^ self cacheAt: #numberOflinesOfDeadCode ifAbsentPut: [ self deadChildren sumNumbers: #numberOfLinesOfCode ]
 ]
 
 { #category : 'metrics' }

--- a/src/Famix-Traits/FamixTypeGroup.class.st
+++ b/src/Famix-Traits/FamixTypeGroup.class.st
@@ -83,42 +83,34 @@ FamixTypeGroup >> averageHierarchyHeighth [
 
 { #category : 'metrics' }
 FamixTypeGroup >> averageNumberOfAttributes [
+
 	<FMProperty: #averageNumberOfAttributes type: #Number>
 	<FMComment: 'Average number of attributes per class'>
-
-	^self
-		lookUpPropertyNamed: #averageNumberOfAttributes
-		computedAs: [(self average: [:each | each numberOfAttributes ]) asFloat]
+	^ self cacheAt: #averageNumberOfAttributes ifAbsentPut: [ (self average: [ :each | each numberOfAttributes ]) asFloat ]
 ]
 
 { #category : 'metrics' }
 FamixTypeGroup >> averageNumberOfLinesOfCode [
+
 	<FMProperty: #averageNumberOfMethods type: #Number>
 	<FMComment: 'Average number of methods per class'>
-	
-	^self
-		lookUpPropertyNamed: #averageNumberOfMethods
-		computedAs: [(self average: [:each | each numberOfLinesOfCode ]) asFloat]
+	^ self cacheAt: #averageNumberOfMethods ifAbsentPut: [ (self average: [ :each | each numberOfLinesOfCode ]) asFloat ]
 ]
 
 { #category : 'metrics' }
 FamixTypeGroup >> averageNumberOfMethods [
+
 	<FMProperty: #averageNumberOfMethods type: #Number>
 	<FMComment: 'Average number of methods per class'>
-
-	^self
-		lookUpPropertyNamed: #averageNumberOfMethods
-		computedAs: [(self average: [:each | each numberOfMethods ]) asFloat]
+	^ self cacheAt: #averageNumberOfMethods ifAbsentPut: [ (self average: [ :each | each numberOfMethods ]) asFloat ]
 ]
 
 { #category : 'metrics' }
 FamixTypeGroup >> averageNumberOfStatements [
-	<FMProperty: #averageNumberOfStatements type: #Number>
-	<FMComment: 'Average number of statements per class'>	
 
-	^self
-		lookUpPropertyNamed: #averageNumberOfStatements
-		computedAs: [(self average: [:each | each numberOfStatements]) asFloat]
+	<FMProperty: #averageNumberOfStatements type: #Number>
+	<FMComment: 'Average number of statements per class'>
+	^ self cacheAt: #averageNumberOfStatements ifAbsentPut: [ (self average: [ :each | each numberOfStatements ]) asFloat ]
 ]
 
 { #category : 'metrics' }

--- a/src/Famix-Traits/MooseAbstractGroup.extension.st
+++ b/src/Famix-Traits/MooseAbstractGroup.extension.st
@@ -137,8 +137,9 @@ MooseAbstractGroup >> allMethods [
 
 { #category : '*Famix-Traits' }
 MooseAbstractGroup >> allModelBehaviourals [
+
 	<navigation: 'All model behavioural entities'>
-	^ self lookUpPropertyNamed: #allModelBehaviourals computedAs: [ self computeAllModelBehaviourals ]
+	^ self cacheAt: #allModelBehaviourals ifAbsent: [ self computeAllModelBehaviourals ]
 ]
 
 { #category : '*Famix-Traits' }
@@ -197,8 +198,9 @@ MooseAbstractGroup >> allModelPureClasses [
 
 { #category : '*Famix-Traits' }
 MooseAbstractGroup >> allModelStructuralEntities [
+
 	<navigation: 'All model structural entities'>
-	^ self lookUpPropertyNamed: #allModelStructuralEntities computedAs: [ self computeAllModelStructuralEntities ]
+	^ self cacheAt: #allModelStructuralEntities ifAbsent: [ self computeAllModelStructuralEntities ]
 ]
 
 { #category : '*Famix-Traits' }
@@ -320,11 +322,10 @@ MooseAbstractGroup >> numberOfEntities [
 
 { #category : '*Famix-Traits' }
 MooseAbstractGroup >> numberOfLinesOfCode [
+
 	<FMProperty: #numberOfLinesOfCode type: #Number>
 	<FMComment: 'The number of classes in the model'>
-	^ self
-		lookUpPropertyNamed: #numberOfLinesOfCode
-		computedAs: [ self allMethods sum: #numberOfLinesOfCode ]
+	^ self cacheAt: #numberOfLinesOfCode ifAbsentPut: [ self allMethods sum: #numberOfLinesOfCode ]
 ]
 
 { #category : '*Famix-Traits' }

--- a/src/Famix-Traits/MooseModel.extension.st
+++ b/src/Famix-Traits/MooseModel.extension.st
@@ -2,10 +2,9 @@ Extension { #name : 'MooseModel' }
 
 { #category : '*Famix-Traits' }
 MooseModel >> allModelEntities [
+
 	<navigation: 'All model entities'>
-	^ self
-		lookUpPropertyNamed: #allModelEntities
-		computedAs: [ self entities reject: #isStub ]
+	^ self cacheAt: #allModelEntities ifAbsent: [ self entities reject: #isStub ]
 ]
 
 { #category : '*Famix-Traits' }
@@ -17,76 +16,67 @@ MooseModel >> allSourceLanguages [
 
 { #category : '*Famix-Traits' }
 MooseModel >> averageCyclomaticComplexity [
+
 	<FMProperty: #averageCyclomaticComplexity type: #Number>
 	<derived>
 	<FMComment: 'The average cyclomatic complexity for methods'>
-	^ self lookUpPropertyNamed: #averageCyclomaticComplexity computedAs: [ (self allMethods collect: #cyclomaticComplexity) ifEmpty: [ 1 ] ifNotEmpty: #average ]
+	^ self cacheAt: #averageCyclomaticComplexity ifAbsentPut: [ (self allMethods collect: #cyclomaticComplexity) ifEmpty: [ 1 ] ifNotEmpty: #average ]
 ]
 
 { #category : '*Famix-Traits' }
 MooseModel >> numberOfClassesPerPackage [
+
 	<FMProperty: #numberOfClassesPerPackage type: #Number>
 	<FMComment: 'The number of methods per package in the model'>
-	^ self
-		lookUpPropertyNamed: #numberOfClassesPerPackage
-		computedAs: [ self numberOfMethods / self numberOfClasses ]
+	^ self cacheAt: #numberOfClassesPerPackage ifAbsentPut: [ self numberOfMethods / self numberOfClasses ]
 ]
 
 { #category : '*Famix-Traits' }
 MooseModel >> numberOfLinesOfCodePerMethod [
+
 	<FMProperty: #numberOfLinesOfCodePerMethod type: #Number>
 	<FMComment: 'The number of lines of code per method in the model'>
-	^ self
-		lookUpPropertyNamed: #numberOfLinesOfCodePerMethod
-		computedAs: [ self numberOfLinesOfCode / self numberOfMethods ]
+	^ self cacheAt: #numberOfLinesOfCodePerMethod ifAbsentPut: [ self numberOfLinesOfCode / self numberOfMethods ]
 ]
 
 { #category : '*Famix-Traits' }
 MooseModel >> numberOfLinesOfCodePerPackage [
+
 	<FMProperty: #numberOfLinesOfCodePerPackage type: #Number>
 	<FMComment: 'The number of lines of code per package in the model'>
-	^ self
-		lookUpPropertyNamed: #numberOfLinesOfCodePerPackage
-		computedAs: [ self numberOfLinesOfCode / self numberOfPackages ]
+	^ self cacheAt: #numberOfLinesOfCodePerPackage ifAbsentPut: [ self numberOfLinesOfCode / self numberOfPackages ]
 ]
 
 { #category : '*Famix-Traits' }
 MooseModel >> numberOfMethods [
+
 	<FMProperty: #numberOfMethods type: #Number>
 	<FMComment: 'The number of methods'>
-	
-	^self
-		lookUpPropertyNamed: #numberOfMethods
-		computedAs: [ self allMethods size ]
+	^ self cacheAt: #numberOfMethods ifAbsentPut: [ self allMethods size ]
 ]
 
 { #category : '*Famix-Traits' }
 MooseModel >> numberOfMethodsPerPackage [
+
 	<FMProperty: #numberOfClassesPerPackage type: #Number>
 	<FMComment: 'The number of methods per package in the model'>
-	^ self
-		lookUpPropertyNamed: #numberOfMethodsPerPackage
-		computedAs: [ self numberOfMethods / self numberOfPackages ]
+	^ self cacheAt: #numberOfMethodsPerPackage ifAbsentPut: [ self numberOfMethods / self numberOfPackages ]
 ]
 
 { #category : '*Famix-Traits' }
 MooseModel >> numberOfModelClasses [
+
 	<FMProperty: #numberOfModelClasses type: #Number>
 	<FMComment: 'The number of classes in the model'>
-	
-	^self
-		lookUpPropertyNamed: #numberOfModelClasses
-		computedAs: [ self allModelClasses size ]
+	^ self cacheAt: #numberOfModelClasses ifAbsentPut: [ self allModelClasses size ]
 ]
 
 { #category : '*Famix-Traits' }
 MooseModel >> numberOfModelMethods [
+
 	<FMProperty: #numberOfModelMethods type: #Number>
 	<FMComment: 'The number of methods in the model'>
-	
-	^self
-		lookUpPropertyNamed: #numberOfModelMethods
-		computedAs: [ self allModelMethods size ]
+	^ self cacheAt: #numberOfModelMethods ifAbsentPut: [ self allModelMethods size ]
 ]
 
 { #category : '*Famix-Traits' }

--- a/src/Moose-Core-Tests/MooseAbstractGroupTest.class.st
+++ b/src/Moose-Core-Tests/MooseAbstractGroupTest.class.st
@@ -400,8 +400,9 @@ MooseAbstractGroupTest >> testOccurenceOf [
 
 { #category : 'tests' }
 MooseAbstractGroupTest >> testPropertyNamed [
-	self should: [group propertyNamed: #UNKNOWN] raise: NotFound.
-	group propertyNamed: 'UNKNOWN' put: 10.
+
+	self should: [ group propertyNamed: #UNKNOWN ] raise: NotFound.
+	group cacheAt: 'UNKNOWN' put: 10.
 	self assert: (group propertyNamed: #UNKNOWN) equals: 10
 ]
 

--- a/src/Moose-Core-Tests/MooseMSEImporterTest.class.st
+++ b/src/Moose-Core-Tests/MooseMSEImporterTest.class.st
@@ -170,14 +170,9 @@ MooseMSEImporterTest >> testUndeclaredProperty [
 	"The importer writes a trace when a property is undeclared.
 	This line will appear in CI traces, hence the following:"
 	self crTrace: '[Testing: This line is expected] '.
-	mooseModel := self readMSEStream:
-		              '((Moose-Core-Tests-Entities.Class (name ''ClassA'') (Undeclared 42) ))'
-			              readStream.
+	mooseModel := self readMSEStream: '((Moose-Core-Tests-Entities.Class (name ''ClassA'') (Undeclared 42) ))' readStream.
 
 	self assert: mooseModel allClasses first name equals: 'ClassA'.
-	self assert:
-		(mooseModel allClasses first propertyNamed: #Undeclared) isNotNil.
-	self
-		assert: (mooseModel allClasses first propertyNamed: #Undeclared)
-		equals: 42
+	self assert: (mooseModel allClasses first attributeAt: #Undeclared) isNotNil.
+	self assert: (mooseModel allClasses first attributeAt: #Undeclared) equals: 42
 ]

--- a/src/Moose-Core/MooseAbstractGroup.class.st
+++ b/src/Moose-Core/MooseAbstractGroup.class.st
@@ -71,8 +71,9 @@ MooseAbstractGroup >> addLast: anEntity [
 
 { #category : 'accessing' }
 MooseAbstractGroup >> allContainers [
+
 	<navigation: 'All containers'>
-	^ self lookUpPropertyNamed: #allContainers computedAs: [ self entities select: #isContainerEntity ]
+	^ self cacheAt: #allContainers ifAbsent: [ self entities select: #isContainerEntity ]
 ]
 
 { #category : 'groups' }
@@ -84,8 +85,9 @@ MooseAbstractGroup >> allMatching: aClassOrTrait [
 
 { #category : 'accessing' }
 MooseAbstractGroup >> allModelContainers [
+
 	<navigation: 'All model containers'>
-	^ self lookUpPropertyNamed: #allModelContainers computedAs: [ self computeAllModelContainers ]
+	^ self cacheAt: #allModelContainers ifAbsent: [ self computeAllModelContainers ]
 ]
 
 { #category : 'groups' }

--- a/src/Moose-Core/MooseAbstractGroup.class.st
+++ b/src/Moose-Core/MooseAbstractGroup.class.st
@@ -733,7 +733,7 @@ MooseAbstractGroup >> removeEntity: anEntity [
 { #category : 'accessing' }
 MooseAbstractGroup >> rootEntities [
 
-	^ self propertyNamed: #rootEntities ifAbsentPut: [ self entities select: [ :entity | entity isQueryable and: [ entity isRoot ] ] ]
+	^ self cacheAt: #rootEntities ifAbsentPut: [ self entities select: [ :entity | entity isQueryable and: [ entity isRoot ] ] ]
 ]
 
 { #category : 'accessing' }

--- a/src/Moose-Core/MooseEntity.class.st
+++ b/src/Moose-Core/MooseEntity.class.st
@@ -141,12 +141,13 @@ MooseEntity >> detectDependenciesUsing: aDetector [
 { #category : 'properties' }
 MooseEntity >> handleFameProperty: aSymbol value: anObject [
 	"If my super method is able to handle the missing property, I'm doing nothing. Else I save the value in the properties of the entity."
+
 	| value |
 	(super handleFameProperty: aSymbol value: anObject) ifTrue: [ ^ self ].
 	value := (anObject isCollection and: [ anObject size = 1 ])
 		         ifTrue: [ anObject anyOne ]
 		         ifFalse: [ anObject ].
-	self propertyNamed: aSymbol put: value
+	self attributeAt: aSymbol put: value
 ]
 
 { #category : 'initialization' }

--- a/src/Moose-Core/MooseGroup.class.st
+++ b/src/Moose-Core/MooseGroup.class.st
@@ -210,5 +210,6 @@ MooseGroup >> species [
 
 { #category : 'properties' }
 MooseGroup >> sumOfPropertyNamed: aPropertyName [
-	^ self inject: 0 into: [ :sum :each | sum + (each propertyNamed: aPropertyName ifNil: [ 0 ]) ]
+
+	^ self inject: 0 into: [ :sum :each | sum + (each cacheAt: aPropertyName ifAbsent: [ 0 ]) ]
 ]

--- a/src/Moose-Core/MooseModel.class.st
+++ b/src/Moose-Core/MooseModel.class.st
@@ -340,8 +340,9 @@ MooseModel >> addNoAnnounce: anElement [
 
 { #category : 'dead code' }
 MooseModel >> allBehaviouralsWithDeadCode [
+
 	<navigation: 'All behaviourals with dead code'>
-	^ self lookUpPropertyNamed: #allBehaviouralsWithDeadCode computedAs: [ self computeAllBehaviouralsWithDeadCode ]
+	^ self cacheAt: #allBehaviouralsWithDeadCode ifAbsent: [ self computeAllBehaviouralsWithDeadCode ]
 ]
 
 { #category : 'accessing' }
@@ -389,9 +390,8 @@ MooseModel >> computeNumberOfLinesOfCode [
 
 { #category : 'dead code' }
 MooseModel >> deadCodeRate [
-	^ self
-		lookUpPropertyNamed: #deadCodeRate
-		computedAs: [ self allBehaviouralsWithDeadCode size / self allModelBehaviourals size ]
+
+	^ self cacheAt: #deadCodeRate ifAbsentPut: [ self allBehaviouralsWithDeadCode size / self allModelBehaviourals size ]
 ]
 
 { #category : 'import-export' }
@@ -718,28 +718,26 @@ MooseModel >> name: aStringOrSymbol [
 
 { #category : 'metrics' }
 MooseModel >> numberOfClasses [
+
 	<FMProperty: #numberOfClasses type: #Number>
 	<FMComment: 'The number of classes'>
-	
-	^self
-		lookUpPropertyNamed: #numberOfClasses
-		computedAs: [ self allClasses size ]
+	^ self cacheAt: #numberOfClasses ifAbsentPut: [ self allClasses size ]
 ]
 
 { #category : 'metrics' }
 MooseModel >> numberOfLinesOfCode [
+
 	<FMProperty: #numberOfLinesOfCode type: #Number>
 	<FMComment: 'The number of lines of code of the project.'>
-	^ self lookUpPropertyNamed: #numberOfLinesOfCode computedAs: [ self computeNumberOfLinesOfCode ]
+	^ self cacheAt: #numberOfLinesOfCode ifAbsentPut: [ self computeNumberOfLinesOfCode ]
 ]
 
 { #category : 'metrics' }
 MooseModel >> numberOfLinesOfCodePerClass [
+
 	<FMProperty: #numberOfLinesOfCodePerClass type: #Number>
 	<FMComment: 'The number of lines of code per class in the model'>
-	^ self
-		lookUpPropertyNamed: #numberOfLinesOfCodePerClass
-		computedAs: [ self numberOfLinesOfCode / self numberOfClasses ]
+	^ self cacheAt: #numberOfLinesOfCodePerClass ifAbsentPut: [ self numberOfLinesOfCode / self numberOfClasses ]
 ]
 
 { #category : 'accessing' }

--- a/src/Moose-Core/MooseObject.class.st
+++ b/src/Moose-Core/MooseObject.class.st
@@ -543,17 +543,6 @@ MooseObject >> propertyNamed: propertyName [
 	^ self cacheAt: propertyName ifAbsent: [ NotFound signalFor: 'Property named ' , propertyName ]
 ]
 
-{ #category : 'properties' }
-MooseObject >> propertyNamed: propertyName ifNil: aBlock [
-	"Return the value of the property named propertyName, evaluate aBlock if the property does not exist"
-
-	^ self
-		cacheAt: propertyName asSymbol
-		ifAbsent: [ ([ self mmGetProperty: (self mooseDescription propertyNamed: propertyName) ]
-				on: Error
-				do: [ :ex | nil ]) ifNil: [ aBlock value ] ]
-]
-
 { #category : 'accessing' }
 MooseObject >> removeAttribute: aSymbol [
 	| each |

--- a/src/Moose-Core/MooseObject.class.st
+++ b/src/Moose-Core/MooseObject.class.st
@@ -255,6 +255,13 @@ MooseObject >> attributeAt: name put: value [
 	^ entityAttributes last value
 ]
 
+{ #category : 'properties' }
+MooseObject >> cacheAt: name [
+	"Returns the value of the property named propertyName, raises an error if the property does not exist"
+
+	^ self cacheAt: name ifAbsent: [ NotFound signalFor: 'Property named ' , name ]
+]
+
 { #category : 'accessing' }
 MooseObject >> cacheAt: name ifAbsent: aBlock [
 	^ cache at: name ifAbsent: [ aBlock value ]
@@ -529,13 +536,6 @@ MooseObject >> properties [
 	"for read only uses, i.e. don't change the returned value"
 	
 	^self allCachedValues
-]
-
-{ #category : 'properties' }
-MooseObject >> propertyNamed: propertyName [
-	"Returns the value of the property named propertyName, raises an error if the property does not exist"
-
-	^ self cacheAt: propertyName ifAbsent: [ NotFound signalFor: 'Property named ' , propertyName ]
 ]
 
 { #category : 'accessing' }

--- a/src/Moose-Core/MooseObject.class.st
+++ b/src/Moose-Core/MooseObject.class.st
@@ -382,11 +382,6 @@ MooseObject >> localMooseModel [
 	^ self mooseModel
 ]
 
-{ #category : 'properties' }
-MooseObject >> lookUpPropertyNamed: selector computedAs: aBlock [
-	^ self cacheAt: selector ifAbsentPut: aBlock
-]
-
 { #category : 'accessing' }
 MooseObject >> metamodel [
 	^ self mooseModel

--- a/src/Moose-Core/MooseObject.class.st
+++ b/src/Moose-Core/MooseObject.class.st
@@ -221,22 +221,37 @@ MooseObject >> announcer: anAnnouncer [
 ]
 
 { #category : 'accessing' }
+MooseObject >> attributeAt: name [
+
+	^ self attributeAt: name ifAbsent: [ NotFound signalFor: 'Property named ' , name ]
+]
+
+{ #category : 'accessing' }
 MooseObject >> attributeAt: name ifAbsent: aBlock [
-	1 to: entityAttributes size do: [ :n | name == (entityAttributes at: n) key ifTrue: [ ^ (entityAttributes at: n) value ] ].
+
+	| aName |
+	aName := name asSymbol.
+	1 to: entityAttributes size do: [ :n | aName == (entityAttributes at: n) key ifTrue: [ ^ (entityAttributes at: n) value ] ].
 	^ aBlock value
 ]
 
 { #category : 'accessing' }
 MooseObject >> attributeAt: name ifAbsentPut: aBlock [
-	1 to: entityAttributes size do: [ :n | name == (entityAttributes at: n) key ifTrue: [ ^ (entityAttributes at: n) value ] ].
-	entityAttributes := entityAttributes copyWith: name -> aBlock value.
+
+	| aName |
+	aName := name asSymbol.
+	1 to: entityAttributes size do: [ :n | aName == (entityAttributes at: n) key ifTrue: [ ^ (entityAttributes at: n) value ] ].
+	entityAttributes := entityAttributes copyWith: aName -> aBlock value.
 	^ entityAttributes last value
 ]
 
 { #category : 'accessing' }
 MooseObject >> attributeAt: name put: value [
-	1 to: entityAttributes size do: [ :n | name == (entityAttributes at: n) key ifTrue: [ ^ (entityAttributes at: n) value: value ] ].
-	entityAttributes := entityAttributes copyWith: name -> value.
+
+	| aName |
+	aName := name asSymbol.
+	1 to: entityAttributes size do: [ :n | aName == (entityAttributes at: n) key ifTrue: [ ^ (entityAttributes at: n) value: value ] ].
+	entityAttributes := entityAttributes copyWith: aName -> value.
 	^ entityAttributes last value
 ]
 
@@ -522,21 +537,10 @@ MooseObject >> properties [
 ]
 
 { #category : 'properties' }
-MooseObject >> propertyNamed: propertyName [ 
+MooseObject >> propertyNamed: propertyName [
 	"Returns the value of the property named propertyName, raises an error if the property does not exist"
 
-	^ self propertyNamed: propertyName ifAbsent: [ NotFound signalFor: 'Property named ', propertyName  ]
-]
-
-{ #category : 'properties' }
-MooseObject >> propertyNamed: propertyName ifAbsent: aBlock [
-	"Return the value of the property named propertyName, evaluate aBlock if the property does not exist"
-
-	^ self
-		cacheAt: propertyName asSymbol
-		ifAbsent: [ ([ self mmGetProperty: (self mooseDescription propertyNamed: propertyName) ]
-				on: Error
-				do: [ :ex | nil ]) ifNil: [ aBlock value ] ]
+	^ self cacheAt: propertyName ifAbsent: [ NotFound signalFor: 'Property named ' , propertyName ]
 ]
 
 { #category : 'properties' }

--- a/src/Moose-Core/MooseObject.class.st
+++ b/src/Moose-Core/MooseObject.class.st
@@ -540,11 +540,6 @@ MooseObject >> propertyNamed: propertyName ifAbsent: aBlock [
 ]
 
 { #category : 'properties' }
-MooseObject >> propertyNamed: name ifAbsentPut: value [
-	^ self cacheAt: name ifAbsentPut: value
-]
-
-{ #category : 'properties' }
 MooseObject >> propertyNamed: propertyName ifNil: aBlock [
 	"Return the value of the property named propertyName, evaluate aBlock if the property does not exist"
 

--- a/src/Moose-Core/MooseObject.class.st
+++ b/src/Moose-Core/MooseObject.class.st
@@ -555,11 +555,6 @@ MooseObject >> propertyNamed: propertyName ifNil: aBlock [
 				do: [ :ex | nil ]) ifNil: [ aBlock value ] ]
 ]
 
-{ #category : 'properties' }
-MooseObject >> propertyNamed: name put: value [
-	^ self cacheAt: name put: value
-]
-
 { #category : 'accessing' }
 MooseObject >> removeAttribute: aSymbol [
 	| each |

--- a/src/Moose-Core/MooseObject.class.st
+++ b/src/Moose-Core/MooseObject.class.st
@@ -530,14 +530,6 @@ MooseObject >> privateSetMooseModel: aMooseModel [
 	"Do nothing in Object"
 ]
 
-{ #category : 'private' }
-MooseObject >> properties [ 
-	 
-	"for read only uses, i.e. don't change the returned value"
-	
-	^self allCachedValues
-]
-
 { #category : 'accessing' }
 MooseObject >> removeAttribute: aSymbol [
 	| each |

--- a/src/Moose-Query/TEntityMetaLevelDependency.trait.st
+++ b/src/Moose-Query/TEntityMetaLevelDependency.trait.st
@@ -339,12 +339,14 @@ TEntityMetaLevelDependency >> allChildrenTypes [
 
 { #category : 'accessing' }
 TEntityMetaLevelDependency >> allClients [
-	^ self lookUpPropertyNamed: #allClients computedAs: [( self queryAllIncoming withoutSelfLoops collect: #source ) flattened ]
+
+	^ self cacheAt: #allClients ifAbsent: [ (self queryAllIncoming withoutSelfLoops collect: #source) flattened ]
 ]
 
 { #category : 'accessing' }
 TEntityMetaLevelDependency >> allClientsAtMyScope [
-	^ self lookUpPropertyNamed: #allClientsAtMyScope computedAs: [ self allClientsAtScope: self class ]
+
+	^ self cacheAt: #allClientsAtMyScope ifAbsent: [ self allClientsAtScope: self class ]
 ]
 
 { #category : 'accessing' }
@@ -380,12 +382,14 @@ TEntityMetaLevelDependency >> allParents [
 
 { #category : 'accessing' }
 TEntityMetaLevelDependency >> allProviders [
-^ self lookUpPropertyNamed: #allProviders computedAs: [ (self queryAllOutgoing  withoutSelfLoops collect: #target) flattened ]
+
+	^ self cacheAt: #allProviders ifAbsentPut: [ (self queryAllOutgoing withoutSelfLoops collect: #target) flattened ]
 ]
 
 { #category : 'accessing' }
 TEntityMetaLevelDependency >> allProvidersAtMyScope [
-	^ self lookUpPropertyNamed: #allProvidersAtMyScope computedAs: [ self allProvidersAtScope: self class ]
+
+	^ self cacheAt: #allProvidersAtMyScope ifAbsent: [ self allProvidersAtScope: self class ]
 ]
 
 { #category : 'accessing' }
@@ -757,42 +761,38 @@ TEntityMetaLevelDependency >> numberOfChildren [
 
 { #category : 'accessing' }
 TEntityMetaLevelDependency >> numberOfExternalClients [
+
 	<FMProperty: #numberOfExternalClients type: #Number>
 	<derived>
 	<FMComment: 'Number of call from myself to outside my container.'>
-	^ self
-		lookUpPropertyNamed: #numberOfExternalClients
-		computedAs: [ (self allClients reject: [ :entity | entity allParents includesAny: self parents ]) size ]
+	^ self cacheAt: #numberOfExternalClients ifAbsentPut: [ (self allClients reject: [ :entity | entity allParents includesAny: self parents ]) size ]
 ]
 
 { #category : 'accessing' }
 TEntityMetaLevelDependency >> numberOfExternalProviders [
+
 	<FMProperty: #numberOfExternalProviders type: #Number>
 	<derived>
 	<FMComment: 'Number of call to myself from outside my container.'>
-	^ self
-		lookUpPropertyNamed: #numberOfExternalProviders
-		computedAs: [ (self allProviders reject: [ :entity | entity allParents includesAny: self parents ]) size ]
+	^ self cacheAt: #numberOfExternalProviders ifAbsentPut: [ (self allProviders reject: [ :entity | entity allParents includesAny: self parents ]) size ]
 ]
 
 { #category : 'accessing' }
 TEntityMetaLevelDependency >> numberOfInternalClients [
+
 	<FMProperty: #numberOfInternalClients type: #Number>
 	<derived>
 	<FMComment: 'Number of call from myself to entities of my container.'>
-	^ self
-		lookUpPropertyNamed: #numberOfInternalClients
-		computedAs: [ (self allClients select: [ :entity | entity allParents includesAny: self parents ]) size ]
+	^ self cacheAt: #numberOfInternalClients ifAbsentPut: [ (self allClients select: [ :entity | entity allParents includesAny: self parents ]) size ]
 ]
 
 { #category : 'accessing' }
 TEntityMetaLevelDependency >> numberOfInternalProviders [
+
 	<FMProperty: #numberOfInternalProviders type: #Number>
 	<derived>
 	<FMComment: 'Number of call to myself from entities from my container.'>
-	^ self
-		lookUpPropertyNamed: #numberOfInternalProviders
-		computedAs: [ (self allProviders select: [ :entity | entity allParents includesAny: self parents ]) size ]
+	^ self cacheAt: #numberOfInternalProviders ifAbsentPut: [ (self allProviders select: [ :entity | entity allParents includesAny: self parents ]) size ]
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
Deprecate the whole "properties" API in favor of the "cache" API. 
This is the first step of the cleaning of the cache API