### PR TITLE
Speedup Moose Query

### DIFF
--- a/src/Famix-Deprecated/MQScopeAllStrategy.class.st
+++ b/src/Famix-Deprecated/MQScopeAllStrategy.class.st
@@ -26,9 +26,8 @@ MQScopeAllStrategy class >> isDeprecated [
 
 { #category : 'query' }
 MQScopeAllStrategy class >> scopeFor: anEntity query: aQuery [
-	MQScopeContainersStrategy scopeFor: anEntity query: aQuery.
-	MQScopeContainedEntitiesStrategy scopeFor: anEntity query: aQuery.
-	^ aQuery result
+
+	self deprecated: 'This feature is removed.'
 ]
 
 { #category : 'accessing' }

--- a/src/Moose-Query/Collection.extension.st
+++ b/src/Moose-Query/Collection.extension.st
@@ -8,6 +8,7 @@ Collection >> isIncludedIn: anEntity containerSelectorsCache: aCollection [
 ]
 
 { #category : '*Moose-Query' }
-Collection >> scopeForQuery: aQuery direction: aDirection [
-	1 to: self size do: [ :ind | aDirection scopeFor: (self at: ind) query: aQuery ]
+Collection >> scopeForQuery: aQuery [
+
+	^ aQuery scopeFor: self
 ]

--- a/src/Moose-Query/MQScopeAbstractStopStrategy.class.st
+++ b/src/Moose-Query/MQScopeAbstractStopStrategy.class.st
@@ -39,7 +39,7 @@ MQScopeAbstractStopStrategy >> hash [
 ]
 
 { #category : 'testing' }
-MQScopeAbstractStopStrategy >> shouldBeSelected: anEntity [
+MQScopeAbstractStopStrategy >> selectMatchingElements: aCollection [
 	^ self subclassResponsibility
 ]
 

--- a/src/Moose-Query/MQScopeAllTypesStrategy.class.st
+++ b/src/Moose-Query/MQScopeAllTypesStrategy.class.st
@@ -15,6 +15,7 @@ Class {
 }
 
 { #category : 'testing' }
-MQScopeAllTypesStrategy >> shouldBeSelected: anEntity [
-	^ true
+MQScopeAllTypesStrategy >> selectMatchingElements: aCollection [
+
+	^ aCollection
 ]

--- a/src/Moose-Query/MQScopeAnyTypeStrategy.class.st
+++ b/src/Moose-Query/MQScopeAnyTypeStrategy.class.st
@@ -47,8 +47,15 @@ MQScopeAnyTypeStrategy >> scopes: anObject [
 ]
 
 { #category : 'testing' }
-MQScopeAnyTypeStrategy >> shouldBeSelected: anEntity [
-	^ scopes anySatisfy: [ :aType | anEntity isOfType: aType ]
+MQScopeAnyTypeStrategy >> selectMatchingElements: aCollection [
+	"We know that the collection has at least 1 element and that all entities are instances of the same class.
+	
+	This could be simpler but this code needs to be the fastest possible."
+
+	| class |
+	class := (aCollection at: 1) class.
+	1 to: scopes size do: [ :index | (class isOfType: (scopes at: index)) ifTrue: [ ^ aCollection ] ].
+	^ Array empty
 ]
 
 { #category : 'printing' }

--- a/src/Moose-Query/MQScopeDirectionStrategy.class.st
+++ b/src/Moose-Query/MQScopeDirectionStrategy.class.st
@@ -18,11 +18,6 @@ MQScopeDirectionStrategy class >> isAbstract [
 	^ self = MQScopeDirectionStrategy
 ]
 
-{ #category : 'query' }
-MQScopeDirectionStrategy class >> scopeFor: anEntity query: aQuery [
-	^ aQuery scopeFor: anEntity direction: self
-]
-
 { #category : 'accessing' }
 MQScopeDirectionStrategy class >> selectorsFor: anEntity [
 	^ self subclassResponsibility

--- a/src/Moose-Query/MQScopePropertyStrategy.class.st
+++ b/src/Moose-Query/MQScopePropertyStrategy.class.st
@@ -47,10 +47,12 @@ MQScopePropertyStrategy >> property: anObject [
 ]
 
 { #category : 'accessing' }
-MQScopePropertyStrategy >> shouldBeSelected: anEntity [
-	^ ([ self property value: anEntity  ]
-		on: Error
-		do: [ false ]) ifNotBoolean: [ MQScopeShouldBeSeclectedReturnNotBooleanValueError stopStrategySignal: self  ]
+MQScopePropertyStrategy >> selectMatchingElements: aCollection [
+
+	^ aCollection select: [ :anEntity |
+			  ([ self property value: anEntity ]
+				   on: Error
+				   do: [ false ]) ifNotBoolean: [ MQScopeShouldBeSeclectedReturnNotBooleanValueError stopStrategySignal: self ] ]
 ]
 
 { #category : 'accessing' }

--- a/src/Moose-Query/MQScopeQuery.class.st
+++ b/src/Moose-Query/MQScopeQuery.class.st
@@ -121,14 +121,15 @@ MQScopeQuery >> direction: anObject [
 
 { #category : 'execution' }
 MQScopeQuery >> execute [
-	^ direction scopeFor: receiver query: self
+
+	^ self scopeFor: { receiver }
 ]
 
 { #category : 'initialization' }
 MQScopeQuery >> initialize [
+
 	super initialize.
-	isRecursive := false.
-	until := [ :each | false ]
+	isRecursive := false
 ]
 
 { #category : 'accessing' }
@@ -139,6 +140,16 @@ MQScopeQuery >> isRecursive [
 { #category : 'accessing' }
 MQScopeQuery >> isRecursive: anObject [
 	isRecursive := anObject
+]
+
+{ #category : 'execution' }
+MQScopeQuery >> isUniform: aCollection [
+
+	| class |
+	class := (aCollection at: 1) class.
+	1 to: aCollection size do: [ :index | (aCollection at: index) class = class ifFalse: [ ^ false ] ].
+
+	^ true
 ]
 
 { #category : 'DSL' }
@@ -165,26 +176,43 @@ MQScopeQuery >> recursively [
 ]
 
 { #category : 'execution' }
-MQScopeQuery >> scopeFor: anEntity direction: aDirection [
+MQScopeQuery >> scopeFor: aCollection [
+	"We leave if the collection is empty to not check that everywhere.
+	
+	We split the collection to group them by class to optimize what follows."
 
-	| selectors |
-	(self stopStrategy shouldBeSelected: anEntity) ifTrue: [ 
-		self add: anEntity.
-		self isRecursive ifFalse: [ ^ self result ] ].
+	aCollection ifEmpty: [ ^ self result ].
 
-	"The content of this block could be much more readable with #do: but we do this solution for performances... We need this method to be really really performant."
-	(self shouldStopOn: anEntity) ifFalse: [ 
-		1 to: (selectors := aDirection selectorsFor: anEntity) size do: [ 
-			:ind | 
-			(anEntity perform: (selectors at: ind))
-				scopeForQuery: self
-				direction: aDirection ] ].
+	(self isUniform: aCollection) ifTrue: [ ^ self scopeForUniformElements: aCollection ].
+
+	(aCollection groupedBy: #class) valuesDo: [ :entities | self scopeForUniformElements: entities ].
+
 	^ self result
 ]
 
-{ #category : 'testing' }
-MQScopeQuery >> shouldStopOn: anEntity [
-	^ self until value: anEntity
+{ #category : 'execution' }
+MQScopeQuery >> scopeForUniformElements: aCollection [
+	"The code could be simpler but it is like this for performance reasons! Do not touch it lightly please."
+
+	| selectors nextElements |
+	(self stopStrategy selectMatchingElements: aCollection) ifEmpty: [ nextElements := aCollection ] ifNotEmpty: [ :selected |
+			self result addAll: selected.
+			nextElements := self isRecursive
+				              ifTrue: [ aCollection ]
+				              ifFalse: [
+						              aCollection size = selected size "If we are not recursive and we select the full result we can quit."
+							              ifTrue: [ ^ self result ]
+							              ifFalse: [ aCollection \ selected ] ] ].
+
+	until ifNotNil: [ nextElements := nextElements reject: [ :entity | until value: entity ] ].
+
+	nextElements ifEmpty: [ ^ self result ].
+
+	selectors := direction selectorsFor: nextElements first.
+
+	nextElements do: [ :anEntity | "The content of this block could be much more readable with #do: but we do this solution for performances... We need this method to be really really performant."
+		1 to: selectors size do: [ :ind | (anEntity perform: (selectors at: ind)) scopeForQuery: self ] ].
+	^ self result
 ]
 
 { #category : 'accessing' }

--- a/src/Moose-Query/MQScopeTypeStrategy.class.st
+++ b/src/Moose-Query/MQScopeTypeStrategy.class.st
@@ -47,8 +47,11 @@ MQScopeTypeStrategy >> scope: anObject [
 ]
 
 { #category : 'testing' }
-MQScopeTypeStrategy >> shouldBeSelected: anEntity [
-	^ anEntity isOfType: scope
+MQScopeTypeStrategy >> selectMatchingElements: aCollection [
+
+	^ (aCollection first isOfType: scope)
+		  ifTrue: [ aCollection ]
+		  ifFalse: [ Array empty ]
 ]
 
 { #category : 'printing' }

--- a/src/Moose-Query/MooseObjectQueryResult.class.st
+++ b/src/Moose-Query/MooseObjectQueryResult.class.st
@@ -21,8 +21,7 @@ MooseObjectQueryResult class >> withAll: aCollection [
 { #category : 'filtering' }
 MooseObjectQueryResult >> executeScopeQuery: aQuery [
 
-	self storage do: [ :entity | 
-		entity scopeForQuery: aQuery direction: aQuery direction ].
+	self storage do: [ :entity | aQuery scopeFor: { entity } ].
 	^ self newObjectResultWith: aQuery result
 ]
 

--- a/src/Moose-Query/TDependencyQueryResult.trait.st
+++ b/src/Moose-Query/TDependencyQueryResult.trait.st
@@ -21,14 +21,14 @@ TDependencyQueryResult >> atScope: aClassFamix withNonMatchingEntitiesDo: aBlock
 		do: [ :dep | 
 			coll := OrderedCollection new.
 			query result: coll.
-			(opposite := self opposite: dep) scopeForQuery: query direction: query direction.
+			(opposite := self opposite: dep) scopeForQuery: query.
 			coll ifEmpty: [ aBlock cull: opposite cull: res ] ifNotEmpty: [ :results | res addAll: results ] ].
 	^ self newObjectResultWith: res asSet
 ]
 
 { #category : 'filtering' }
 TDependencyQueryResult >> executeScopeQuery: aQuery [
-	self storage do: [ :dep | (self opposite: dep) scopeForQuery: aQuery direction: aQuery direction ].
+	self storage do: [ :dep | (self opposite: dep) scopeForQuery: aQuery ].
 	^ self newObjectResultWith: aQuery result
 ]
 

--- a/src/Moose-Query/TEntityMetaLevelDependency.trait.st
+++ b/src/Moose-Query/TEntityMetaLevelDependency.trait.st
@@ -909,8 +909,9 @@ TEntityMetaLevelDependency >> rootContainers [
 ]
 
 { #category : 'private' }
-TEntityMetaLevelDependency >> scopeForQuery: aQuery direction: aDirection [
-	aDirection scopeFor: self query: aQuery
+TEntityMetaLevelDependency >> scopeForQuery: aQuery [
+
+	^ aQuery scopeFor: { self }
 ]
 
 { #category : 'query - scoping' }

--- a/src/Moose-Query/UndefinedObject.extension.st
+++ b/src/Moose-Query/UndefinedObject.extension.st
@@ -8,6 +8,7 @@ UndefinedObject >> isIncludedIn: aFAMIXLocalVariable containerSelectorsCache: aC
 ]
 
 { #category : '*Moose-Query' }
-UndefinedObject >> scopeForQuery: aQuery direction: aDirection [
+UndefinedObject >> scopeForQuery: aQuery [
+
 	
 ]


### PR DESCRIPTION
The bigest change is that now instead of executing the query on each elements, they are grouped by class allowing to execute some actions faster

I have a project that was taking 60second to load. After my last speedup it got down to 50sec and it is now down to 40second with this change (and this includes the parsing and the visit, not only the symbol resolution!).

With this, MooseQuery is in average twice faster than before