### PR TITLE
Make metamodel generator prefix required

### DIFF
--- a/src/Famix-MetamodelBuilder-Core/FamixMetamodelGenerator.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FamixMetamodelGenerator.class.st
@@ -157,7 +157,7 @@ FamixMetamodelGenerator class >> packageName [
 FamixMetamodelGenerator class >> prefix [
 
 	<ignoreForCoverage>
-	^ self packageName
+	^ self subclassResponsibility
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
Instead of using a package name that contains illegal caracters for a class name