### PR TITLE
Introduce FamixTBytesFileAnchor

### DIFF
--- a/src/Famix-MetamodelGeneration/FamixGenerator.class.st
+++ b/src/Famix-MetamodelGeneration/FamixGenerator.class.st
@@ -125,7 +125,8 @@ Class {
 		'tTypeArgument',
 		'tTypeParameter',
 		'tCompilationUnit',
-		'tWithCompilationUnits'
+		'tWithCompilationUnits',
+		'tBytesFileAnchor'
 	],
 	#category : 'Famix-MetamodelGeneration',
 	#package : 'Famix-MetamodelGeneration'
@@ -272,6 +273,12 @@ FamixGenerator >> commentForTAttribute [
 
 	^ 'FamixTAttribute represents a field of a class. It is an attribute of the parent type.
 '
+]
+
+{ #category : 'comments' }
+FamixGenerator >> commentForTBytesFileAnchor [
+
+	^ 'I am a file anchor that saves the position of the source code in the file using the start byte and end byte in the file. I will need to detect the encoder of the file and decode the bytes in between the positions to read the source text.'
 ]
 
 { #category : 'comments' }
@@ -1037,6 +1044,8 @@ FamixGenerator >> defineHierarchy [
 
 	tAnnotationTypeAttribute --|> tAttribute.
 
+	tBytesFileAnchor --|> tFileAnchor.
+	
 	tCohesionCouplingMetrics --|> tPackage.
 
 	tClass --|> tWithMethods.
@@ -1209,6 +1218,9 @@ FamixGenerator >> defineParametricRelations [
 FamixGenerator >> defineProperties [
 
 	super defineProperties.
+	
+	(tBytesFileAnchor property: #startByte type: #Number) comment: 'Start position in the source in number of bytes'.
+	(tBytesFileAnchor property: #endByte type: #Number) comment: 'Stop position in the source in number of bytes'.
 
 	(tCanBeAbstract
 		 property: #isAbstract
@@ -1219,54 +1231,35 @@ FamixGenerator >> defineProperties [
 	(tCanBeClassSide
 		 property: #isClassSide
 		 type: #Boolean
-		 defaultValue: false) comment:
-		'Entity can be declared class side i.e. static'.
+		 defaultValue: false) comment: 'Entity can be declared class side i.e. static'.
 
-	(tFileAnchor property: #correspondingFile type: #FamixTFile)
-		comment: 'File associated to this source anchor'.
-	(tFileAnchor property: #encoding type: #String) comment:
-		'A string representing the encoding of a file'.
-	(tFileAnchor property: #fileName type: #String) comment:
-		'Name of the source file'.
+	(tFileAnchor property: #correspondingFile type: #FamixTFile) comment: 'File associated to this source anchor'.
+	(tFileAnchor property: #encoding type: #String) comment: 'A string representing the encoding of a file'.
+	(tFileAnchor property: #fileName type: #String) comment: 'Name of the source file'.
 
-	(tAccess property: #isWrite type: #Boolean defaultValue: false)
-		comment: 'Write access'.
+	(tAccess property: #isWrite type: #Boolean defaultValue: false) comment: 'Write access'.
 
-	(tAnnotationInstanceAttribute property: #value type: #String)
-		comment: 'Actual value of the attribute used in an annotation'.
+	(tAnnotationInstanceAttribute property: #value type: #String) comment: 'Actual value of the attribute used in an annotation'.
 
-	(tNamedEntity property: #name type: #String) comment:
-		'Basic name of the entity, not full reference.'.
+	(tNamedEntity property: #name type: #String) comment: 'Basic name of the entity, not full reference.'.
 
-	(tHasVisibility property: #visibility type: #String) comment:
-		'Visibility of the entity'.
+	(tHasVisibility property: #visibility type: #String) comment: 'Visibility of the entity'.
 
-	(tHasKind property: #kind type: #String) comment:
-		'Tag indicating a setter, getter, constant, constructor method'.
+	(tHasKind property: #kind type: #String) comment: 'Tag indicating a setter, getter, constant, constructor method'.
 
-	(tHasSignature property: #signature type: #String) comment:
-		'Signature of the message being sent'.
+	(tHasSignature property: #signature type: #String) comment: 'Signature of the message being sent'.
 
-	(tCanBeStub property: #isStub type: #Boolean defaultValue: false)
-		comment:
-		'Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.'.
+	(tCanBeStub property: #isStub type: #Boolean defaultValue: false) comment: 'Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.'.
 
-	(tFileNavigation property: #startLine type: #Number) comment:
-		'Number of the start line'.
-	(tFileNavigation property: #endLine type: #Number) comment:
-		'Number of the end line'.
-	(tFileNavigation property: #startColumn type: #Number) comment:
-		'Number of the start column'.
-	(tFileNavigation property: #endColumn type: #Number) comment:
-		'Number of the end column'.
+	(tFileNavigation property: #startLine type: #Number) comment: 'Number of the start line'.
+	(tFileNavigation property: #endLine type: #Number) comment: 'Number of the end line'.
+	(tFileNavigation property: #startColumn type: #Number) comment: 'Number of the start column'.
+	(tFileNavigation property: #endColumn type: #Number) comment: 'Number of the end column'.
 
-	(tIndexedFileNavigation property: #startPos type: #Number) comment:
-		'Start position in the source'.
-	(tIndexedFileNavigation property: #endPos type: #Number) comment:
-		'Stop position in the source'.
+	(tIndexedFileNavigation property: #startPos type: #Number) comment: 'Start position in the source'.
+	(tIndexedFileNavigation property: #endPos type: #Number) comment: 'Stop position in the source'.
 
-	(tHasImmediateSource property: #source type: #String) comment:
-		'Actual source code of the source entity'.
+	(tHasImmediateSource property: #source type: #String) comment: 'Actual source code of the source entity'.
 
 	(tMultipleFileAnchor property: #fileAnchors type: #FamixTFileAnchor)
 		comment: 'All source code definition files';
@@ -1276,10 +1269,8 @@ FamixGenerator >> defineProperties [
 		 property: #relatedAnchor
 		 type: #FamixTSourceAnchor) comment:
 		'Source anchor to which I am relative.'.
-	(tRelativeSourceAnchor property: #startPos type: #Number) comment:
-		'Start position in the source'.
-	(tRelativeSourceAnchor property: #endPos type: #Number) comment:
-		'Stop position in the source'.
+	(tRelativeSourceAnchor property: #startPos type: #Number) comment: 'Start position in the source'.
+	(tRelativeSourceAnchor property: #endPos type: #Number) comment: 'Stop position in the source'.
 ]
 
 { #category : 'definition' }
@@ -1644,6 +1635,8 @@ FamixGenerator >> defineTraits [
 
 	tAttribute := builder newTraitNamed: #TAttribute comment: self commentForTAttribute.
 	tAttribute withTesting.
+	
+	tBytesFileAnchor := builder newTraitNamed: #TBytesFileAnchor comment: self commentForTBytesFileAnchor.
 
 	tCanBeClassSide := builder newTraitNamed: #TCanBeClassSide.
 

--- a/src/Famix-Test1-Entities/FamixTest1BytesFileAnchor.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1BytesFileAnchor.class.st
@@ -1,0 +1,31 @@
+"
+## Properties
+======================
+
+| Name | Type | Default value | Comment |
+|---|
+| `correspondingFile` | `FamixTFile` | nil | File associated to this source anchor|
+| `encoding` | `String` | nil | A string representing the encoding of a file|
+| `endByte` | `Number` | nil | Stop position in the source in number of bytes|
+| `fileName` | `String` | nil | Name of the source file|
+| `startByte` | `Number` | nil | Start position in the source in number of bytes|
+
+"
+Class {
+	#name : 'FamixTest1BytesFileAnchor',
+	#superclass : 'FamixTest1SourceAnchor',
+	#traits : 'FamixTBytesFileAnchor',
+	#classTraits : 'FamixTBytesFileAnchor classTrait',
+	#category : 'Famix-Test1-Entities-Entities',
+	#package : 'Famix-Test1-Entities',
+	#tag : 'Entities'
+}
+
+{ #category : 'meta' }
+FamixTest1BytesFileAnchor class >> annotation [
+
+	<FMClass: #BytesFileAnchor super: #FamixTest1SourceAnchor>
+	<package: #'Famix-Test1-Entities'>
+	<generated>
+	^ self
+]

--- a/src/Famix-Test1-Entities/FamixTest1ImportingContext.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1ImportingContext.class.st
@@ -32,6 +32,13 @@ FamixTest1ImportingContext >> importAttribute [
 ]
 
 { #category : 'importing' }
+FamixTest1ImportingContext >> importBytesFileAnchor [
+
+	<generated>
+	^ self importConcreteEntity: (self class fm3ClassNamed: #BytesFileAnchor)
+]
+
+{ #category : 'importing' }
 FamixTest1ImportingContext >> importClass [
 
 	<generated>
@@ -113,6 +120,13 @@ FamixTest1ImportingContext >> shouldImportAttribute [
 
 	<generated>
 	^ self shouldImport: #Attribute
+]
+
+{ #category : 'testing' }
+FamixTest1ImportingContext >> shouldImportBytesFileAnchor [
+
+	<generated>
+	^ self shouldImport: #BytesFileAnchor
 ]
 
 { #category : 'testing' }

--- a/src/Famix-Test1-Entities/FamixTest1TEntityCreator.trait.st
+++ b/src/Famix-Test1-Entities/FamixTest1TEntityCreator.trait.st
@@ -42,6 +42,13 @@ FamixTest1TEntityCreator >> newAttributeNamed: aName [
 ]
 
 { #category : 'entity creation' }
+FamixTest1TEntityCreator >> newBytesFileAnchor [
+
+	<generated>
+	^ self add: FamixTest1BytesFileAnchor new
+]
+
+{ #category : 'entity creation' }
 FamixTest1TEntityCreator >> newClass [
 
 	<generated>

--- a/src/Famix-Test1-Tests/FamixAbstractFileAnchorTest.class.st
+++ b/src/Famix-Test1-Tests/FamixAbstractFileAnchorTest.class.st
@@ -12,6 +12,11 @@ FamixAbstractFileAnchorTest class >> isAbstract [
 ]
 
 { #category : 'helpers' }
+FamixAbstractFileAnchorTest >> adaptAnchorForCrlf: anchor [
+	"Nothing by default"
+]
+
+{ #category : 'helpers' }
 FamixAbstractFileAnchorTest >> anchorForClassTest [
 	"I should return a file anchor of a class for some tests as testLineCount."
 
@@ -68,12 +73,9 @@ FamixAbstractFileAnchorTest >> testIsFileAnchor [
 
 { #category : 'tests' }
 FamixAbstractFileAnchorTest >> testLineCount [
-	| file anchor |
-	(file := FileSystem memory / 'test.txt')
-		ensureCreateFile;
-		writeStreamDo: [ :s | s << self sourceCodeForTest ].
+
+	| anchor |
 	anchor := self anchorForClassTest.
-	anchor stub fileReference willReturn: file.
 	self assert: anchor lineCount equals: 17
 ]
 
@@ -84,6 +86,7 @@ FamixAbstractFileAnchorTest >> testLineCountWithCRLF [
 		ensureCreateFile;
 		writeStreamDo: [ :s | s << (self sourceCodeForTest copyReplaceAll: String cr with: String crlf) ].
 	anchor := self anchorForClassTest.
+	self adaptAnchorForCrlf: anchor.
 	anchor stub fileReference willReturn: file.
 	self assert: anchor lineCount equals: 17
 ]

--- a/src/Famix-Test1-Tests/FamixBytesFileAnchorTest.class.st
+++ b/src/Famix-Test1-Tests/FamixBytesFileAnchorTest.class.st
@@ -1,0 +1,93 @@
+Class {
+	#name : 'FamixBytesFileAnchorTest',
+	#superclass : 'FamixAbstractFileAnchorTest',
+	#category : 'Famix-Test1-Tests-SourceAnchor',
+	#package : 'Famix-Test1-Tests',
+	#tag : 'SourceAnchor'
+}
+
+{ #category : 'helpers' }
+FamixBytesFileAnchorTest >> actualClass [
+	^ FamixTest1BytesFileAnchor
+]
+
+{ #category : 'helpers' }
+FamixBytesFileAnchorTest >> adaptAnchorForCrlf: anchor [
+
+	anchor
+		startByte: 54;
+		endByte: 281
+]
+
+{ #category : 'helpers' }
+FamixBytesFileAnchorTest >> anchorForClassTest [
+	| file anchor |
+	file := (FileSystem memory / 'test.java')
+		ensureCreateFile;
+		writeStreamDo: [ :s | s nextPutAll: self sourceCodeForTest ];
+		yourself.
+	anchor := self actualClass new
+		startByte: 50;
+		endByte: 261;
+		fileName: 'test.java';
+		yourself.
+	anchor stub rootFolder willReturn: file parent.
+	^ anchor
+]
+
+{ #category : 'helpers' }
+FamixBytesFileAnchorTest >> sourceCodeForTest [
+	"I'm adding emojies to have characters with multiple bytes."
+
+	^ 'package goosegame.dice;
+
+import goosegame.Dice;
+
+/**
+ * Dice9 return 9 all the time.😀😃
+ */
+public class Dice9 implements Dice {
+
+
+	public Dice9() {
+	}
+
+	/* (non-Javadoc)
+	 * @see goosegame.Dice#throwDice()
+	 */
+	public int throwDice() {
+		return 9;
+	}
+
+}'
+]
+
+{ #category : 'tests' }
+FamixBytesFileAnchorTest >> testEndPos [
+
+	| anchor |
+	anchor := self anchorForClassTest.
+	self assert: anchor endPos equals: 254
+]
+
+{ #category : 'tests' }
+FamixBytesFileAnchorTest >> testSourceText [
+
+	| anchor |
+	anchor := self anchorForClassTest
+		          startByte: 219;
+		          endByte: 257;
+		          yourself.
+	anchor stub completeText willReturn: self sourceCodeForTest.
+	self assert: anchor sourceText equals: 'public int throwDice() {
+		return 9;
+	}'
+]
+
+{ #category : 'tests' }
+FamixBytesFileAnchorTest >> testStartPos [
+
+	| anchor |
+	anchor := self anchorForClassTest.
+	self assert: anchor startPos equals: 50
+]

--- a/src/Famix-TestGenerators/FamixTest1Generator.class.st
+++ b/src/Famix-TestGenerators/FamixTest1Generator.class.st
@@ -37,7 +37,8 @@ Class {
 		'multipleFileAnchor',
 		'class',
 		'model',
-		'tCanBeClassSide'
+		'tCanBeClassSide',
+		'bytesFileAnchor'
 	],
 	#category : 'Famix-TestGenerators',
 	#package : 'Famix-TestGenerators'
@@ -72,6 +73,7 @@ FamixTest1Generator >> defineClasses [
 	fileAnchor := builder newClassNamed: #FileAnchor.
 	folder := builder newClassNamed: #Folder.
 	indexedFileAnchor := builder newClassNamed: #IndexedFileAnchor.
+	bytesFileAnchor := builder newClassNamed: #BytesFileAnchor.
 	multipleFileAnchor := builder newClassNamed: #MultipleFileAnchor
 ]
 
@@ -87,6 +89,9 @@ FamixTest1Generator >> defineHierarchy [
 		--|> #TAttribute;
 		--|> #TSourceEntity;
 	  --|> tCanBeClassSide.
+	
+	bytesFileAnchor --|> sourceAnchor.
+	bytesFileAnchor --|> #TBytesFileAnchor.
 
 	class
 		--|> namedEntity ;

--- a/src/Famix-Traits/FamixTBytesFileAnchor.trait.st
+++ b/src/Famix-Traits/FamixTBytesFileAnchor.trait.st
@@ -1,0 +1,107 @@
+"
+I am a file anchor that saves the position of the source code in the file using the start byte and end byte in the file. I will need to detect the encoder of the file and decode the bytes in between the positions to read the source text.
+
+## Properties
+======================
+
+| Name | Type | Default value | Comment |
+|---|
+| `correspondingFile` | `FamixTFile` | nil | File associated to this source anchor|
+| `encoding` | `String` | nil | A string representing the encoding of a file|
+| `endByte` | `Number` | nil | Stop position in the source in number of bytes|
+| `fileName` | `String` | nil | Name of the source file|
+| `startByte` | `Number` | nil | Start position in the source in number of bytes|
+
+"
+Trait {
+	#name : 'FamixTBytesFileAnchor',
+	#instVars : [
+		'#startByte => FMProperty',
+		'#endByte => FMProperty'
+	],
+	#traits : 'FamixTFileAnchor',
+	#classTraits : 'FamixTFileAnchor classTrait',
+	#category : 'Famix-Traits-SourceAnchor',
+	#package : 'Famix-Traits',
+	#tag : 'SourceAnchor'
+}
+
+{ #category : 'meta' }
+FamixTBytesFileAnchor classSide >> annotation [
+
+	<FMClass: #TBytesFileAnchor super: #Object>
+	<package: #'Famix-Traits'>
+	<generated>
+	^ self
+]
+
+{ #category : 'visitor' }
+FamixTBytesFileAnchor >> accept: aVisitor [
+
+	<generated>
+	^ aVisitor visitFamixTBytesFileAnchor: self
+]
+
+{ #category : 'accessing' }
+FamixTBytesFileAnchor >> endByte [
+
+	<FMProperty: #endByte type: #Number>
+	<generated>
+	<FMComment: 'Stop position in the source in number of bytes'>
+	^ endByte
+]
+
+{ #category : 'accessing' }
+FamixTBytesFileAnchor >> endByte: anObject [
+	<generated>
+	endByte := anObject
+]
+
+{ #category : 'accessing' }
+FamixTBytesFileAnchor >> endLine [
+	^ self cacheAt: #endLine ifAbsentPut: [ self completeText lineNumberCorrespondingToIndex: self endPos ]
+]
+
+{ #category : 'accessing' }
+FamixTBytesFileAnchor >> endPos [
+
+	^ self cacheAt: #endPos ifAbsentPut: [ self startPos + self sourceText size - 1 ]
+]
+
+{ #category : 'accessing' }
+FamixTBytesFileAnchor >> sourceText [
+
+	self sourcesAreReadable ifFalse: [ ^ '' ].
+
+	^ self fileReference binaryReadStreamDo: [ :in |
+			  in skip: self startByte - 1.
+			  (in next: self endByte - (self startByte - 1)) decodeWith: self encoding ]
+]
+
+{ #category : 'accessing' }
+FamixTBytesFileAnchor >> startByte [
+
+	<FMProperty: #startByte type: #Number>
+	<generated>
+	<FMComment: 'Start position in the source in number of bytes'>
+	^ startByte
+]
+
+{ #category : 'accessing' }
+FamixTBytesFileAnchor >> startByte: anObject [
+	<generated>
+	startByte := anObject
+]
+
+{ #category : 'accessing' }
+FamixTBytesFileAnchor >> startLine [
+	^ self cacheAt: #startLine ifAbsentPut: [ self completeText lineNumberCorrespondingToIndex: self startPos ]
+]
+
+{ #category : 'accessing' }
+FamixTBytesFileAnchor >> startPos [
+
+	^ self
+		  cacheAt: #startPos
+		  ifAbsentPut: [ self fileReference binaryReadStreamDo: [ :in | self encoding asZnCharacterEncoder numberOfCharactersFrom: (in next: self startByte) ] ]
+]

--- a/src/Famix-Traits/FamixTFileAnchor.trait.st
+++ b/src/Famix-Traits/FamixTFileAnchor.trait.st
@@ -181,6 +181,12 @@ FamixTFileAnchor >> rootFolder [
 	^ self mooseModel rootFolder
 ]
 
+{ #category : 'accessing' }
+FamixTFileAnchor >> sourceText [
+
+	^ self explicitRequirement
+]
+
 { #category : 'testing' }
 FamixTFileAnchor >> sourcesAreReadable [
 	^ self fileReference
@@ -190,7 +196,7 @@ FamixTFileAnchor >> sourcesAreReadable [
 
 { #category : 'accessing' }
 FamixTFileAnchor >> startLine [
-	^ self explicitRequirement
+	^ self cacheAt: #startLine ifAbsentPut: [ self completeText lineNumberCorrespondingToIndex: self startPos ]
 ]
 
 { #category : 'accessing' }

--- a/src/Famix-Traits/FamixTVisitor.trait.st
+++ b/src/Famix-Traits/FamixTVisitor.trait.st
@@ -108,6 +108,13 @@ FamixTVisitor >> visitFamixTAttribute: aFamixTAttribute [
 ]
 
 { #category : 'visiting' }
+FamixTVisitor >> visitFamixTBytesFileAnchor: aFamixTBytesFileAnchor [
+
+	<generated>
+	self visitFamixTFileAnchor: aFamixTBytesFileAnchor
+]
+
+{ #category : 'visiting' }
 FamixTVisitor >> visitFamixTCanBeAbstract: aFamixTCanBeAbstract [
 
 	<generated>


### PR DESCRIPTION
A FamixTBytesFilesAnchor is a kind of file anchor that saves a file and the position of the source code in number of bytes instead of characters like FamixTIndexedFileAnchor. This allows faster source text reading but slower start and end positions in character access. 

This will be especially useful for importers built with TreeSitter because TreeSitter provides the positions in number of bytes and it takes time to build an IndexedFileAnchor from this (In the python parser, after a big op[timization phase, we have a 15% overhead creating indexed file anchor compared to bytes file ancho) and on top of this MooseIDE will be faster to access source code with this file anchor, This should speed up some tools such as the duplication detector.

Next steps: 
- Adapt Famix-TreeSitter-Integration to use this source anchor
- Adapt the Python parser
- Adapt the C parser

Fixes #1081  