### PR TITLE
Fix double superclass declaration in Pharo MM

### DIFF
--- a/src/Famix-PharoSmalltalk-Generator/FamixPharoSmalltalkGenerator.class.st
+++ b/src/Famix-PharoSmalltalk-Generator/FamixPharoSmalltalkGenerator.class.st
@@ -85,9 +85,8 @@ FamixPharoSmalltalkGenerator >> defineHierarchy [
 	annotationType --|> #TWithAttributes.
 	annotationType --|> #TPackageable.
 
-	annotationTypeAttribute --|> namedEntity.
-	annotationTypeAttribute --|> #TEntityMetaLevelDependency.
 	annotationTypeAttribute --|> sourcedEntity.
+	annotationTypeAttribute --|> #TEntityMetaLevelDependency.
 	annotationTypeAttribute --|> #TAnnotationTypeAttribute.
 
 	attribute --|> namedEntity.


### PR DESCRIPTION
Un the Smalltalk MM zwe duclared 2 superclasses to a class but we can have only one in Pharo. Thus the last declared win.

Fixing this problem. I'll forbid to set two classes as superclasses in my refactoring of the Moose generator