### PR TITLE
Improve errors of builder

### DIFF
--- a/src/Famix-MetamodelBuilder-Core/FamixMetamodelGenerator.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FamixMetamodelGenerator.class.st
@@ -428,18 +428,26 @@ FamixMetamodelGenerator >> prefix [
 
 { #category : 'definition' }
 FamixMetamodelGenerator >> remoteEntity: anEntityName withPrefix: aPrefixName [
-	^ ((subBuildersMapByPrefix at: aPrefixName) ensureClassNamed: anEntityName)
-		isRemote: true;
-		remoteBuilder: builder;
-		yourself
+
+	| subBuilder |
+	subBuilder := subBuildersMapByPrefix at: aPrefixName ifAbsent: [ NotFound signalFor: aPrefixName in: subBuildersMapByPrefix keys ].
+
+	^ ((subBuilder classNamed: anEntityName) ifNil: [ NotFound signalFor: anEntityName in: subBuilder classes ])
+		  isRemote: true;
+		  remoteBuilder: builder;
+		  yourself
 ]
 
 { #category : 'definition' }
 FamixMetamodelGenerator >> remoteTrait: anEntityName withPrefix: aPrefixName [
-	^ ((subBuildersMapByPrefix at: aPrefixName) traitNamed: anEntityName)
-		isRemote: true;
-		remoteBuilder: builder;
-		yourself
+
+	| subBuilder |
+	subBuilder := subBuildersMapByPrefix at: aPrefixName ifAbsent: [ NotFound signalFor: aPrefixName in: subBuildersMapByPrefix keys ].
+
+	^ ((subBuilder traitNamed: anEntityName) ifNil: [ NotFound signalFor: anEntityName in: subBuilder traits ])
+		  isRemote: true;
+		  remoteBuilder: builder;
+		  yourself
 ]
 
 { #category : 'accessing' }

--- a/src/Famix-MetamodelBuilder-Tests/FamixRemoteRootEntityGeneratorA.class.st
+++ b/src/Famix-MetamodelBuilder-Tests/FamixRemoteRootEntityGeneratorA.class.st
@@ -2,7 +2,8 @@ Class {
 	#name : 'FamixRemoteRootEntityGeneratorA',
 	#superclass : 'FamixTestGenerator',
 	#instVars : [
-		'fmx'
+		'fmx',
+		'entity'
 	],
 	#category : 'Famix-MetamodelBuilder-Tests-GeneratorRessources',
 	#package : 'Famix-MetamodelBuilder-Tests',
@@ -27,6 +28,14 @@ FamixRemoteRootEntityGeneratorA class >> prefix [
 FamixRemoteRootEntityGeneratorA >> defineClasses [
 
 	super defineClasses.
+	entity := builder newClassNamed: #Entity.
 	fmx := builder newClassNamed: #EntityA.
 	fmx withTesting
+]
+
+{ #category : 'definition' }
+FamixRemoteRootEntityGeneratorA >> defineHierarchy [
+
+	super defineHierarchy.
+	fmx --|> entity
 ]

--- a/src/Famix-MetamodelBuilder-Tests/FamixRemoteRootEntityGeneratorB.class.st
+++ b/src/Famix-MetamodelBuilder-Tests/FamixRemoteRootEntityGeneratorB.class.st
@@ -2,7 +2,8 @@ Class {
 	#name : 'FamixRemoteRootEntityGeneratorB',
 	#superclass : 'FamixTestGenerator',
 	#instVars : [
-		'fmx'
+		'fmx',
+		'entity'
 	],
 	#category : 'Famix-MetamodelBuilder-Tests-GeneratorRessources',
 	#package : 'Famix-MetamodelBuilder-Tests',
@@ -27,6 +28,14 @@ FamixRemoteRootEntityGeneratorB class >> prefix [
 FamixRemoteRootEntityGeneratorB >> defineClasses [
 
 	super defineClasses.
+	entity := builder newClassNamed: #Entity.
 	fmx := builder newClassNamed: #EntityB.
 	fmx withTesting
+]
+
+{ #category : 'definition' }
+FamixRemoteRootEntityGeneratorB >> defineHierarchy [
+
+	super defineHierarchy.
+	fmx --|> entity
 ]


### PR DESCRIPTION
Improve #remoteEntity: and #remoteTrait in the MM builder to raise useful errors if the prefix or the entity is missing. It will print the list of available MM and Entities. Also now it will not create the entity by default if it is missing