### PR TITLE
Remove explicit requirement

### DIFF
--- a/src/Famix-Traits/FamixTSourceEntity.trait.st
+++ b/src/Famix-Traits/FamixTSourceEntity.trait.st
@@ -109,11 +109,6 @@ FamixTSourceEntity >> multipleFileAnchorClass [
 				ifAbsent: [ self error: 'This metamodel does not includes the full concept of MultipleFileAnchor needed.' ] ]
 ]
 
-{ #category : 'properties' }
-FamixTSourceEntity >> notExistentMetricValue [
-	^ self explicitRequirement
-]
-
 { #category : 'metrics' }
 FamixTSourceEntity >> numberOfLinesOfCode [
 


### PR DESCRIPTION
This method is implemented on the top of MooseObject hierarchy already and #explicitRequirement will be removed