### PR TITLE
Fix export of #numberOfStatements

### DIFF
--- a/src/Famix-Traits/FamixTWithStatements.trait.st
+++ b/src/Famix-Traits/FamixTWithStatements.trait.st
@@ -72,7 +72,7 @@ FamixTWithStatements >> numberOfStatements [
 
 	<FMProperty: #numberOfStatements type: #Number>
 	<FMComment: 'The number of statements in a class'>
-	^ self attributeAt: #numberOfStatements ifAbsent: [ MooseUnavailableMetric ]
+	^ self attributeAt: #numberOfStatements ifAbsent: [ self notExistentMetricValue ]
 ]
 
 { #category : 'metrics' }

--- a/src/Famix-VerveineJ-Tests/VerveineJModelTest.class.st
+++ b/src/Famix-VerveineJ-Tests/VerveineJModelTest.class.st
@@ -33,9 +33,5 @@ VerveineJModelTest >> testNumberOfLinesOfCode [
 { #category : 'tests' }
 VerveineJModelTest >> testNumberOfStatements [
 
-	self
-		assert: (model allMethods entityNamed:
-				 #'moose.lan.server.PrintServer.output(Packet)')
-				numberOfStatements
-		equals: MooseUnavailableMetric
+	self assert: (model allMethods entityNamed: #'moose.lan.server.PrintServer.output(Packet)') numberOfStatements equals: -1
 ]


### PR DESCRIPTION
We cannot export MooseUnavailableMetric in JSON/MSE for now. We should probably fix this, but in the meatime I'm using the same trick as we are using in other places with #notExistentMetricValue