### PR TITLE
Speedup #sourceText

### DIFF
--- a/src/Famix-Traits/FamixTAccess.trait.st
+++ b/src/Famix-Traits/FamixTAccess.trait.st
@@ -88,13 +88,13 @@ FamixTAccess >> accessor: anObject [
 	accessor := anObject
 ]
 
-{ #category : #adding }
+{ #category : 'adding' }
 FamixTAccess >> addCandidate: anObject [
 	<generated>
 	^ self candidates add: anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 FamixTAccess >> candidates [
 	"Relation named: #candidates type: #FamixTAccessible opposite: #incomingAccesses"
 
@@ -105,14 +105,14 @@ FamixTAccess >> candidates [
 	^ candidates
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 FamixTAccess >> candidates: anObject [
 
 	<generated>
 	candidates value: anObject
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 FamixTAccess >> displayFullStringOn: aStream [
 
 	self source displayFullStringOn: aStream.
@@ -122,7 +122,7 @@ FamixTAccess >> displayFullStringOn: aStream [
 		 ifFalse: [ self candidates ]) displayStringOn: aStream
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 FamixTAccess >> displayStringOn: aStream [
 
 	(self candidates size = 1
@@ -175,7 +175,7 @@ FamixTAccess >> printOn: aStream [
 	aStream nextPutAll: ' (Access)'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 FamixTAccess >> target: aTarget [
 
 	aTarget isCollection
@@ -183,7 +183,7 @@ FamixTAccess >> target: aTarget [
 		ifFalse: [ self variable: aTarget ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 FamixTAccess >> variable [
 	"This method returns only one candidate if there is one, or raises an error if there is more or less than one candidate."
 
@@ -193,7 +193,7 @@ FamixTAccess >> variable [
 	^ self candidates anyOne
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 FamixTAccess >> variable: anEntity [
 
 	^ self candidates: { anEntity }

--- a/src/Famix-Traits/FamixTIndexedFileNavigation.trait.st
+++ b/src/Famix-Traits/FamixTIndexedFileNavigation.trait.st
@@ -147,7 +147,7 @@ FamixTIndexedFileNavigation >> sourceText [
 		binaryReadStreamDo: [ :in | 
 			| stream |
 			stream := ZnCharacterReadStream on: in encoding: self encoding.
-			1 to: start - 1 do: [ :i | stream next ].
+			stream position:  start - 1.
 			stream next: (endPos ifNil: [ in size + 1 ]) - start + 1 ]
 ]
 

--- a/src/Famix-Traits/FamixTInvocation.trait.st
+++ b/src/Famix-Traits/FamixTInvocation.trait.st
@@ -211,7 +211,7 @@ FamixTInvocation >> sender: anObject [
 	sender := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 FamixTInvocation >> target: aTarget [
 
 	aTarget isCollection


### PR DESCRIPTION
I think the API of stream evolved since I implemented the optimized #sourceText and we can do even more performant now!

+ Fix tonel format after the merge of an old PR