### PR TITLE
Export literal array issue

### DIFF
--- a/src/Famix-Java-Entities/FamixJavaAnnotationInstanceAttribute.class.st
+++ b/src/Famix-Java-Entities/FamixJavaAnnotationInstanceAttribute.class.st
@@ -18,7 +18,7 @@
 
 | Name | Type | Default value | Comment |
 |---|
-| `value` | `String` | nil | Actual value of the attribute used in an annotation|
+| `value` | `Object` | nil | Actual value of the attribute used in an annotation|
 
 "
 Class {

--- a/src/Famix-MetamodelGeneration/FamixGenerator.class.st
+++ b/src/Famix-MetamodelGeneration/FamixGenerator.class.st
@@ -1226,7 +1226,7 @@ FamixGenerator >> defineProperties [
 
 	(tAccess property: #isWrite type: #Boolean defaultValue: false) comment: 'Write access'.
 
-	(tAnnotationInstanceAttribute property: #value type: #String) comment: 'Actual value of the attribute used in an annotation'.
+	(tAnnotationInstanceAttribute property: #value type: #Object) comment: 'Actual value of the attribute used in an annotation'.
 
 	(tNamedEntity property: #name type: #String) comment: 'Basic name of the entity, not full reference.'.
 

--- a/src/Famix-PharoSmalltalk-Entities/FamixStAnnotationInstanceAttribute.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStAnnotationInstanceAttribute.class.st
@@ -18,7 +18,7 @@
 
 | Name | Type | Default value | Comment |
 |---|
-| `value` | `String` | nil | Actual value of the attribute used in an annotation|
+| `value` | `Object` | nil | Actual value of the attribute used in an annotation|
 
 "
 Class {

--- a/src/Famix-Traits/FamixTAnnotationInstanceAttribute.trait.st
+++ b/src/Famix-Traits/FamixTAnnotationInstanceAttribute.trait.st
@@ -28,7 +28,7 @@ Instance Variables:
 
 | Name | Type | Default value | Comment |
 |---|
-| `value` | `String` | nil | Actual value of the attribute used in an annotation|
+| `value` | `Object` | nil | Actual value of the attribute used in an annotation|
 
 "
 Trait {
@@ -89,7 +89,7 @@ FamixTAnnotationInstanceAttribute >> parentAnnotationInstance: anObject [
 { #category : 'accessing' }
 FamixTAnnotationInstanceAttribute >> value [
 
-	<FMProperty: #value type: #String>
+	<FMProperty: #value type: #Object>
 	<generated>
 	<FMComment: 'Actual value of the attribute used in an annotation'>
 	^ value


### PR DESCRIPTION
fix:  bug when trying to export a literal array as an argument to a TAnnotationInstanceAttribute