### PR TITLE
fix: proposal to solve "FamixUMLRoassalBackend does not show all relevant associations when displaying CoastersCollector example" as illustrated in moosetechnology#1070

### DIFF
--- a/src/Famix-UMLDocumentor/FamixUMLRoassalDescriptor.class.st
+++ b/src/Famix-UMLDocumentor/FamixUMLRoassalDescriptor.class.st
@@ -39,6 +39,16 @@ FamixUMLRoassalDescriptor >> aggregations [
 ]
 
 { #category : 'accessing' }
+FamixUMLRoassalDescriptor >> associations [ 
+
+	^(umlModel
+		select: [ :umlEntity | umlEntity class = FamixUMLAssociation and: [ umlEntity aggregation = #off ]]
+		thenCollect: [ :use |
+			(self umlClassNamed: use target) -> (self umlClassNamed: use source) ])
+
+]
+
+{ #category : 'accessing' }
 FamixUMLRoassalDescriptor >> compositions [
 
 	^(umlModel


### PR DESCRIPTION
[fix: proposal to solve "FamixUMLRoassalBackend does not show all relevant associations when displaying CoastersCollector example" as illustrated in](https://github.com/bart-at-qqdatafruits/Famix/commit/c890c170d102c9d6b82262df2cb08943444cb8b7) https://github.com/moosetechnology/Famix/issues/1070