### PR TITLE
Use "Fame" instead of "MSE" when it makes sens

### DIFF
--- a/src/Famix-Deprecated/TEntityMetaLevelDependency.extension.st
+++ b/src/Famix-Deprecated/TEntityMetaLevelDependency.extension.st
@@ -1,0 +1,16 @@
+Extension { #name : 'TEntityMetaLevelDependency' }
+
+{ #category : '*Famix-Deprecated' }
+TEntityMetaLevelDependency >> incomingMSEProperties [
+
+	self deprecated: 'Use #incomingFameProperties instead.' transformWith: '`@rcv incomingMSEProperties' -> '`@rcv incomingFameProperties'.
+	^ self incomingFameProperties
+]
+
+{ #category : '*Famix-Deprecated' }
+TEntityMetaLevelDependency >> outgoingMSEProperties [
+	"finds all properties from entities of 'self class' to other entities"
+
+	self deprecated: 'Use #outgoingFameProperties instead.' transformWith: '`@rcv outgoingMSEProperties' -> '`@rcv outgoingFameProperties'.
+	^ self outgoingFameProperties
+]

--- a/src/Famix-Java-Tests/FamixJavaQueryTest.class.st
+++ b/src/Famix-Java-Tests/FamixJavaQueryTest.class.st
@@ -172,5 +172,6 @@ FamixJavaQueryTest >> testFamixJavaAnnotationInstanceAttributeCanHaveIncoming [
 
 { #category : 'tests - class' }
 FamixJavaQueryTest >> testFamixJavaAnnotationInstanceAttributeCanHaveOutgoing [
-	self assert: annotationInstanceAttribute1 outgoingMSEProperties isCollection
+
+	self assert: annotationInstanceAttribute1 outgoingFameProperties isCollection
 ]

--- a/src/Moose-Query/MQNavigationDirectionStrategy.class.st
+++ b/src/Moose-Query/MQNavigationDirectionStrategy.class.st
@@ -35,6 +35,11 @@ MQNavigationDirectionStrategy class >> entityFor: anAssociation [
 	^ self subclassResponsibility
 ]
 
+{ #category : 'accessing' }
+MQNavigationDirectionStrategy class >> famePropertiesOf: anEntity [
+	^ self subclassResponsibility
+]
+
 { #category : 'instance creation' }
 MQNavigationDirectionStrategy class >> fromSymbol: aSymbol [
 	"I return the right strategy from a Symbol representing a direction"
@@ -45,11 +50,6 @@ MQNavigationDirectionStrategy class >> fromSymbol: aSymbol [
 { #category : 'testing' }
 MQNavigationDirectionStrategy class >> isAbstract [
 	^ self = MQNavigationDirectionStrategy
-]
-
-{ #category : 'accessing' }
-MQNavigationDirectionStrategy class >> msePropertiesOf: anEntity [
-	^ self subclassResponsibility
 ]
 
 { #category : 'accessing' }

--- a/src/Moose-Query/MQNavigationIncomingDirectionStrategy.class.st
+++ b/src/Moose-Query/MQNavigationIncomingDirectionStrategy.class.st
@@ -23,8 +23,9 @@ MQNavigationIncomingDirectionStrategy class >> entityFor: anAssociation [
 ]
 
 { #category : 'accessing' }
-MQNavigationIncomingDirectionStrategy class >> msePropertiesOf: anEntity [
-	^ anEntity incomingMSEProperties
+MQNavigationIncomingDirectionStrategy class >> famePropertiesOf: anEntity [
+
+	^ anEntity incomingFameProperties
 ]
 
 { #category : 'accessing' }

--- a/src/Moose-Query/MQNavigationOutgoingDirectionStrategy.class.st
+++ b/src/Moose-Query/MQNavigationOutgoingDirectionStrategy.class.st
@@ -23,8 +23,9 @@ MQNavigationOutgoingDirectionStrategy class >> entityFor: anAssociation [
 ]
 
 { #category : 'accessing' }
-MQNavigationOutgoingDirectionStrategy class >> msePropertiesOf: anEntity [
-	^ anEntity outgoingMSEProperties
+MQNavigationOutgoingDirectionStrategy class >> famePropertiesOf: anEntity [
+
+	^ anEntity outgoingFameProperties
 ]
 
 { #category : 'accessing' }

--- a/src/Moose-Query/MQNavigationQuery.class.st
+++ b/src/Moose-Query/MQNavigationQuery.class.st
@@ -143,7 +143,7 @@ MQNavigationQuery >> hasLocalFor: anEntity [
 
 	| properties |
 	"Instead of #to:do: we could just use #do: but this implementation is much faster. Maybe sista will remove the needs of the todo later."
-	1 to: (properties := directionStrategy msePropertiesOf: anEntity) size do: [ :ind | 
+	1 to: (properties := directionStrategy famePropertiesOf: anEntity) size do: [ :ind | 
 		(anEntity perform: (properties at: ind) name)
 			ifNotNil: [ :coll | (associationSelectionStrategy selectAssociationsIn: coll asCollection) ifNotEmpty: [ ^ true ] ] ].
 	^ false
@@ -207,7 +207,7 @@ MQNavigationQuery >> queryLocalFor: anEntity [
 	| properties |
 	"Instead of #to:do: we could just use #do: but this implementation is much faster. Maybe sista will remove the needs of the todo later."
 	1 to:
-		(properties := directionStrategy msePropertiesOf: anEntity) size do: [ 
+		(properties := directionStrategy famePropertiesOf: anEntity) size do: [ 
 		:ind | 
 		(anEntity perform: (properties at: ind) name) ifNotNil: [ :coll | 
 			result addAll: (resultKindStrategy

--- a/src/Moose-Query/TEntityMetaLevelDependency.trait.st
+++ b/src/Moose-Query/TEntityMetaLevelDependency.trait.st
@@ -120,10 +120,10 @@ TEntityMetaLevelDependency classSide >> incomingAssociationTypesIn: aMetamodel [
 ]
 
 { #category : 'accessing' }
-TEntityMetaLevelDependency classSide >> incomingMSEPropertiesIn: aMetamodel [
+TEntityMetaLevelDependency classSide >> incomingFamePropertiesIn: aMetamodel [
 	"computes all properties that are target of association for self (a class) belonging to aMetamodel"
 
-	^ aMetamodel additionalProperty: #incomingMSEProperties for: self ifAbsentPut: [ self privateIncomingMSEPropertiesIn: aMetamodel ]
+	^ aMetamodel additionalProperty: #incomingFameProperties for: self ifAbsentPut: [ self privateIncomingFamePropertiesIn: aMetamodel ]
 ]
 
 { #category : 'accessing' }
@@ -134,9 +134,9 @@ TEntityMetaLevelDependency classSide >> outgoingAssociationTypesIn: aMetamodel [
 ]
 
 { #category : 'accessing' }
-TEntityMetaLevelDependency classSide >> outgoingMSEPropertiesIn: aMetamodel [
+TEntityMetaLevelDependency classSide >> outgoingFamePropertiesIn: aMetamodel [
 
-	^ aMetamodel additionalProperty: #outgoingMSEProperties for: self ifAbsentPut: [ self privateOutgoingMSEPropertiesIn: aMetamodel ]
+	^ aMetamodel additionalProperty: #outgoingFameProperties for: self ifAbsentPut: [ self privateOutgoingFamePropertiesIn: aMetamodel ]
 	
 ]
 
@@ -214,16 +214,14 @@ TEntityMetaLevelDependency classSide >> privateIncomingAssociationTypesIn: aMeta
 ]
 
 { #category : 'private' }
-TEntityMetaLevelDependency classSide >> privateIncomingMSEPropertiesIn: aMetamodel [
-
+TEntityMetaLevelDependency classSide >> privateIncomingFamePropertiesIn: aMetamodel [
 	"Collects all fame properties defining an incoming dependency to self.
 	
 	An incoming dependency is reified by an association.	
 	My property has an opposite, that is the property of the association. This property is target.
 	Since the direction of the relation is defined in the association, my property is not source, nor target."
 
-	^ (self allDeclaredPropertiesIn: aMetamodel) select: [ :p | 
-		  p hasOpposite and: [ p opposite isTarget and: [ p isSource not ] ] ]
+	^ (self allDeclaredPropertiesIn: aMetamodel) select: [ :p | p hasOpposite and: [ p opposite isTarget and: [ p isSource not ] ] ]
 ]
 
 { #category : 'private' }
@@ -237,16 +235,14 @@ TEntityMetaLevelDependency classSide >> privateOutgoingAssociationTypesIn: aMeta
 ]
 
 { #category : 'private' }
-TEntityMetaLevelDependency classSide >> privateOutgoingMSEPropertiesIn: aMetamodel [
-
+TEntityMetaLevelDependency classSide >> privateOutgoingFamePropertiesIn: aMetamodel [
 	"Collects all fame properties defining a outgoing dependency to self.
 	
 	An outgoing dependency is reified by an association.	
 	My property has an opposite, that is the property of the association. This property is source.
 	Since the direction of the relation is defined in the association, my property is not source, nor target."
 
-	^ (self allDeclaredPropertiesIn: aMetamodel) select: [ :p | 
-		  p hasOpposite and: [ p opposite isSource and: [ p isTarget not ] ] ]
+	^ (self allDeclaredPropertiesIn: aMetamodel) select: [ :p | p hasOpposite and: [ p opposite isSource and: [ p isTarget not ] ] ]
 ]
 
 { #category : 'private' }
@@ -695,8 +691,8 @@ TEntityMetaLevelDependency >> incomingAssociationTypes [
 ]
 
 { #category : 'accessing' }
-TEntityMetaLevelDependency >> incomingMSEProperties [
-	^ self class incomingMSEPropertiesIn: self metamodel
+TEntityMetaLevelDependency >> incomingFameProperties [
+	^ self class incomingFamePropertiesIn: self metamodel
 ]
 
 { #category : 'testing' }
@@ -801,9 +797,10 @@ TEntityMetaLevelDependency >> outgoingAssociationTypes [
 ]
 
 { #category : 'accessing' }
-TEntityMetaLevelDependency >> outgoingMSEProperties [
+TEntityMetaLevelDependency >> outgoingFameProperties [
 	"finds all properties from entities of 'self class' to other entities"
-	^ self class outgoingMSEPropertiesIn: self metamodel
+
+	^ self class outgoingFamePropertiesIn: self metamodel
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
We have still methods with "MSE" in the name instead of "Fame" because it has nothing to do with the MSE format.

Fixes #734