### PR TITLE
fix #1093

### DIFF
--- a/src/Famix-PharoSmalltalk-Tests/FamixPharoMethodTest.class.st
+++ b/src/Famix-PharoSmalltalk-Tests/FamixPharoMethodTest.class.st
@@ -3,7 +3,9 @@ Class {
 	#superclass : 'TestCase',
 	#instVars : [
 		'method',
-		'signature'
+		'signature',
+		'constructor',
+		'm1'
 	],
 	#category : 'Famix-PharoSmalltalk-Tests',
 	#package : 'Famix-PharoSmalltalk-Tests'
@@ -18,6 +20,10 @@ FamixPharoMethodTest >> setUp [
 	method := FamixStMethod new.
 	signature := 'pharoMethod'.
 	method signature: signature.
+	constructor := FamixStMethod new.
+	constructor protocol: 'instance_creation'. 
+	m1 := FamixStMethod new.
+	m1 protocol: 'myProtocol'. 
 ]
 
 { #category : 'tests' }
@@ -54,6 +60,13 @@ FamixPharoMethodTest >> testIsClassSide [
 	method := FamixStMethod new.
 	method isClassSide: true.
 	self assert: method isClassSide .
+]
+
+{ #category : 'tests' }
+FamixPharoMethodTest >> testIsConstructor [
+	self deny: method isConstructor.
+	self deny: m1 isConstructor.
+	self assert: constructor isConstructor
 ]
 
 { #category : 'tests' }

--- a/src/Moose-SmalltalkImporter/SmalltalkMethodVisitor.class.st
+++ b/src/Moose-SmalltalkImporter/SmalltalkMethodVisitor.class.st
@@ -29,7 +29,6 @@ SmalltalkMethodVisitor >> classifyMethodNode: aMethodNode [
 	 
 	self matchGetter: aMethodNode. 
 	self matchSetter: aMethodNode. 
-	self matchConstructor: aMethodNode. 
 	self matchConstant: aMethodNode
 ]
 
@@ -101,7 +100,8 @@ SmalltalkMethodVisitor >> matchConstant: aMethodNode [
 
 { #category : 'method-classifying' }
 SmalltalkMethodVisitor >> matchConstructor: aMethodNode [
-
+self deprecated:
+		'#beConstructor is deprecated it was the setter for isConctructor. There is no more setter for this property that is computed in Pharo. Consequently matchConstructor is also deprecated'.
 	famixMethod protocol ifNotNil: [ 
 		('*instance*creation*' match: famixMethod protocol asLowercase) 
 			ifTrue: [ famixMethod beConstructor ] ]


### PR DESCRIPTION
fix: 1093 
refactor: remove the call to matchConstructor that is now deprecated, because isConstructor is computed and there is no setter