### PR TITLE
Update manual navigation methods

### DIFF
--- a/src/Famix-Deprecated/FamixGlobalVariableGroup.extension.st
+++ b/src/Famix-Deprecated/FamixGlobalVariableGroup.extension.st
@@ -1,0 +1,19 @@
+Extension { #name : 'FamixGlobalVariableGroup' }
+
+{ #category : '*Famix-Deprecated' }
+FamixGlobalVariableGroup >> variableUnusedGroup [
+
+	self deprecated:
+		'This method was used in old Moose interfaces but is not used anymore and is probably dead code. If you use it, contact the Moose team to ask the removal of the deprecation.'.
+
+	^ self class withAll: self variableUnused
+]
+
+{ #category : '*Famix-Deprecated' }
+FamixGlobalVariableGroup >> variablesAccessedFromDifferentPackagesGroup [
+	"Variables accessed from more than one package"
+
+	self deprecated:
+		'This method was used in old Moose interfaces but is not used anymore and is probably dead code. If you use it, contact the Moose team to ask the removal of the deprecation.'.
+	^ self class withAll: self variablesAccessedFromDifferentPackages
+]

--- a/src/Famix-Deprecated/FamixTFile.extension.st
+++ b/src/Famix-Deprecated/FamixTFile.extension.st
@@ -1,6 +1,15 @@
 Extension { #name : 'FamixTFile' }
 
 { #category : '*Famix-Deprecated' }
+FamixTFile >> entitiesGroup [
+
+	self deprecated:
+		'This method was used in old Moose interfaces but is not used anymore and is probably dead code. If you use it, contact the Moose team to ask the removal of the deprecation.'.
+
+	^ MooseGroup withAll: self entities withDescription: 'Entities defined in a file'
+]
+
+{ #category : '*Famix-Deprecated' }
 FamixTFile >> parentFolderGroup [
 	self deprecated: 'Use #asMooseSpecializedGroup instead.' transformWith: '`@rcv parentFolderGroup' -> '`@rcv parentFolder asMooseSpecializedGroup'.
 	^ self parentFolder asMooseSpecializedGroup

--- a/src/Famix-Deprecated/FamixTFolder.extension.st
+++ b/src/Famix-Deprecated/FamixTFolder.extension.st
@@ -7,6 +7,24 @@ FamixTFolder >> childrenFileSystemEntitiesGroup [
 ]
 
 { #category : '*Famix-Deprecated' }
+FamixTFolder >> filesGroup [
+
+	self deprecated:
+		'This method was used in old Moose interfaces but is not used anymore and is probably dead code. If you use it, contact the Moose team to ask the removal of the deprecation.'.
+
+	^ FamixFileGroup withAll: self files withDescription: 'Files'
+]
+
+{ #category : '*Famix-Deprecated' }
+FamixTFolder >> foldersGroup [
+
+	self deprecated:
+		'This method was used in old Moose interfaces but is not used anymore and is probably dead code. If you use it, contact the Moose team to ask the removal of the deprecation.'.
+
+	^ FamixFolderGroup withAll: self folders withDescription: 'Folders'
+]
+
+{ #category : '*Famix-Deprecated' }
 FamixTFolder >> parentFolderGroup [
 	self deprecated: 'Use #asMooseSpecializedGroup instead.' transformWith: '`@rcv parentFolderGroup' -> '`@rcv parentFolder asMooseSpecializedGroup'.
 	^ self parentFolder asMooseSpecializedGroup

--- a/src/Famix-Deprecated/FamixTWithInheritances.extension.st
+++ b/src/Famix-Deprecated/FamixTWithInheritances.extension.st
@@ -1,0 +1,10 @@
+Extension { #name : 'FamixTWithInheritances' }
+
+{ #category : '*Famix-Deprecated' }
+FamixTWithInheritances >> withSuperclassHierarchyGroup [
+
+	self deprecated:
+		'This method was used in old Moose interfaces but is not used anymore and is probably dead code. If you use it, contact the Moose team to ask the removal of the deprecation.'.
+
+	^ MooseGroup withAll: self withSuperclassHierarchy asSet withDescription: 'With all superclasses of ' , self mooseName
+]

--- a/src/Famix-Deprecated/FamixTWithInvocations.extension.st
+++ b/src/Famix-Deprecated/FamixTWithInvocations.extension.st
@@ -1,0 +1,12 @@
+Extension { #name : 'FamixTWithInvocations' }
+
+{ #category : '*Famix-Deprecated' }
+FamixTWithInvocations >> outgoingInvocationsGroup [
+
+	self deprecated:
+		'This method was used in old Moose interfaces but is not used anymore and is probably dead code. If you use it, contact the Moose team to ask the removal of the deprecation.'.
+
+	^ self
+		  cacheAt: #outgoingInvocationsGroup
+		  ifAbsentPut: [ MooseGroup withAll: self outgoingInvocations withDescription: 'Outgoing invocations from ' , self mooseName ]
+]

--- a/src/Famix-Deprecated/FamixTWithMethods.extension.st
+++ b/src/Famix-Deprecated/FamixTWithMethods.extension.st
@@ -1,0 +1,10 @@
+Extension { #name : 'FamixTWithMethods' }
+
+{ #category : '*Famix-Deprecated' }
+FamixTWithMethods >> methodsGroup [
+
+	self deprecated:
+		'This method was used in old Moose interfaces but is not used anymore and is probably dead code. If you use it, contact the Moose team to ask the removal of the deprecation.'.
+
+	^ MooseGroup withAll: self methods withDescription: 'Methods from ' , self mooseName
+]

--- a/src/Famix-Java-Entities/FamixJavaTWithInterfaces.trait.st
+++ b/src/Famix-Java-Entities/FamixJavaTWithInterfaces.trait.st
@@ -33,10 +33,7 @@ FamixJavaTWithInterfaces classSide >> annotation [
 FamixJavaTWithInterfaces >> containedInterfaces [
 	"Classes are usually seen as types from the point of view of a Container. However, there may other types (e.g. aspects) which we dont want to see as classes and are rejected by this method."
 
-	<navigation: 'Contained Interfaces'>
-	^ self
-		  cacheAt: #containedInterfaces 
-		  ifAbsentPut: [ self types select: #isInterface ]
+	^ self cacheAt: #containedInterfaces ifAbsentPut: [ self types select: #isInterface ]
 ]
 
 { #category : 'accessing' }

--- a/src/Famix-Java-Entities/FamixJavaType.class.st
+++ b/src/Famix-Java-Entities/FamixJavaType.class.st
@@ -173,11 +173,3 @@ FamixJavaType >> printOn: aStream [
 		nextPutAll: (self class name withoutPrefix: 'FamixJava');
 		nextPut: $)
 ]
-
-{ #category : 'Famix-Implementation' }
-FamixJavaType >> withSuperclassHierarchyGroup [
-	<navigation: 'With all superclasses'>
-	^ MooseGroup
-		withAll: self withSuperclassHierarchy asSet
-		withDescription: 'With all superclasses of ' , self mooseName
-]

--- a/src/Famix-PharoSmalltalk-Entities/FamixStClass.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStClass.class.st
@@ -184,7 +184,7 @@ FamixStClass >> numberOfMessageSends [
 	<FMProperty: #numberOfMessageSends type: #Number>
 	<derived>
 	<FMComment: 'The number of message sends from a class'>
-	^ self cacheAt: #numberOfMessageSends ifAbsent: [ self methodsGroup sumNumbers: #numberOfMessageSends ]
+	^ self cacheAt: #numberOfMessageSends ifAbsent: [ self methods sumNumbers: #numberOfMessageSends ]
 ]
 
 { #category : 'as yet unclassified' }

--- a/src/Famix-PharoSmalltalk-Entities/FamixStPackage.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStPackage.class.st
@@ -96,11 +96,8 @@ FamixStPackage >> localClasses [
 
 { #category : 'accessing' }
 FamixStPackage >> localClassesGroup [
-	<navigation: 'Local classes'>
 
-	^ FamixClassGroup 
-		withAll: self localClasses
-		withDescription: 'Local classes'
+	^ FamixClassGroup withAll: self localClasses withDescription: 'Local classes'
 ]
 
 { #category : 'accessing' }

--- a/src/Famix-Test1-Tests/FamixWithMethodsTest.class.st
+++ b/src/Famix-Test1-Tests/FamixWithMethodsTest.class.st
@@ -41,16 +41,6 @@ FamixWithMethodsTest >> testMethods [
 ]
 
 { #category : 'tests' }
-FamixWithMethodsTest >> testMethodsGroup [
-
-	| group |
-	group := c1 methodsGroup.
-	self assertCollection: group entities hasSameElements: {
-			m1.
-			constructor }
-]
-
-{ #category : 'tests' }
 FamixWithMethodsTest >> testNumberOfLinesOfCode [
 
 	self assert: c1 numberOfLinesOfCode equals: 2.

--- a/src/Famix-Traits/FamixGlobalVariableGroup.class.st
+++ b/src/Famix-Traits/FamixGlobalVariableGroup.class.st
@@ -14,24 +14,12 @@ FamixGlobalVariableGroup >> variableNamed: aVarName [
 
 { #category : 'accessing' }
 FamixGlobalVariableGroup >> variableUnused [
-	^ self select: [:var | var incomingAccesses size = 0 ]
-]
 
-{ #category : 'navigation' }
-FamixGlobalVariableGroup >> variableUnusedGroup [
-	<navigation: 'Variable unsued'>
-	^ self class withAll: self variableUnused  
+	^ self select: [ :var | var incomingAccesses isEmpty ]
 ]
 
 { #category : 'accessing' }
 FamixGlobalVariableGroup >> variablesAccessedFromDifferentPackages [
-	^ self select: [:var | 
-		((var incomingAccesses collect: #accessor)
-			collect: #parentScope) asSet size > 1]
-]
 
-{ #category : 'navigation' }
-FamixGlobalVariableGroup >> variablesAccessedFromDifferentPackagesGroup [
-	<navigation: 'Variables accessed from more than one package'>
-	^ self class withAll: self variablesAccessedFromDifferentPackages  
+	^ self select: [ :var | ((var incomingAccesses collect: #accessor) collect: #parentScope) asSet size > 1 ]
 ]

--- a/src/Famix-Traits/FamixTFile.trait.st
+++ b/src/Famix-Traits/FamixTFile.trait.st
@@ -84,13 +84,6 @@ FamixTFile >> entities: anObject [
 	entities value: anObject
 ]
 
-{ #category : 'accessing' }
-FamixTFile >> entitiesGroup [
-	<navigation: 'Entities'>
-	
-	^ MooseGroup withAll: self entities withDescription: 'Entities defined in a file'
-]
-
 { #category : 'testing' }
 FamixTFile >> exists [
 	^ self fileExists 

--- a/src/Famix-Traits/FamixTFolder.trait.st
+++ b/src/Famix-Traits/FamixTFolder.trait.st
@@ -100,20 +100,8 @@ FamixTFolder >> files [
 ]
 
 { #category : 'adding' }
-FamixTFolder >> filesGroup [
-	<navigation: 'Files'>
-	^FamixFileGroup withAll: self files withDescription: 'Files'
-]
-
-{ #category : 'adding' }
 FamixTFolder >> folders [
 	^ self childrenFileSystemEntities select: #isFolder
-]
-
-{ #category : 'adding' }
-FamixTFolder >> foldersGroup [
-	<navigation: 'Folders'>
-	^FamixFolderGroup withAll: self folders withDescription: 'Folders'
 ]
 
 { #category : 'testing' }

--- a/src/Famix-Traits/FamixTWithClasses.trait.st
+++ b/src/Famix-Traits/FamixTWithClasses.trait.st
@@ -29,9 +29,12 @@ FamixTWithClasses classSide >> annotation [
 
 { #category : 'accessing' }
 FamixTWithClasses >> classes [
-	"Classes are usually seen as types from the point of view of a Container. However, there may other types (e.g. aspects) which we dont want to see as classes and are rejected by this method."
 
-	<navigation: 'Classes'>
+	<FMProperty: #classes type: #FamixTClass>
+	<FMComment:
+	'Classes are usually seen as types from the point of view of a Container. However, there may other types (e.g. aspects) which we dont want to see as classes and are rejected by this method.'>
+	<derived>
+	<multivalued>
 	^ self cacheAt: #classes ifAbsentPut: [ self types select: #isClass ]
 ]
 

--- a/src/Famix-Traits/FamixTWithInheritances.trait.st
+++ b/src/Famix-Traits/FamixTWithInheritances.trait.st
@@ -183,7 +183,7 @@ FamixTWithInheritances >> subclassHierarchyDepth: aNumber [
 
 { #category : 'enumerating' }
 FamixTWithInheritances >> subclassHierarchyGroup [
-	<navigation: 'All subclasses'>
+
 	^ MooseGroup withAll: self subclassHierarchy asSet withDescription: 'All subclasses of ' , self mooseName
 ]
 
@@ -219,10 +219,8 @@ FamixTWithInheritances >> superclassHierarchy [
 
 { #category : 'enumerating' }
 FamixTWithInheritances >> superclassHierarchyGroup [
-	<navigation: 'All superclasses'>
-	^ MooseGroup
-		withAll: self superclassHierarchy asSet
-		withDescription: 'All superclasses of ' , self mooseName
+
+	^ MooseGroup withAll: self superclassHierarchy asSet withDescription: 'All superclasses of ' , self mooseName
 ]
 
 { #category : 'Famix-Implementation' }

--- a/src/Famix-Traits/FamixTWithInvocations.trait.st
+++ b/src/Famix-Traits/FamixTWithInvocations.trait.st
@@ -58,14 +58,3 @@ FamixTWithInvocations >> outgoingInvocations: anObject [
 	<generated>
 	outgoingInvocations value: anObject
 ]
-
-{ #category : 'adding' }
-FamixTWithInvocations >> outgoingInvocationsGroup [
-	<navigation: 'Outgoing invocations'>
-	^ self cacheAt:
-		#outgoingInvocationsGroup
-		ifAbsentPut:
-			[MooseGroup
-				withAll: self outgoingInvocations
-				withDescription: 'Outgoing invocations from ' , self mooseName]
-]

--- a/src/Famix-Traits/FamixTWithMethods.trait.st
+++ b/src/Famix-Traits/FamixTWithMethods.trait.st
@@ -57,21 +57,13 @@ FamixTWithMethods >> methods: anObject [
 	methods value: anObject
 ]
 
-{ #category : 'accessing' }
-FamixTWithMethods >> methodsGroup [
-	<navigation: 'Methods'>
-	^MooseGroup
-		withAll: self methods
-		withDescription: 'Methods from ' , self mooseName
-]
-
 { #category : 'metrics' }
 FamixTWithMethods >> numberOfAbstractMethods [
 
 	<FMProperty: #numberOfAbstractMethods type: #Number>
 	<derived>
 	<FMComment: 'The number of abstract methods in the class'>
-	^ self cacheAt: #numberOfAbstractMethods ifAbsentPut: [ self methodsGroup count: [ :each | each isAbstract ] ]
+	^ self cacheAt: #numberOfAbstractMethods ifAbsentPut: [ self methods count: [ :each | each isAbstract ] ]
 ]
 
 { #category : 'metrics' }
@@ -138,7 +130,7 @@ FamixTWithMethods >> weightedMethodCount [
 	<FMProperty: #weightedMethodCount type: #Number>
 	<derived>
 	<FMComment: 'The sum of the complexity in a class'>
-	^ self cacheAt: #weightedMethodCount ifAbsent: [ self methodsGroup sumNumbers: #cyclomaticComplexity ]
+	^ self cacheAt: #weightedMethodCount ifAbsent: [ self methods sumNumbers: #cyclomaticComplexity ]
 ]
 
 { #category : 'metrics' }


### PR DESCRIPTION
This changes "groups" method added manually. For methods making sense, I removed the dead "navigation:" pragma. For other methods I deprecated them because they are either dead code, or just calling another method. Using #asMooseGroup is the same.

*done on my free time*