### PR TITLE
Add a testing selector to speed up FAST

### DIFF
--- a/src/Famix-Java-Entities/FamixJavaEntity.class.st
+++ b/src/Famix-Java-Entities/FamixJavaEntity.class.st
@@ -45,6 +45,13 @@ FamixJavaEntity >> canBeStub [
 ]
 
 { #category : 'testing' }
+FamixJavaEntity >> hasImmediateSource [
+
+	<generated>
+	^ false
+]
+
+{ #category : 'testing' }
 FamixJavaEntity >> isAccess [
 
 	<generated>

--- a/src/Famix-MetamodelGeneration/FamixGenerator.class.st
+++ b/src/Famix-MetamodelGeneration/FamixGenerator.class.st
@@ -1845,6 +1845,7 @@ FamixGenerator >> defineTraits [
 	tWithTypes := builder newTraitNamed: #TWithTypes comment: self commentForTWithTypes.
 
 	tHasImmediateSource := builder newTraitNamed: #THasImmediateSource comment: self commentForTHasImmediateSource.
+	tHasImmediateSource testingSelector: #hasImmediateSource.
 
 	tHasVisibility := builder newTraitNamed: #THasVisibility.
 

--- a/src/Famix-PharoSmalltalk-Entities/FamixStEntity.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStEntity.class.st
@@ -38,6 +38,13 @@ FamixStEntity >> canBeStub [
 ]
 
 { #category : 'testing' }
+FamixStEntity >> hasImmediateSource [
+
+	<generated>
+	^ false
+]
+
+{ #category : 'testing' }
 FamixStEntity >> isAccess [
 
 	<generated>

--- a/src/Famix-Test1-Entities/FamixTest1Entity.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1Entity.class.st
@@ -38,6 +38,13 @@ FamixTest1Entity >> canBeStub [
 ]
 
 { #category : 'testing' }
+FamixTest1Entity >> hasImmediateSource [
+
+	<generated>
+	^ false
+]
+
+{ #category : 'testing' }
 FamixTest1Entity >> isAssociation [
 
 	<generated>

--- a/src/Famix-Test2-Entities/FamixTest2Entity.class.st
+++ b/src/Famix-Test2-Entities/FamixTest2Entity.class.st
@@ -38,6 +38,13 @@ FamixTest2Entity >> canBeStub [
 ]
 
 { #category : 'testing' }
+FamixTest2Entity >> hasImmediateSource [
+
+	<generated>
+	^ false
+]
+
+{ #category : 'testing' }
 FamixTest2Entity >> isAssociation [
 
 	<generated>

--- a/src/Famix-Test3-Entities/FamixTest3Entity.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3Entity.class.st
@@ -38,6 +38,13 @@ FamixTest3Entity >> canBeStub [
 ]
 
 { #category : 'testing' }
+FamixTest3Entity >> hasImmediateSource [
+
+	<generated>
+	^ false
+]
+
+{ #category : 'testing' }
 FamixTest3Entity >> isAccess [
 
 	<generated>

--- a/src/Famix-Test3-Entities/FamixTest3TypeGroup.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3TypeGroup.class.st
@@ -30,6 +30,13 @@ FamixTest3TypeGroup >> canBeStub [
 ]
 
 { #category : 'testing' }
+FamixTest3TypeGroup >> hasImmediateSource [
+
+	<generated>
+	^ false
+]
+
+{ #category : 'testing' }
 FamixTest3TypeGroup >> isAccess [
 
 	<generated>

--- a/src/Famix-Test6-Entities/FamixTest6Entity.class.st
+++ b/src/Famix-Test6-Entities/FamixTest6Entity.class.st
@@ -31,6 +31,13 @@ FamixTest6Entity class >> metamodel [
 ]
 
 { #category : 'testing' }
+FamixTest6Entity >> hasImmediateSource [
+
+	<generated>
+	^ false
+]
+
+{ #category : 'testing' }
 FamixTest6Entity >> isComment [
 
 	<generated>

--- a/src/Famix-Test7-Entities/FamixTest7Entity.class.st
+++ b/src/Famix-Test7-Entities/FamixTest7Entity.class.st
@@ -38,6 +38,13 @@ FamixTest7Entity >> canBeStub [
 ]
 
 { #category : 'testing' }
+FamixTest7Entity >> hasImmediateSource [
+
+	<generated>
+	^ false
+]
+
+{ #category : 'testing' }
 FamixTest7Entity >> isAssociation [
 
 	<generated>

--- a/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1Entity.class.st
+++ b/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1Entity.class.st
@@ -38,6 +38,13 @@ FamixTestComposed1Entity >> canBeStub [
 ]
 
 { #category : 'testing' }
+FamixTestComposed1Entity >> hasImmediateSource [
+
+	<generated>
+	^ false
+]
+
+{ #category : 'testing' }
 FamixTestComposed1Entity >> isBehavioural [
 
 	<generated>

--- a/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2Entity.class.st
+++ b/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2Entity.class.st
@@ -38,6 +38,13 @@ FamixTestComposed2Entity >> canBeStub [
 ]
 
 { #category : 'testing' }
+FamixTestComposed2Entity >> hasImmediateSource [
+
+	<generated>
+	^ false
+]
+
+{ #category : 'testing' }
 FamixTestComposed2Entity >> isBehavioural [
 
 	<generated>

--- a/src/Famix-Traits/FamixTHasImmediateSource.trait.st
+++ b/src/Famix-Traits/FamixTHasImmediateSource.trait.st
@@ -61,6 +61,13 @@ FamixTHasImmediateSource >> accept: aVisitor [
 ]
 
 { #category : 'testing' }
+FamixTHasImmediateSource >> hasImmediateSource [
+
+	<generated>
+	^ true
+]
+
+{ #category : 'testing' }
 FamixTHasImmediateSource >> hasSource [
 	^ self source isEmptyOrNil not
 ]

--- a/src/Moose-Core-Tests-Entities/MooseMSEImporterTestEntity.class.st
+++ b/src/Moose-Core-Tests-Entities/MooseMSEImporterTestEntity.class.st
@@ -38,6 +38,13 @@ MooseMSEImporterTestEntity >> canBeStub [
 ]
 
 { #category : 'testing' }
+MooseMSEImporterTestEntity >> hasImmediateSource [
+
+	<generated>
+	^ false
+]
+
+{ #category : 'testing' }
 MooseMSEImporterTestEntity >> isAssociation [
 
 	<generated>


### PR DESCRIPTION
Adding a testing selector to make #sourceCode faster in FAST

This will speed up the FAST-Python importer but probably multiple other importers and browsers