### PR TITLE
Fix generation of testing methods on top of the hierarchy

### DIFF
--- a/src/Famix-MetamodelBuilder-Core/FamixMetamodelBuilder.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FamixMetamodelBuilder.class.st
@@ -289,7 +289,7 @@ FamixMetamodelBuilder >> generateTestingMethodsOfRemoteEntities [
 					self testingSelectorsMapping keysAndValuesDo: [
 							:behavior
 							:selectors |
-							((self shouldGeneratorTestingMethodsOf: behavior) and: [
+							((self shouldGeneratorTestingMethodsOf: behavior in: remoteClass) and: [
 								 subclassesAndTraits includes: behavior ]) ifTrue: [
 									selectors do: [ :selector |
 											(remoteClass realClass includesSelector: selector)
@@ -596,11 +596,14 @@ FamixMetamodelBuilder >> shouldGenerateModel [
 ]
 
 { #category : 'asserting' }
-FamixMetamodelBuilder >> shouldGeneratorTestingMethodsOf: aClass [
+FamixMetamodelBuilder >> shouldGeneratorTestingMethodsOf: aClass in: targetClass [
 	"In case a testing selector is relatif to a Trait that is not used in the current MM, then we do not need to generate the testing selector."
 
 	aClass isMetamodelTrait ifFalse: [ ^ true ].
-
+	
+	"If the target class contains the trait, then it should not generate a testing method returning false, else it will override the method returning true."
+	(targetClass allTransitiveTraits includes: aClass) ifTrue: [ ^ false ].
+	
 	^ self classes anySatisfy: [ :class | class allTransitiveTraits includes: aClass ]
 ]
 

--- a/src/Famix-MetamodelBuilder-Core/FmxMBClass.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxMBClass.class.st
@@ -202,7 +202,7 @@ FmxMBClass >> generateTestingMethodsIn: aClass [
 
 	self isRoot ifTrue: [
 			builder testingSelectorsMapping keysAndValuesDo: [ :concernedClass :selectors |
-					(builder shouldGeneratorTestingMethodsOf: concernedClass) ifTrue: [
+					(builder shouldGeneratorTestingMethodsOf: concernedClass in: self) ifTrue: [
 							selectors do: [ :sel |
 									| selectorsFromTraits |
 									selectorsFromTraits := self traitGeneralizations flatCollect: #testingSelectors.

--- a/src/Famix-Test5-Entities/FamixTest5Entity.class.st
+++ b/src/Famix-Test5-Entities/FamixTest5Entity.class.st
@@ -1,6 +1,8 @@
 Class {
 	#name : 'FamixTest5Entity',
 	#superclass : 'MooseEntity',
+	#traits : 'FamixTest5TEntity',
+	#classTraits : 'FamixTest5TEntity classTrait',
 	#category : 'Famix-Test5-Entities-Entities',
 	#package : 'Famix-Test5-Entities',
 	#tag : 'Entities'

--- a/src/Famix-Test5-Entities/FamixTest5TEntity.trait.st
+++ b/src/Famix-Test5-Entities/FamixTest5TEntity.trait.st
@@ -1,0 +1,17 @@
+Trait {
+	#name : 'FamixTest5TEntity',
+	#traits : 'TEntityMetaLevelDependency',
+	#classTraits : 'TEntityMetaLevelDependency classTrait',
+	#category : 'Famix-Test5-Entities-Traits',
+	#package : 'Famix-Test5-Entities',
+	#tag : 'Traits'
+}
+
+{ #category : 'meta' }
+FamixTest5TEntity classSide >> annotation [
+
+	<FMClass: #TEntity super: #Object>
+	<package: #'Famix-Test5-Entities'>
+	<generated>
+	^ self
+]

--- a/src/Famix-Test5-Tests/FamixTest5Test.class.st
+++ b/src/Famix-Test5-Tests/FamixTest5Test.class.st
@@ -39,3 +39,10 @@ FamixTest5Test >> testApplyOnOppositeTraitOn [
 	self assert: (ctype traits includes: ttype).
 	self assert: (cwith traits includes: twith)
 ]
+
+{ #category : 'tests' }
+FamixTest5Test >> testTestingMethodsAreRight [
+	"Regression test: https://github.com/moosetechnology/Famix/issues/1090"
+	
+	self assert: FamixTest5AnnotationType1 new isQueryable 
+]

--- a/src/Famix-TestGenerators/FamixTest5Generator.class.st
+++ b/src/Famix-TestGenerators/FamixTest5Generator.class.st
@@ -5,7 +5,9 @@ Class {
 		'annotationType1',
 		'withAnnotationType1',
 		'annotationType2',
-		'withAnnotationType2'
+		'withAnnotationType2',
+		'entity',
+		'tEntity'
 	],
 	#category : 'Famix-TestGenerators',
 	#package : 'Famix-TestGenerators'
@@ -38,7 +40,18 @@ FamixTest5Generator >> defineClasses [
 	
 	annotationType2 := builder newClassNamed: #AnnotationType2.
 	withAnnotationType2 := builder newClassNamed: #WithAnnotationType2.
+	
+	entity := builder ensureClassNamed: #Entity
+]
 
+{ #category : 'definition' }
+FamixTest5Generator >> defineHierarchy [
+
+	super defineHierarchy.
+
+	entity --|> tEntity.
+
+	tEntity --|> #TEntityMetaLevelDependency
 ]
 
 { #category : 'definition' }
@@ -50,4 +63,11 @@ FamixTest5Generator >> defineRelations [
 
 	self apply: #TWithAnnotationTypes on: withAnnotationType2 oppositeOn: annotationType2.
 
+]
+
+{ #category : 'definition' }
+FamixTest5Generator >> defineTraits [
+	super defineTraits.
+	
+	tEntity := builder newTraitNamed: #TEntity
 ]


### PR DESCRIPTION
Fixes #1090

We should not generate a testing method returning false if the top class contains a trait with the testing method to generate. Else it will override it. I also added a regression test