### PR TITLE
Add #isSelfInvocation/#isSuperInvocation

### DIFF
--- a/src/Famix-Traits/FamixTInvocation.trait.st
+++ b/src/Famix-Traits/FamixTInvocation.trait.st
@@ -162,6 +162,22 @@ FamixTInvocation >> isInvocation [
 	^ true
 ]
 
+{ #category : 'testing' }
+FamixTInvocation >> isSelfInvocation [
+
+	self receiver ifNil: [ ^ false ].
+
+	^ self receiver isImplicitVariable and: [ self receiver isSelf ]
+]
+
+{ #category : 'testing' }
+FamixTInvocation >> isSuperInvocation [
+
+	self receiver ifNil: [ ^ false ].
+
+	^ self receiver isImplicitVariable and: [ self receiver isSuper ]
+]
+
 { #category : 'accessing' }
 FamixTInvocation >> receiver [
 	"Relation named: #receiver type: #FamixTInvocationsReceiver opposite: #receivingInvocations"


### PR DESCRIPTION
This is needed for the class blueprint and now it is also needed for the callgraphs. 

I generalized the implementation of the class blueprint for it to work on FamixTInvocation