### PR TITLE
Fix bug causing remote relations to never be seen as multivalued

### DIFF
--- a/src/Famix-MetamodelBuilder-Core/FmxMBNonRemoteRelationSideGenerationStrategy.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxMBNonRemoteRelationSideGenerationStrategy.class.st
@@ -11,39 +11,37 @@ FmxMBNonRemoteRelationSideGenerationStrategy >> generateGetterCoreIn: aClassOrTr
 
 	aStream
 		tab;
-		nextPutAll:
-			('<FMProperty: #{1} type: #{2} opposite: #{3}>' format: { 
+		nextPutAll: ('<FMProperty: #{1} type: #{2} opposite: #{3}>' format: {
 						 aRelationSide name.
 						 aRelationSide oppositeType.
 						 aRelationSide oppositeName });
 		cr.
 
-	aRelationSide remoteBuilderDo: [ :aRemoteBuilder | 
-		aStream
-			tab;
-			nextPutAll: ('<package: #''{1}''>' format:
-						 { aRemoteBuilder generator packageName });
-			cr ].
+	"We need to add the multivalued since we do not use a FMMany slot."
+	aRelationSide isMany ifTrue: [
+			aStream
+				tab;
+				nextPutAll: '<multivalued>';
+				cr ].
+
+	aRelationSide remoteBuilderDo: [ :aRemoteBuilder |
+			aStream
+				tab;
+				nextPutAll: ('<package: #''{1}''>' format: { aRemoteBuilder generator packageName });
+				cr ].
 
 	aStream
 		tab;
 		nextPutAll: '^ self attributeAt: #';
 		nextPutAll: aRelationSide name.
 
-	aRelationSide isOne ifTrue: [ 
-		aStream nextPutAll: ' ifAbsent: [ nil ]' ].
+	aRelationSide isOne ifTrue: [ aStream nextPutAll: ' ifAbsent: [ nil ]' ].
 
-	(aRelationSide otherSide isOne and: [ aRelationSide isMany ]) 
-		ifTrue: [ 
-			aStream nextPutAll:
-				(' ifAbsentPut: [ FMMultivalueLink on: self opposite: #{1}: ]' 
-					 format: { aRelationSide otherSide name }) ].
+	(aRelationSide otherSide isOne and: [ aRelationSide isMany ]) ifTrue: [
+		aStream nextPutAll: (' ifAbsentPut: [ FMMultivalueLink on: self opposite: #{1}: ]' format: { aRelationSide otherSide name }) ].
 
-	(aRelationSide isMany and: [ aRelationSide otherSide isMany ]) 
-		ifTrue: [ 
-			aStream nextPutAll:
-				(' ifAbsentPut: [ FMMultiMultivalueLink on: self opposite: #{1} ]' 
-					 format: { aRelationSide otherSide name }) ]
+	(aRelationSide isMany and: [ aRelationSide otherSide isMany ]) ifTrue: [
+		aStream nextPutAll: (' ifAbsentPut: [ FMMultiMultivalueLink on: self opposite: #{1} ]' format: { aRelationSide otherSide name }) ]
 ]
 
 { #category : 'generation' }

--- a/src/Famix-MetamodelBuilder-Core/FmxMBRelationSideGenerationStrategy.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxMBRelationSideGenerationStrategy.class.st
@@ -40,6 +40,7 @@ FmxMBRelationSideGenerationStrategy >> generateGetterCoreIn: aClassOrTrait on: a
 FmxMBRelationSideGenerationStrategy >> generateGetterIn: aClassOrTrait for: aRelationSide [
 
 	| methodSource commentDefinition |
+
 	commentDefinition := aRelationSide comment ifNotEmpty: [ :comment | 
 		                     '<FMComment: {1}>' format:
 			                     { comment printString } ].

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed1CustomEntity2.extension.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed1CustomEntity2.extension.st
@@ -7,6 +7,7 @@ FamixTestComposed1CustomEntity2 >> c22s [
 	<generated>
 	<derived>
 	<FMProperty: #c22s type: #FamixTestComposed2CustomEntity2 opposite: #c12>
+	<multivalued>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 	^ self attributeAt: #c22s ifAbsentPut: [ FMMultivalueLink on: self opposite: #c12: ]
 ]

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed1CustomEntity3.extension.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed1CustomEntity3.extension.st
@@ -24,6 +24,7 @@ FamixTestComposed1CustomEntity3 >> customEntities3 [
 	<generated>
 	<derived>
 	<FMProperty: #customEntities3 type: #FamixTestComposedCustomEntity3 opposite: #customEntity3>
+	<multivalued>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 	^ self attributeAt: #customEntities3 ifAbsentPut: [ FMMultivalueLink on: self opposite: #customEntity3: ]
 ]

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed1CustomEntity4.extension.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed1CustomEntity4.extension.st
@@ -7,6 +7,7 @@ FamixTestComposed1CustomEntity4 >> c24s [
 	<generated>
 	<derived>
 	<FMProperty: #c24s type: #FamixTestComposed2CustomEntity4 opposite: #c14s>
+	<multivalued>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 	^ self attributeAt: #c24s ifAbsentPut: [ FMMultiMultivalueLink on: self opposite: #c14s ]
 ]
@@ -24,6 +25,7 @@ FamixTestComposed1CustomEntity4 >> customEntities4 [
 
 	<generated>
 	<FMProperty: #customEntities4 type: #FamixTestComposedCustomEntity4 opposite: #customEntities4>
+	<multivalued>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 	^ self attributeAt: #customEntities4 ifAbsentPut: [ FMMultiMultivalueLink on: self opposite: #customEntities4 ]
 ]

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed1CustomEntity5.extension.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed1CustomEntity5.extension.st
@@ -7,6 +7,7 @@ FamixTestComposed1CustomEntity5 >> associations [
 	<generated>
 	<derived>
 	<FMProperty: #associations type: #FamixTestComposedAssociation opposite: #c15>
+	<multivalued>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 	^ self attributeAt: #associations ifAbsentPut: [ FMMultivalueLink on: self opposite: #c15: ]
 ]

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed2CustomEntity3.extension.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed2CustomEntity3.extension.st
@@ -7,6 +7,7 @@ FamixTestComposed2CustomEntity3 >> c13s [
 	<generated>
 	<derived>
 	<FMProperty: #c13s type: #FamixTestComposed1CustomEntity3 opposite: #c23>
+	<multivalued>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 	^ self attributeAt: #c13s ifAbsentPut: [ FMMultivalueLink on: self opposite: #c23: ]
 ]
@@ -25,6 +26,7 @@ FamixTestComposed2CustomEntity3 >> c3s [
 	<generated>
 	<derived>
 	<FMProperty: #c3s type: #FamixTestComposedCustomEntity3 opposite: #c23>
+	<multivalued>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 	^ self attributeAt: #c3s ifAbsentPut: [ FMMultivalueLink on: self opposite: #c23: ]
 ]

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed2CustomEntity4.extension.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed2CustomEntity4.extension.st
@@ -6,6 +6,7 @@ FamixTestComposed2CustomEntity4 >> c14s [
 
 	<generated>
 	<FMProperty: #c14s type: #FamixTestComposed1CustomEntity4 opposite: #c24s>
+	<multivalued>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 	^ self attributeAt: #c14s ifAbsentPut: [ FMMultiMultivalueLink on: self opposite: #c24s ]
 ]
@@ -23,6 +24,7 @@ FamixTestComposed2CustomEntity4 >> c4s [
 
 	<generated>
 	<FMProperty: #c4s type: #FamixTestComposedCustomEntity4 opposite: #c24s>
+	<multivalued>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 	^ self attributeAt: #c4s ifAbsentPut: [ FMMultiMultivalueLink on: self opposite: #c24s ]
 ]

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed2CustomEntity5.extension.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed2CustomEntity5.extension.st
@@ -7,6 +7,7 @@ FamixTestComposed2CustomEntity5 >> associations [
 	<generated>
 	<derived>
 	<FMProperty: #associations type: #FamixTestComposedAssociation opposite: #c25>
+	<multivalued>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 	^ self attributeAt: #associations ifAbsentPut: [ FMMultivalueLink on: self opposite: #c25: ]
 ]

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedCustomEntity2.class.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedCustomEntity2.class.st
@@ -47,6 +47,7 @@ FamixTestComposedCustomEntity2 >> c22s [
 	<generated>
 	<derived>
 	<FMProperty: #c22s type: #FamixTestComposed2CustomEntity2 opposite: #c2>
+	<multivalued>
 	^ self attributeAt: #c22s ifAbsentPut: [ FMMultivalueLink on: self opposite: #c2: ]
 ]
 
@@ -64,6 +65,7 @@ FamixTestComposedCustomEntity2 >> customEntities2 [
 	<generated>
 	<derived>
 	<FMProperty: #customEntities2 type: #FamixTestComposed1CustomEntity2 opposite: #customEntity2>
+	<multivalued>
 	^ self attributeAt: #customEntities2 ifAbsentPut: [ FMMultivalueLink on: self opposite: #customEntity2: ]
 ]
 

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedCustomEntity4.class.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedCustomEntity4.class.st
@@ -47,6 +47,7 @@ FamixTestComposedCustomEntity4 >> c24s [
 	<generated>
 	<derived>
 	<FMProperty: #c24s type: #FamixTestComposed2CustomEntity4 opposite: #c4s>
+	<multivalued>
 	^ self attributeAt: #c24s ifAbsentPut: [ FMMultiMultivalueLink on: self opposite: #c4s ]
 ]
 
@@ -64,6 +65,7 @@ FamixTestComposedCustomEntity4 >> customEntities4 [
 	<generated>
 	<derived>
 	<FMProperty: #customEntities4 type: #FamixTestComposed1CustomEntity4 opposite: #customEntities4>
+	<multivalued>
 	^ self attributeAt: #customEntities4 ifAbsentPut: [ FMMultiMultivalueLink on: self opposite: #customEntities4 ]
 ]
 

--- a/src/Famix-TestComposedMetamodel/FamixTestComposedMetamodels.class.st
+++ b/src/Famix-TestComposedMetamodel/FamixTestComposedMetamodels.class.st
@@ -122,6 +122,16 @@ FamixTestComposedMetamodels >> testManyToOneRemote [
 ]
 
 { #category : 'tests' }
+FamixTestComposedMetamodels >> testMultivaluedRelationsAreSeenAsMultivalued [
+	"Regression test. If we add a multivalued relation to a remote entity, it was not considered as multivalued in Fame because we neither had a FMMany slot since it's remote, nor we had a multivalued pragma."
+
+	| relation |
+	relation := c12 mooseDescription allRelationProperties detect: [ :relation | relation name = 'c22s' ].
+
+	self assert: relation isMultivalued
+]
+
+{ #category : 'tests' }
 FamixTestComposedMetamodels >> testOneToManyRemote [
 
 	c2 c22s: {c22}.


### PR DESCRIPTION
In Fame we have two ways of knowing if a relation is multivalued or not. Either they are stored in a FMMany slot or they have the <multivalued> pragma.

But for remote relations they had neither of them causing relations to never be multivalued even when they should have.

I'm proposing a fix with a test.

I hesitated to add the pragma all the time or only if on remote relations. I went with the second option but I still have doubts