### PR TITLE
Simplify generation of specialized groups

### DIFF
--- a/src/Famix-MetamodelBuilder-Core/FmxMBConfiguration.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxMBConfiguration.class.st
@@ -8,8 +8,6 @@ Class {
 		'prefix',
 		'packageName',
 		'packageNameForAnnotations',
-		'navigationForContainers',
-		'navigationForNonContainers',
 		'shouldGenerateFileImportHelpers'
 	],
 	#category : 'Famix-MetamodelBuilder-Core-Basic',
@@ -22,35 +20,7 @@ FmxMBConfiguration >> initialize [
 
 	super initialize.
 
-	shouldGenerateFileImportHelpers := false.
-
-	navigationForContainers := true.
-	navigationForNonContainers := false
-]
-
-{ #category : 'accessing' }
-FmxMBConfiguration >> navigationForContainers [
-
-	"define if navigation methods for Moose Finder should be generated for containment relations"
-	^ navigationForContainers
-]
-
-{ #category : 'accessing' }
-FmxMBConfiguration >> navigationForContainers: anObject [
-	navigationForContainers := anObject
-]
-
-{ #category : 'accessing' }
-FmxMBConfiguration >> navigationForNonContainers [
-
-	"define if navigation methods for Moose Finder should be generated for non-containment relations"
-
-	^ navigationForNonContainers
-]
-
-{ #category : 'accessing' }
-FmxMBConfiguration >> navigationForNonContainers: anObject [
-	navigationForNonContainers := anObject
+	shouldGenerateFileImportHelpers := false
 ]
 
 { #category : 'accessing' }

--- a/src/Famix-MetamodelBuilder-Core/FmxMBRelationSideTrait.trait.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxMBRelationSideTrait.trait.st
@@ -75,8 +75,7 @@ FmxMBRelationSideTrait >> containsMany: aRelationSide [
 	
 	aRelation := self oneToMany: aRelationSide.
 	aRelation right container.
-	self builder configuration navigationForContainers
-		ifTrue: [ aRelation withNavigation ].
+	aRelation withNavigation.
 			
 	^ aRelation
 	
@@ -89,8 +88,7 @@ FmxMBRelationSideTrait >> containsOne: aRelationSide [
 	
 	aRelation := self oneToOne: aRelationSide.
 	aRelation right container.
-	self builder configuration navigationForContainers
-		ifTrue: [ aRelation withNavigation ].
+	aRelation withNavigation.
 			
 	^ aRelation
 	
@@ -103,8 +101,7 @@ FmxMBRelationSideTrait >> manyBelongTo: aRelationSide [
 	
 	aRelation := self manyToOne: aRelationSide.
 	aRelation left container.
-	self builder configuration navigationForContainers
-		ifTrue: [ aRelation withNavigation ].
+	aRelation withNavigation.
 			
 	^ aRelation
 
@@ -121,8 +118,6 @@ FmxMBRelationSideTrait >> manyToMany: aRelationSide [
 	ownSide derived.
 	oppositeSide many.
 	aRelation := self relationFrom: ownSide to: oppositeSide.
-	self builder configuration navigationForNonContainers
-		ifTrue: [ aRelation withNavigation ].
 
 	self isRemote ifTrue: [ ownSide makeRemote ].
 	aRelationSide isRemote ifTrue: [ oppositeSide makeRemote ].
@@ -144,8 +139,6 @@ FmxMBRelationSideTrait >> manyToOne: aRelationSide [
 	oppositeSide many.
 	oppositeSide derived.
 	aRelation := self relationFrom: ownSide to: oppositeSide.
-	self builder configuration navigationForNonContainers
-		ifTrue: [ aRelation withNavigation ].
 
 	self isRemote ifTrue: [ ownSide makeRemote ].
 	aRelationSide isRemote ifTrue: [ oppositeSide makeRemote ].
@@ -164,8 +157,7 @@ FmxMBRelationSideTrait >> oneBelongsTo: aRelationSide [
 	
 	aRelation := self oneToOne: aRelationSide.
 	aRelation left container.
-	self builder configuration navigationForContainers
-		ifTrue: [ aRelation withNavigation ].
+	aRelation withNavigation.
 			
 	^ aRelation
 
@@ -180,9 +172,7 @@ FmxMBRelationSideTrait >> oneToMany: aRelationSide [
 	ownSide many.
 	ownSide derived.
 	aRelation := self relationFrom: ownSide to: oppositeSide.
-	self builder configuration navigationForNonContainers
-		ifTrue: [ aRelation withNavigation ].
-		
+
 	self isRemote ifTrue: [ ownSide makeRemote ].
 	aRelationSide isRemote ifTrue: [ oppositeSide makeRemote ].
 	(self isRemote and: [ aRelationSide isRemote not ]) ifTrue: [ oppositeSide makeNonremote ].
@@ -202,8 +192,6 @@ FmxMBRelationSideTrait >> oneToOne: aRelationSide [
 	oppositeSide := aRelationSide asRelationSideNamed: self propertyName.
 	oppositeSide derived.
 	aRelation := self relationFrom: ownSide to: oppositeSide.
-	self builder configuration navigationForNonContainers
-		ifTrue: [ aRelation withNavigation ].
 		
 	self isRemote ifTrue: [ ownSide makeRemote ].
 	aRelationSide isRemote ifTrue: [ oppositeSide makeRemote ].

--- a/src/Famix-MetamodelBuilder-Tests/FmxMBConfigurationTest.class.st
+++ b/src/Famix-MetamodelBuilder-Tests/FmxMBConfigurationTest.class.st
@@ -13,14 +13,6 @@ FmxMBConfigurationTest >> testConfiguration [
 
 	self assert: config isNotNil.
 
-	self assert: config navigationForContainers.
-	config navigationForContainers: false.
-	self deny: config navigationForContainers.
-
-	self deny: config navigationForNonContainers.
-	config navigationForNonContainers: true.
-	self assert: config navigationForNonContainers.
-
 	self deny: config shouldGenerateFileImportHelpers.
 	config shouldGenerateFileImportHelpers: true.
 	self assert: config shouldGenerateFileImportHelpers

--- a/src/Famix-MetamodelBuilder-Tests/FmxMBNavigationGroupTest.class.st
+++ b/src/Famix-MetamodelBuilder-Tests/FmxMBNavigationGroupTest.class.st
@@ -22,7 +22,6 @@ FmxMBNavigationGroupTest >> testEmptyRelationGroups [
 { #category : 'tests' }
 FmxMBNavigationGroupTest >> testRelationGroupsForTraits [
 	| tClass tMethod class method relation |
-	builder configuration navigationForContainers.
 
 	tClass := builder newTraitNamed: #TClass.
 	tMethod := builder newTraitNamed: #TMethod.

--- a/src/Famix-Test4-Entities/FamixTest4Student.class.st
+++ b/src/Famix-Test4-Entities/FamixTest4Student.class.st
@@ -80,10 +80,3 @@ FamixTest4Student >> teachers: anObject [
 	<generated>
 	teachers value: anObject
 ]
-
-{ #category : 'navigation' }
-FamixTest4Student >> teachersGroup [
-	<generated>
-	<navigation: 'Teachers'>
-	^ MooseSpecializedGroup withAll: self teachers asSet
-]

--- a/src/Famix-Test4-Entities/FamixTest4Teacher.class.st
+++ b/src/Famix-Test4-Entities/FamixTest4Teacher.class.st
@@ -79,10 +79,3 @@ FamixTest4Teacher >> students: anObject [
 	<generated>
 	students value: anObject
 ]
-
-{ #category : 'navigation' }
-FamixTest4Teacher >> studentsGroup [
-	<generated>
-	<navigation: 'Students'>
-	^ MooseSpecializedGroup withAll: self students asSet
-]

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedCustomEntity1.class.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedCustomEntity1.class.st
@@ -77,10 +77,3 @@ FamixTestComposedCustomEntity1 >> customEntity1: anObject [
 		self attributeAt: #customEntity1 put: anObject.
 		anObject customEntity1: self ]
 ]
-
-{ #category : 'navigation' }
-FamixTestComposedCustomEntity1 >> customEntity1Group [
-	<generated>
-	<navigation: 'CustomEntity1'>
-	^ MooseSpecializedGroup with: self customEntity1
-]

--- a/src/Famix-TestGenerators/FamixTest4Generator.class.st
+++ b/src/Famix-TestGenerators/FamixTest4Generator.class.st
@@ -34,14 +34,6 @@ FamixTest4Generator class >> prefix [
 ]
 
 { #category : 'definition' }
-FamixTest4Generator >> adoptBuilder: aBuilder [
-
-	super adoptBuilder: aBuilder.
-
-	aBuilder configuration navigationForNonContainers: true.
-]
-
-{ #category : 'definition' }
 FamixTest4Generator >> defineClasses [
 
 	super defineClasses.


### PR DESCRIPTION
We have multiple configurations of the specialized groups generation but none of those are used and they make the generator more complex. 

On top of this, we discussed in a Moose meeting a few month ago about reducing the number of groups because they were used for the MooseInspector but it does not use the groups anymore. 

This is a first step to the simplification

Fixes #1115