### PR TITLE
adding `canBeStub` testing method to speed up this check

### DIFF
--- a/src/Famix-Java-Entities/FamixJavaEntity.class.st
+++ b/src/Famix-Java-Entities/FamixJavaEntity.class.st
@@ -38,6 +38,13 @@ FamixJavaEntity >> accept: aVisitor [
 ]
 
 { #category : 'testing' }
+FamixJavaEntity >> canBeStub [
+
+	<generated>
+	^ false
+]
+
+{ #category : 'testing' }
 FamixJavaEntity >> isAccess [
 
 	<generated>

--- a/src/Famix-MetamodelGeneration/FamixGenerator.class.st
+++ b/src/Famix-MetamodelGeneration/FamixGenerator.class.st
@@ -1880,4 +1880,5 @@ FamixGenerator >> defineTraits [
 	tShadower := builder newTraitNamed: #TShadower comment: self commentForTShadower.
 	
 	tCanBeStub := builder newTraitNamed: #TCanBeStub.
+	tCanBeStub testingSelector: #canBeStub
 ]

--- a/src/Famix-PharoSmalltalk-Entities/FamixStEntity.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStEntity.class.st
@@ -31,6 +31,13 @@ FamixStEntity class >> metamodel [
 ]
 
 { #category : 'testing' }
+FamixStEntity >> canBeStub [
+
+	<generated>
+	^ false
+]
+
+{ #category : 'testing' }
 FamixStEntity >> isAccess [
 
 	<generated>

--- a/src/Famix-Test1-Entities/FamixTest1Entity.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1Entity.class.st
@@ -31,6 +31,13 @@ FamixTest1Entity class >> metamodel [
 ]
 
 { #category : 'testing' }
+FamixTest1Entity >> canBeStub [
+
+	<generated>
+	^ false
+]
+
+{ #category : 'testing' }
 FamixTest1Entity >> isAssociation [
 
 	<generated>

--- a/src/Famix-Test2-Entities/FamixTest2Entity.class.st
+++ b/src/Famix-Test2-Entities/FamixTest2Entity.class.st
@@ -31,6 +31,13 @@ FamixTest2Entity class >> metamodel [
 ]
 
 { #category : 'testing' }
+FamixTest2Entity >> canBeStub [
+
+	<generated>
+	^ false
+]
+
+{ #category : 'testing' }
 FamixTest2Entity >> isAssociation [
 
 	<generated>

--- a/src/Famix-Test3-Entities/FamixTest3Entity.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3Entity.class.st
@@ -31,6 +31,13 @@ FamixTest3Entity class >> metamodel [
 ]
 
 { #category : 'testing' }
+FamixTest3Entity >> canBeStub [
+
+	<generated>
+	^ false
+]
+
+{ #category : 'testing' }
 FamixTest3Entity >> isAccess [
 
 	<generated>

--- a/src/Famix-Test3-Entities/FamixTest3TypeGroup.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3TypeGroup.class.st
@@ -23,6 +23,13 @@ FamixTest3TypeGroup class >> metamodel [
 ]
 
 { #category : 'testing' }
+FamixTest3TypeGroup >> canBeStub [
+
+	<generated>
+	^ false
+]
+
+{ #category : 'testing' }
 FamixTest3TypeGroup >> isAccess [
 
 	<generated>

--- a/src/Famix-Test7-Entities/FamixTest7Entity.class.st
+++ b/src/Famix-Test7-Entities/FamixTest7Entity.class.st
@@ -31,6 +31,13 @@ FamixTest7Entity class >> metamodel [
 ]
 
 { #category : 'testing' }
+FamixTest7Entity >> canBeStub [
+
+	<generated>
+	^ false
+]
+
+{ #category : 'testing' }
 FamixTest7Entity >> isAssociation [
 
 	<generated>

--- a/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1Entity.class.st
+++ b/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1Entity.class.st
@@ -31,6 +31,13 @@ FamixTestComposed1Entity class >> metamodel [
 ]
 
 { #category : 'testing' }
+FamixTestComposed1Entity >> canBeStub [
+
+	<generated>
+	^ false
+]
+
+{ #category : 'testing' }
 FamixTestComposed1Entity >> isBehavioural [
 
 	<generated>

--- a/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2Entity.class.st
+++ b/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2Entity.class.st
@@ -31,6 +31,13 @@ FamixTestComposed2Entity class >> metamodel [
 ]
 
 { #category : 'testing' }
+FamixTestComposed2Entity >> canBeStub [
+
+	<generated>
+	^ false
+]
+
+{ #category : 'testing' }
 FamixTestComposed2Entity >> isBehavioural [
 
 	<generated>

--- a/src/Famix-Traits/FamixTCanBeStub.trait.st
+++ b/src/Famix-Traits/FamixTCanBeStub.trait.st
@@ -44,6 +44,12 @@ FamixTCanBeStub >> accept: aVisitor [
 	^ aVisitor visitFamixTCanBeStub: self
 ]
 
+{ #category : 'testing' }
+FamixTCanBeStub >> canBeStub [
+	"testing method to speed up this check"
+	^ true
+]
+
 { #category : 'accessing' }
 FamixTCanBeStub >> isStub [
 

--- a/src/Famix-Traits/FamixTCanBeStub.trait.st
+++ b/src/Famix-Traits/FamixTCanBeStub.trait.st
@@ -46,7 +46,8 @@ FamixTCanBeStub >> accept: aVisitor [
 
 { #category : 'testing' }
 FamixTCanBeStub >> canBeStub [
-	"testing method to speed up this check"
+
+	<generated>
 	^ true
 ]
 

--- a/src/Moose-Core-Tests-Entities/MooseMSEImporterTestEntity.class.st
+++ b/src/Moose-Core-Tests-Entities/MooseMSEImporterTestEntity.class.st
@@ -31,6 +31,13 @@ MooseMSEImporterTestEntity class >> metamodel [
 ]
 
 { #category : 'testing' }
+MooseMSEImporterTestEntity >> canBeStub [
+
+	<generated>
+	^ false
+]
+
+{ #category : 'testing' }
 MooseMSEImporterTestEntity >> isAssociation [
 
 	<generated>

--- a/src/Moose-Core/MooseEntity.class.st
+++ b/src/Moose-Core/MooseEntity.class.st
@@ -128,6 +128,12 @@ MooseEntity >> asOrderedCollection [
 	^ OrderedCollection with: self
 ]
 
+{ #category : 'testing' }
+MooseEntity >> canBeStub [
+	"false by default, only true for FamixTCanBeStub traits owner"
+	^ false
+]
+
 { #category : 'dependencies' }
 MooseEntity >> canRecursivelyBeItsParent [
 	^ false

--- a/src/Moose-Core/MooseEntity.class.st
+++ b/src/Moose-Core/MooseEntity.class.st
@@ -128,12 +128,6 @@ MooseEntity >> asOrderedCollection [
 	^ OrderedCollection with: self
 ]
 
-{ #category : 'testing' }
-MooseEntity >> canBeStub [
-	"false by default, only true for FamixTCanBeStub traits owner"
-	^ false
-]
-
 { #category : 'dependencies' }
 MooseEntity >> canRecursivelyBeItsParent [
 	^ false


### PR DESCRIPTION
Adding this method to avoid having to test whether or not a class has the trait `FamixTCanBeStub`. Interesting for Famix-Bridge (among other tools and uses maybe?)