### PR TITLE
Remove usage of private API in the generators

### DIFF
--- a/src/Famix-MetamodelBuilder-Core/FmxMBRelationSide.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxMBRelationSide.class.st
@@ -59,7 +59,8 @@ FmxMBRelationSide >> cardinality: anObject [
 
 { #category : 'properties' }
 FmxMBRelationSide >> container [
-	
+	"This method should not be called directly by the user. This is reserved to be used internaly in the builder."
+
 	self withNavigationOf: self relation.
 	container := true
 ]

--- a/src/Famix-MetamodelGeneration/FamixGenerator.class.st
+++ b/src/Famix-MetamodelGeneration/FamixGenerator.class.st
@@ -1297,9 +1297,8 @@ FamixGenerator >> defineRelations [
 			comment: 'This property corresponds to the set of annotations associated to the entity').
 
 	((tAnnotationInstanceAttribute property: #parentAnnotationInstance)
-			comment: 'The instance of the annotation in which the attribute is used.';
-			container)
-		*-
+			comment: 'The instance of the annotation in which the attribute is used.')
+		*-<>
 	((tAnnotationInstance property: #attributes)
 			comment: 'This corresponds to the actual values of the attributes in an AnnotationInstance').
 
@@ -1311,9 +1310,8 @@ FamixGenerator >> defineRelations [
 			container"). "TODO: resolve"
 
 	((tAnnotationType property: #annotationTypesContainer)
-			comment: 'Container in which an AnnotationType may reside';
-			container	)
-		*-
+			comment: 'Container in which an AnnotationType may reside')
+		*-<>
 	((tWithAnnotationTypes property: #definedAnnotationTypes)
 			comment: 'The container in which the AnnotationTypes may be declared').
 
@@ -1330,16 +1328,14 @@ FamixGenerator >> defineRelations [
 			comment: 'Next association in an ordered collection of associations. Currently not supported by the Moose importer').
 
 	((tAttribute property: #parentType)
-			comment: 'Type declaring the attribute. belongsTo implementation';
-			container)
-		*-
+			comment: 'Type declaring the attribute. belongsTo implementation')
+		*-<>
 	((tWithAttributes property: #attributes)
 			comment: 'List of attributes declared by this type.').
 
 	((tCompilationUnit property: #compilationUnitOwner)
-			comment: 'The compilation unit that defines this module';
-			container)
-		-
+			comment: 'The compilation unit that defines this module')
+		-<>
 	((tWithCompilationUnits property: #compilationUnit)).
 
 	((tThrowable property: #catchingEntities))
@@ -1348,9 +1344,8 @@ FamixGenerator >> defineRelations [
 			comment: 'The exceptions caught by the method').
 
 	((tComment property: #commentedEntity)
-			comment: 'Source code commented by the comment';
-			container)
-		*-
+			comment: 'Source code commented by the comment')
+		*-<>
 	((tWithComments property: #comments)
 			comment: 'List of comments for the entity').
 
@@ -1366,17 +1361,15 @@ FamixGenerator >> defineRelations [
 			comment: 'List of invocations performed on BehaviouralEntities referenced by this entity').
 
 	((tEnumValue property: #parentEnum)
-			comment: 'The Enum declaring this value. It offers the implementation of belongsTo';
-			container)
-		*-
+			comment: 'The Enum declaring this value. It offers the implementation of belongsTo')
+		*-<>
 	((tWithEnumValues property: #enumValues)).
 
 	((tFolder property: #childrenFileSystemEntities)
 			comment: 'List of entities contained in this folder.')
-		-*
+		<>-*
 	((tFileSystemEntity property: #parentFolder)
-		comment: 'Folder entity containing this file.';
-		container).
+		comment: 'Folder entity containing this file.').
 
 	((tFile property: #entities)
 			comment: 'List of entities defined in the file')
@@ -1397,30 +1390,26 @@ FamixGenerator >> defineRelations [
 			comment: 'The include entities that have this file as a target.').
 
 	((tFunction property: #functionOwner)
-			comment: 'The container defining the function. The function is placed in a container, because certain languages can nest functions in functions.';
-			container)
-		*-
+			comment: 'The container defining the function. The function is placed in a container, because certain languages can nest functions in functions.')
+		*-<>
 	((tWithFunctions property: #functions)
 			comment: 'Functions defined in the container, if any.').
 
 	((tLambda property: #lambdaContainer)
-			comment: 'The container defining the lambda expression. The lambda is placed in a container, because certain languages can nest lambdas in lambdas.';
-			container)
-		*-
+			comment: 'The container defining the lambda expression. The lambda is placed in a container, because certain languages can nest lambdas in lambdas.')
+		*-<>
 	((tWithLambdas property: #lambdas)
 			comment: 'Lambdas defined in the container, if any.').
 
 	((tGlobalVariable property: #parentScope)
-			comment: 'Scope declaring the global variable. belongsTo implementation';
-			container)
-		*-
+			comment: 'Scope declaring the global variable. belongsTo implementation')
+		*-<>
 	((tWithGlobalVariables property: #globalVariables)
 			comment: 'Global variables defined in the scope, if any.').
 
 	((tImplicitVariable property: #parentBehaviouralEntity)
-			comment: 'The behaviour containing this implicit variable. belongsTo implementation';
-			container)
-		*-
+			comment: 'The behaviour containing this implicit variable. belongsTo implementation')
+		*-<>
 	((tWithImplicitVariables property: #implicitVariables)
 			comment: 'Implicit variables used locally by this behaviour.').
 
@@ -1459,36 +1448,31 @@ FamixGenerator >> defineRelations [
 			comment: 'List of imports of this entity').
 
 	((tLocalVariable property: #parentBehaviouralEntity)
-			comment: 'Behavioural entity declaring this local variable. belongsTo implementation';
-			container)
-		*-
+			comment: 'Behavioural entity declaring this local variable. belongsTo implementation')
+		*-<>
 	((tWithLocalVariables property: #localVariables)
 			comment: 'Variables locally defined by this behaviour.').
 
 	((tMethod property: #parentType)
-			comment: 'Type declaring the method. It provides the implementation for belongsTo.';
-			container)
-		*-
+			comment: 'Type declaring the method. It provides the implementation for belongsTo.')
+		*-<>
 	((tWithMethods property: #methods)
 			comment: 'Methods declared by this type.').
 
 	((tModule property: #moduleEntities))
-		-*
+		<>-*
 	((tDefinedInModule property: #parentModule)
-			comment: 'Module that contains the definition of this entity';
-			container).
+			comment: 'Module that contains the definition of this entity').
 
 	((tPackage property: #childEntities))
-		-*
+		<>-*
 	((tPackageable property: #parentPackage)
-		comment: 'Package containing the entity in the code structure (if applicable)';
-		container).
+		comment: 'Package containing the entity in the code structure (if applicable)').
 
 
 	((tParameter property: #parentBehaviouralEntity)
-			comment: 'Behavioural entity containing this parameter. belongsTo implementation';
-			container)
-		*-
+			comment: 'Behavioural entity containing this parameter. belongsTo implementation')
+		*-<>
 	((tWithParameters property: #parameters)
 			comment: 'List of formal parameters declared by this behaviour.').
 
@@ -1532,37 +1516,30 @@ FamixGenerator >> defineRelations [
 	((tWithInheritances property: #subInheritances)
 			comment: 'Subinheritance relationships, i.e. known subclasses of this type.').
 
-	((tTemplate property: #templateOwner) container)
-		*-
-	((tWithTemplates property: #templates)).
+	(tTemplate property: #templateOwner) *-<> (tWithTemplates property: #templates).
 
-	((tTemplate property: #templateUsers))
-		-*
-	((tTemplateUser property: #template)).
+	(tTemplate property: #templateUsers) -* (tTemplateUser property: #template).
 
-	((tThrowable property: #throwingEntities))
+	(tThrowable property: #throwingEntities)
 		*-*
 	((tWithExceptions property: #thrownExceptions)
 			comment: 'The exceptions thrown by the method').
 
-	((tTrait property: #traitOwner) container )
-		*-
-	((tWithTraits property: #traits)).
+	(tTrait property: #traitOwner ) *-<> (tWithTraits property: #traits).
 
-	((tTrait property: #incomingTraitUsages))
+	(tTrait property: #incomingTraitUsages)
 		-*
 	((tTraitUsage property: #trait)
 			source).
 
-	((tTraitUser property: #traitUsages))
+	(tTraitUser property: #traitUsages)
 		-*
 	((tTraitUsage property: #user)
 			target).
 
 	((tType property: #typeContainer)
-			comment: 'Container entity to which this type belongs. Container is a namespace, not a package (Smalltalk).';
-			container)
-		*-
+			comment: 'Container entity to which this type belongs. Container is a namespace, not a package (Smalltalk).')
+		*-<>
 	((tWithTypes property: #types)
 		comment: 'Types contained (declared) in this entity, if any.
 #types is declared in ContainerEntity because different kinds of container can embed types. Types are usually contained in a Famix.Namespace. But types can also be contained in a Famix.Class or Famix.Method (in Java with inner classes for example). Famix.Function can also contain some types such as structs.').

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedCustomEntity1.class.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedCustomEntity1.class.st
@@ -77,3 +77,10 @@ FamixTestComposedCustomEntity1 >> customEntity1: anObject [
 		self attributeAt: #customEntity1 put: anObject.
 		anObject customEntity1: self ]
 ]
+
+{ #category : 'navigation' }
+FamixTestComposedCustomEntity1 >> customEntity1Group [
+	<generated>
+	<navigation: 'CustomEntity1'>
+	^ MooseSpecializedGroup with: self customEntity1
+]

--- a/src/Famix-Traits/FamixTAnnotationInstance.trait.st
+++ b/src/Famix-Traits/FamixTAnnotationInstance.trait.st
@@ -120,6 +120,13 @@ FamixTAnnotationInstance >> attributes: anObject [
 	attributes value: anObject
 ]
 
+{ #category : 'navigation' }
+FamixTAnnotationInstance >> attributesGroup [
+	<generated>
+	<navigation: 'Attributes'>
+	^ MooseSpecializedGroup withAll: self attributes asSet
+]
+
 { #category : 'printing' }
 FamixTAnnotationInstance >> displayStringOn: aStream [
 

--- a/src/Famix-Traits/FamixTFolder.trait.st
+++ b/src/Famix-Traits/FamixTFolder.trait.st
@@ -102,6 +102,13 @@ FamixTFolder >> childrenFileSystemEntities: anObject [
 	childrenFileSystemEntities value: anObject
 ]
 
+{ #category : 'navigation' }
+FamixTFolder >> childrenFileSystemEntitiesGroup [
+	<generated>
+	<navigation: 'ChildrenFileSystemEntities'>
+	^ MooseSpecializedGroup withAll: self childrenFileSystemEntities asSet
+]
+
 { #category : 'adding' }
 FamixTFolder >> files [
 	^ self childrenFileSystemEntities reject: #isFolder

--- a/src/Famix-Traits/FamixTModule.trait.st
+++ b/src/Famix-Traits/FamixTModule.trait.st
@@ -68,3 +68,10 @@ FamixTModule >> moduleEntities: anObject [
 	<generated>
 	moduleEntities value: anObject
 ]
+
+{ #category : 'navigation' }
+FamixTModule >> moduleEntitiesGroup [
+	<generated>
+	<navigation: 'ModuleEntities'>
+	^ MooseSpecializedGroup withAll: self moduleEntities asSet
+]

--- a/src/Famix-Traits/FamixTPackage.trait.st
+++ b/src/Famix-Traits/FamixTPackage.trait.st
@@ -83,6 +83,13 @@ FamixTPackage >> childEntities: anObject [
 	childEntities value: anObject
 ]
 
+{ #category : 'navigation' }
+FamixTPackage >> childEntitiesGroup [
+	<generated>
+	<navigation: 'ChildEntities'>
+	^ MooseSpecializedGroup withAll: self childEntities asSet
+]
+
 { #category : 'testing' }
 FamixTPackage >> isPackage [
 

--- a/src/Famix-Traits/FamixTWithAnnotationTypes.trait.st
+++ b/src/Famix-Traits/FamixTWithAnnotationTypes.trait.st
@@ -58,3 +58,10 @@ FamixTWithAnnotationTypes >> definedAnnotationTypes: anObject [
 	<generated>
 	definedAnnotationTypes value: anObject
 ]
+
+{ #category : 'navigation' }
+FamixTWithAnnotationTypes >> definedAnnotationTypesGroup [
+	<generated>
+	<navigation: 'DefinedAnnotationTypes'>
+	^ MooseSpecializedGroup withAll: self definedAnnotationTypes asSet
+]

--- a/src/Famix-Traits/FamixTWithAttributes.trait.st
+++ b/src/Famix-Traits/FamixTWithAttributes.trait.st
@@ -58,6 +58,13 @@ FamixTWithAttributes >> attributes: anObject [
 	attributes value: anObject
 ]
 
+{ #category : 'navigation' }
+FamixTWithAttributes >> attributesGroup [
+	<generated>
+	<navigation: 'Attributes'>
+	^ MooseSpecializedGroup withAll: self attributes asSet
+]
+
 { #category : 'Famix-Extensions' }
 FamixTWithAttributes >> numberOfAttributes [
 

--- a/src/Famix-Traits/FamixTWithComments.trait.st
+++ b/src/Famix-Traits/FamixTWithComments.trait.st
@@ -60,6 +60,13 @@ FamixTWithComments >> comments: anObject [
 	comments value: anObject
 ]
 
+{ #category : 'navigation' }
+FamixTWithComments >> commentsGroup [
+	<generated>
+	<navigation: 'Comments'>
+	^ MooseSpecializedGroup withAll: self comments asSet
+]
+
 { #category : 'testing' }
 FamixTWithComments >> hasComments [
 	<FMProperty: #hasComments type: #Boolean>

--- a/src/Famix-Traits/FamixTWithCompilationUnits.trait.st
+++ b/src/Famix-Traits/FamixTWithCompilationUnits.trait.st
@@ -51,3 +51,10 @@ FamixTWithCompilationUnits >> compilationUnit: anObject [
 	<generated>
 	compilationUnit := anObject
 ]
+
+{ #category : 'navigation' }
+FamixTWithCompilationUnits >> compilationUnitGroup [
+	<generated>
+	<navigation: 'CompilationUnit'>
+	^ MooseSpecializedGroup with: self compilationUnit
+]

--- a/src/Famix-Traits/FamixTWithEnumValues.trait.st
+++ b/src/Famix-Traits/FamixTWithEnumValues.trait.st
@@ -57,3 +57,10 @@ FamixTWithEnumValues >> enumValues: anObject [
 	<generated>
 	enumValues value: anObject
 ]
+
+{ #category : 'navigation' }
+FamixTWithEnumValues >> enumValuesGroup [
+	<generated>
+	<navigation: 'EnumValues'>
+	^ MooseSpecializedGroup withAll: self enumValues asSet
+]

--- a/src/Famix-Traits/FamixTWithFunctions.trait.st
+++ b/src/Famix-Traits/FamixTWithFunctions.trait.st
@@ -58,3 +58,10 @@ FamixTWithFunctions >> functions: anObject [
 	<generated>
 	functions value: anObject
 ]
+
+{ #category : 'navigation' }
+FamixTWithFunctions >> functionsGroup [
+	<generated>
+	<navigation: 'Functions'>
+	^ MooseSpecializedGroup withAll: self functions asSet
+]

--- a/src/Famix-Traits/FamixTWithGlobalVariables.trait.st
+++ b/src/Famix-Traits/FamixTWithGlobalVariables.trait.st
@@ -60,3 +60,10 @@ FamixTWithGlobalVariables >> globalVariables: anObject [
 	<generated>
 	globalVariables value: anObject
 ]
+
+{ #category : 'navigation' }
+FamixTWithGlobalVariables >> globalVariablesGroup [
+	<generated>
+	<navigation: 'GlobalVariables'>
+	^ MooseSpecializedGroup withAll: self globalVariables asSet
+]

--- a/src/Famix-Traits/FamixTWithImplicitVariables.trait.st
+++ b/src/Famix-Traits/FamixTWithImplicitVariables.trait.st
@@ -57,3 +57,10 @@ FamixTWithImplicitVariables >> implicitVariables: anObject [
 	<generated>
 	implicitVariables value: anObject
 ]
+
+{ #category : 'navigation' }
+FamixTWithImplicitVariables >> implicitVariablesGroup [
+	<generated>
+	<navigation: 'ImplicitVariables'>
+	^ MooseSpecializedGroup withAll: self implicitVariables asSet
+]

--- a/src/Famix-Traits/FamixTWithLambdas.trait.st
+++ b/src/Famix-Traits/FamixTWithLambdas.trait.st
@@ -60,3 +60,10 @@ FamixTWithLambdas >> lambdas: anObject [
 	<generated>
 	lambdas value: anObject
 ]
+
+{ #category : 'navigation' }
+FamixTWithLambdas >> lambdasGroup [
+	<generated>
+	<navigation: 'Lambdas'>
+	^ MooseSpecializedGroup withAll: self lambdas asSet
+]

--- a/src/Famix-Traits/FamixTWithLocalVariables.trait.st
+++ b/src/Famix-Traits/FamixTWithLocalVariables.trait.st
@@ -57,3 +57,10 @@ FamixTWithLocalVariables >> localVariables: anObject [
 	<generated>
 	localVariables value: anObject
 ]
+
+{ #category : 'navigation' }
+FamixTWithLocalVariables >> localVariablesGroup [
+	<generated>
+	<navigation: 'LocalVariables'>
+	^ MooseSpecializedGroup withAll: self localVariables asSet
+]

--- a/src/Famix-Traits/FamixTWithParameters.trait.st
+++ b/src/Famix-Traits/FamixTWithParameters.trait.st
@@ -71,3 +71,10 @@ FamixTWithParameters >> parameters: anObject [
 	<generated>
 	parameters value: anObject
 ]
+
+{ #category : 'navigation' }
+FamixTWithParameters >> parametersGroup [
+	<generated>
+	<navigation: 'Parameters'>
+	^ MooseSpecializedGroup withAll: self parameters asSet
+]

--- a/src/Famix-Traits/FamixTWithTemplates.trait.st
+++ b/src/Famix-Traits/FamixTWithTemplates.trait.st
@@ -57,3 +57,10 @@ FamixTWithTemplates >> templates: anObject [
 	<generated>
 	templates value: anObject
 ]
+
+{ #category : 'navigation' }
+FamixTWithTemplates >> templatesGroup [
+	<generated>
+	<navigation: 'Templates'>
+	^ MooseSpecializedGroup withAll: self templates asSet
+]

--- a/src/Famix-Traits/FamixTWithTraits.trait.st
+++ b/src/Famix-Traits/FamixTWithTraits.trait.st
@@ -57,3 +57,10 @@ FamixTWithTraits >> traits: anObject [
 	<generated>
 	traits value: anObject
 ]
+
+{ #category : 'navigation' }
+FamixTWithTraits >> traitsGroup [
+	<generated>
+	<navigation: 'Traits'>
+	^ MooseSpecializedGroup withAll: self traits asSet
+]

--- a/src/Famix-Traits/FamixTWithTypes.trait.st
+++ b/src/Famix-Traits/FamixTWithTypes.trait.st
@@ -77,3 +77,10 @@ FamixTWithTypes >> types: anObject [
 	<generated>
 	types value: anObject
 ]
+
+{ #category : 'navigation' }
+FamixTWithTypes >> typesGroup [
+	<generated>
+	<navigation: 'Types'>
+	^ MooseSpecializedGroup withAll: self types asSet
+]


### PR DESCRIPTION
The FamixGenerator is using the method #container but this method should not be called from the generator. It should be called by #containsOne:, #containsMany:, manyBelongsTo: or #oneBelongsTo:. 

Using it in the generator is bypassing some features of the generator. 

In this change, I remove the usage of this method in the generators of Moose. 

In a next step, I'll refactore the generation of the specialized groups further and this will raise a new error if someone tries to declare a relation as container before we create the relation