### PR TITLE
Changing TEntityMetaLevelDependency>>children

### DIFF
--- a/src/Famix-Java-Tests/FamixJavaQueryTest.class.st
+++ b/src/Famix-Java-Tests/FamixJavaQueryTest.class.st
@@ -167,7 +167,9 @@ FamixJavaQueryTest >> setUp [
 
 { #category : 'tests - class' }
 FamixJavaQueryTest >> testFamixJavaAnnotationInstanceAttributeCanHaveIncoming [
-	self assert: annotationInstanceAttribute1 incomingMSEProperties isCollection
+
+	self assert:
+		annotationInstanceAttribute1 incomingFameProperties isCollection
 ]
 
 { #category : 'tests - class' }

--- a/src/Moose-Core-Tests/MooseAbstractGroupTest.class.st
+++ b/src/Moose-Core-Tests/MooseAbstractGroupTest.class.st
@@ -401,9 +401,9 @@ MooseAbstractGroupTest >> testOccurenceOf [
 { #category : 'tests' }
 MooseAbstractGroupTest >> testPropertyNamed [
 
-	self should: [ group propertyNamed: #UNKNOWN ] raise: NotFound.
+	self should: [ group cacheAt: #UNKNOWN ] raise: NotFound.
 	group cacheAt: 'UNKNOWN' put: 10.
-	self assert: (group propertyNamed: #UNKNOWN) equals: 10
+	self assert: (group cacheAt: #UNKNOWN) equals: 10
 ]
 
 { #category : 'tests' }

--- a/src/Moose-Query/TEntityMetaLevelDependency.trait.st
+++ b/src/Moose-Query/TEntityMetaLevelDependency.trait.st
@@ -512,7 +512,7 @@ TEntityMetaLevelDependency >> belongsTo: anEntity [
 TEntityMetaLevelDependency >> children [
 
 	| res |
-	res := Set new.
+	res := OrderedCollection new.
 	self childrenSelectors do: [ :accessor |
 		(self perform: accessor) ifNotNil: [ :r |
 			r isCollection


### PR DESCRIPTION
TEntityMetaLevelDependency>>children return OrderedCollection instead of a set.