### PR TITLE
Fix duplicated generation of specialized groups

### DIFF
--- a/src/Famix-MetamodelBuilder-Core/FmxMBRelationSide.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxMBRelationSide.class.st
@@ -61,7 +61,7 @@ FmxMBRelationSide >> cardinality: anObject [
 FmxMBRelationSide >> container [
 	"This method should not be called directly by the user. This is reserved to be used internaly in the builder."
 
-	self withNavigationOf: self relation.
+	self relation withNavigation.
 	container := true
 ]
 

--- a/src/Famix-MetamodelBuilder-Core/FmxMBRelationSideTrait.trait.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxMBRelationSideTrait.trait.st
@@ -72,39 +72,27 @@ FmxMBRelationSideTrait >> asRelationSideNamed: aPropertyName [
 FmxMBRelationSideTrait >> containsMany: aRelationSide [
 
 	| aRelation |
-	
 	aRelation := self oneToMany: aRelationSide.
 	aRelation right container.
-	aRelation withNavigation.
-			
 	^ aRelation
-	
 ]
 
 { #category : 'relations - named containers' }
 FmxMBRelationSideTrait >> containsOne: aRelationSide [
 
 	| aRelation |
-	
 	aRelation := self oneToOne: aRelationSide.
 	aRelation right container.
-	aRelation withNavigation.
-			
 	^ aRelation
-	
 ]
 
 { #category : 'relations - named containers' }
 FmxMBRelationSideTrait >> manyBelongTo: aRelationSide [
 
 	| aRelation |
-	
 	aRelation := self manyToOne: aRelationSide.
 	aRelation left container.
-	aRelation withNavigation.
-			
 	^ aRelation
-
 ]
 
 { #category : 'relations - named' }
@@ -154,13 +142,9 @@ FmxMBRelationSideTrait >> manyToOne: aRelationSide [
 FmxMBRelationSideTrait >> oneBelongsTo: aRelationSide [
 
 	| aRelation |
-	
 	aRelation := self oneToOne: aRelationSide.
 	aRelation left container.
-	aRelation withNavigation.
-			
 	^ aRelation
-
 ]
 
 { #category : 'relations - named' }

--- a/src/Famix-MetamodelBuilder-Tests/FmxMBRelationSideTest.class.st
+++ b/src/Famix-MetamodelBuilder-Tests/FmxMBRelationSideTest.class.st
@@ -125,12 +125,11 @@ FmxMBRelationSideTest >> testProperties [
 	side := FmxMBRelationSide new.
 
 	self deny: side isContainer.
-	side container.
+	side container: true.
 	self assert: side isContainer.
 	side container: false.
 	self deny: side isContainer.
-	side container.
-	self assert: side isContainer.
+	side container: true.
 	side noContainer.
 	self deny: side isContainer.
 


### PR DESCRIPTION
The generation of specialized group could happens 3 times for the same group. With a previous change I reduced this to 2 times.  With this change, it will happen only once now.