### PR TITLE
fix #1077

### DIFF
--- a/src/Famix-Java-Entities/FamixJavaMethod.class.st
+++ b/src/Famix-Java-Entities/FamixJavaMethod.class.st
@@ -260,8 +260,8 @@ FamixJavaMethod >> isMethodDefinition [
 
 	self parentType isInterface ifFalse: [ ^ true ].
 	
-	"If the parent is an interface, we have a definition if the method has the #default keyword"
-	^ self isDefault
+	"If the parent is an interface, we have a definition if the method has the #default or #static keyword"
+	^ self isDefault or: [ self isClassSide ]
 ]
 
 { #category : 'testing' }

--- a/src/Famix-Java-Tests/FamixJavaMethodTest.class.st
+++ b/src/Famix-Java-Tests/FamixJavaMethodTest.class.st
@@ -221,6 +221,14 @@ FamixJavaMethodTest >> testIsMethodDefinition [
 	method kind: #default.
 
 	self assert: method isMethodDefinition.
+	
+	"Method from interfaces with #static keyword should be considered as defined."
+	class := FamixJavaInterface new.
+	method := FamixJavaMethod new.
+	method parentType: class.
+	method isClassSide: true.
+
+	self assert: method isMethodDefinition.
 ]
 
 { #category : 'tests' }


### PR DESCRIPTION
Adding a check to method `isMethodDefinition` to include static methods from interfaces. The test was modified to add a test for this specific case.