### PR TITLE
Add #ignoreForCoverage pragmas to generated methods

### DIFF
--- a/src/Famix-Java-Entities/FamixJavaAccess.class.st
+++ b/src/Famix-Java-Entities/FamixJavaAccess.class.st
@@ -41,6 +41,7 @@ Class {
 { #category : 'meta' }
 FamixJavaAccess class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Access super: #FamixJavaEntity>
 	<package: #'Famix-Java-Entities'>
 	<generated>

--- a/src/Famix-Java-Entities/FamixJavaAnnotationInstance.class.st
+++ b/src/Famix-Java-Entities/FamixJavaAnnotationInstance.class.st
@@ -29,6 +29,7 @@ Class {
 { #category : 'meta' }
 FamixJavaAnnotationInstance class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #AnnotationInstance super: #FamixJavaSourcedEntity>
 	<package: #'Famix-Java-Entities'>
 	<generated>

--- a/src/Famix-Java-Entities/FamixJavaAnnotationInstanceAttribute.class.st
+++ b/src/Famix-Java-Entities/FamixJavaAnnotationInstanceAttribute.class.st
@@ -34,6 +34,7 @@ Class {
 { #category : 'meta' }
 FamixJavaAnnotationInstanceAttribute class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #AnnotationInstanceAttribute super: #FamixJavaSourcedEntity>
 	<package: #'Famix-Java-Entities'>
 	<generated>

--- a/src/Famix-Java-Entities/FamixJavaAnnotationType.class.st
+++ b/src/Famix-Java-Entities/FamixJavaAnnotationType.class.st
@@ -53,6 +53,7 @@ Class {
 { #category : 'meta' }
 FamixJavaAnnotationType class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #AnnotationType super: #FamixJavaType>
 	<package: #'Famix-Java-Entities'>
 	<generated>

--- a/src/Famix-Java-Entities/FamixJavaAnnotationTypeAttribute.class.st
+++ b/src/Famix-Java-Entities/FamixJavaAnnotationTypeAttribute.class.st
@@ -51,6 +51,7 @@ Class {
 { #category : 'meta' }
 FamixJavaAnnotationTypeAttribute class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #AnnotationTypeAttribute super: #FamixJavaVariable>
 	<package: #'Famix-Java-Entities'>
 	<generated>

--- a/src/Famix-Java-Entities/FamixJavaAttribute.class.st
+++ b/src/Famix-Java-Entities/FamixJavaAttribute.class.st
@@ -55,6 +55,7 @@ Class {
 { #category : 'meta' }
 FamixJavaAttribute class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Attribute super: #FamixJavaVariable>
 	<package: #'Famix-Java-Entities'>
 	<generated>

--- a/src/Famix-Java-Entities/FamixJavaClass.class.st
+++ b/src/Famix-Java-Entities/FamixJavaClass.class.st
@@ -64,6 +64,7 @@ Class {
 { #category : 'meta' }
 FamixJavaClass class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Class super: #FamixJavaType>
 	<package: #'Famix-Java-Entities'>
 	<generated>

--- a/src/Famix-Java-Entities/FamixJavaComment.class.st
+++ b/src/Famix-Java-Entities/FamixJavaComment.class.st
@@ -28,6 +28,7 @@ Class {
 { #category : 'meta' }
 FamixJavaComment class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Comment super: #FamixJavaSourcedEntity>
 	<package: #'Famix-Java-Entities'>
 	<generated>

--- a/src/Famix-Java-Entities/FamixJavaConcretization.class.st
+++ b/src/Famix-Java-Entities/FamixJavaConcretization.class.st
@@ -36,6 +36,7 @@ Class {
 { #category : 'meta' }
 FamixJavaConcretization class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Concretization super: #FamixJavaEntity>
 	<package: #'Famix-Java-Entities'>
 	<generated>

--- a/src/Famix-Java-Entities/FamixJavaContainerEntity.class.st
+++ b/src/Famix-Java-Entities/FamixJavaContainerEntity.class.st
@@ -24,6 +24,7 @@ Class {
 { #category : 'meta' }
 FamixJavaContainerEntity class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #ContainerEntity super: #FamixJavaNamedEntity>
 	<package: #'Famix-Java-Entities'>
 	<generated>
@@ -33,6 +34,7 @@ FamixJavaContainerEntity class >> annotation [
 { #category : 'testing' }
 FamixJavaContainerEntity class >> isAbstract [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self == FamixJavaContainerEntity
 ]

--- a/src/Famix-Java-Entities/FamixJavaEntity.class.st
+++ b/src/Famix-Java-Entities/FamixJavaEntity.class.st
@@ -9,6 +9,7 @@ Class {
 { #category : 'meta' }
 FamixJavaEntity class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Entity super: #MooseEntity>
 	<package: #'Famix-Java-Entities'>
 	<generated>
@@ -18,6 +19,7 @@ FamixJavaEntity class >> annotation [
 { #category : 'testing' }
 FamixJavaEntity class >> isAbstract [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self == FamixJavaEntity
 ]
@@ -25,6 +27,7 @@ FamixJavaEntity class >> isAbstract [
 { #category : 'meta' }
 FamixJavaEntity class >> metamodel [
 
+	<ignoreForCoverage>
 	<generated>
 	^ FamixJavaModel metamodel
 ]
@@ -32,6 +35,7 @@ FamixJavaEntity class >> metamodel [
 { #category : 'testing' }
 FamixJavaEntity >> canBeStub [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -39,6 +43,7 @@ FamixJavaEntity >> canBeStub [
 { #category : 'testing' }
 FamixJavaEntity >> hasImmediateSource [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -46,6 +51,7 @@ FamixJavaEntity >> hasImmediateSource [
 { #category : 'testing' }
 FamixJavaEntity >> isAccess [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -53,6 +59,7 @@ FamixJavaEntity >> isAccess [
 { #category : 'testing' }
 FamixJavaEntity >> isAssociation [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -60,6 +67,7 @@ FamixJavaEntity >> isAssociation [
 { #category : 'testing' }
 FamixJavaEntity >> isAttribute [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -67,6 +75,7 @@ FamixJavaEntity >> isAttribute [
 { #category : 'testing' }
 FamixJavaEntity >> isBehavioural [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -74,6 +83,7 @@ FamixJavaEntity >> isBehavioural [
 { #category : 'testing' }
 FamixJavaEntity >> isClass [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -81,6 +91,7 @@ FamixJavaEntity >> isClass [
 { #category : 'testing' }
 FamixJavaEntity >> isComment [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -88,6 +99,7 @@ FamixJavaEntity >> isComment [
 { #category : 'testing' }
 FamixJavaEntity >> isEnumValue [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -95,6 +107,7 @@ FamixJavaEntity >> isEnumValue [
 { #category : 'testing' }
 FamixJavaEntity >> isException [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -102,6 +115,7 @@ FamixJavaEntity >> isException [
 { #category : 'testing' }
 FamixJavaEntity >> isFileAnchor [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -109,6 +123,7 @@ FamixJavaEntity >> isFileAnchor [
 { #category : 'testing' }
 FamixJavaEntity >> isImplicitVariable [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -116,6 +131,7 @@ FamixJavaEntity >> isImplicitVariable [
 { #category : 'testing' }
 FamixJavaEntity >> isInheritance [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -123,6 +139,7 @@ FamixJavaEntity >> isInheritance [
 { #category : 'testing' }
 FamixJavaEntity >> isInterface [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -130,6 +147,7 @@ FamixJavaEntity >> isInterface [
 { #category : 'testing' }
 FamixJavaEntity >> isInvocation [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -137,6 +155,7 @@ FamixJavaEntity >> isInvocation [
 { #category : 'testing' }
 FamixJavaEntity >> isLocalVariable [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -144,6 +163,7 @@ FamixJavaEntity >> isLocalVariable [
 { #category : 'testing' }
 FamixJavaEntity >> isMethod [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -151,6 +171,7 @@ FamixJavaEntity >> isMethod [
 { #category : 'testing' }
 FamixJavaEntity >> isNamedEntity [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -158,6 +179,7 @@ FamixJavaEntity >> isNamedEntity [
 { #category : 'testing' }
 FamixJavaEntity >> isPackage [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -165,6 +187,7 @@ FamixJavaEntity >> isPackage [
 { #category : 'testing' }
 FamixJavaEntity >> isParametricAssociation [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -172,6 +195,7 @@ FamixJavaEntity >> isParametricAssociation [
 { #category : 'testing' }
 FamixJavaEntity >> isParametricEntity [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -179,6 +203,7 @@ FamixJavaEntity >> isParametricEntity [
 { #category : 'testing' }
 FamixJavaEntity >> isPrimitiveType [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -186,6 +211,7 @@ FamixJavaEntity >> isPrimitiveType [
 { #category : 'testing' }
 FamixJavaEntity >> isQueryable [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -193,6 +219,7 @@ FamixJavaEntity >> isQueryable [
 { #category : 'testing' }
 FamixJavaEntity >> isReference [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -200,6 +227,7 @@ FamixJavaEntity >> isReference [
 { #category : 'testing' }
 FamixJavaEntity >> isStructuralEntity [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -207,6 +235,7 @@ FamixJavaEntity >> isStructuralEntity [
 { #category : 'testing' }
 FamixJavaEntity >> isType [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]

--- a/src/Famix-Java-Entities/FamixJavaEntityTyping.class.st
+++ b/src/Famix-Java-Entities/FamixJavaEntityTyping.class.st
@@ -35,6 +35,7 @@ Class {
 { #category : 'meta' }
 FamixJavaEntityTyping class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #EntityTyping super: #FamixJavaEntity>
 	<package: #'Famix-Java-Entities'>
 	<generated>

--- a/src/Famix-Java-Entities/FamixJavaEnum.class.st
+++ b/src/Famix-Java-Entities/FamixJavaEnum.class.st
@@ -60,6 +60,7 @@ Class {
 { #category : 'meta' }
 FamixJavaEnum class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Enum super: #FamixJavaType>
 	<package: #'Famix-Java-Entities'>
 	<generated>

--- a/src/Famix-Java-Entities/FamixJavaEnumValue.class.st
+++ b/src/Famix-Java-Entities/FamixJavaEnumValue.class.st
@@ -50,6 +50,7 @@ Class {
 { #category : 'meta' }
 FamixJavaEnumValue class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #EnumValue super: #FamixJavaVariable>
 	<package: #'Famix-Java-Entities'>
 	<generated>

--- a/src/Famix-Java-Entities/FamixJavaException.class.st
+++ b/src/Famix-Java-Entities/FamixJavaException.class.st
@@ -58,6 +58,7 @@ Class {
 { #category : 'meta' }
 FamixJavaException class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Exception super: #FamixJavaClass>
 	<package: #'Famix-Java-Entities'>
 	<generated>

--- a/src/Famix-Java-Entities/FamixJavaImplementation.class.st
+++ b/src/Famix-Java-Entities/FamixJavaImplementation.class.st
@@ -35,6 +35,7 @@ Class {
 { #category : 'meta' }
 FamixJavaImplementation class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Implementation super: #FamixJavaEntity>
 	<package: #'Famix-Java-Entities'>
 	<generated>

--- a/src/Famix-Java-Entities/FamixJavaImplicitVariable.class.st
+++ b/src/Famix-Java-Entities/FamixJavaImplicitVariable.class.st
@@ -45,6 +45,7 @@ Class {
 { #category : 'meta' }
 FamixJavaImplicitVariable class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #ImplicitVariable super: #FamixJavaVariable>
 	<package: #'Famix-Java-Entities'>
 	<generated>

--- a/src/Famix-Java-Entities/FamixJavaImport.class.st
+++ b/src/Famix-Java-Entities/FamixJavaImport.class.st
@@ -35,6 +35,7 @@ Class {
 { #category : 'meta' }
 FamixJavaImport class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Import super: #FamixJavaEntity>
 	<package: #'Famix-Java-Entities'>
 	<generated>

--- a/src/Famix-Java-Entities/FamixJavaImportingContext.class.st
+++ b/src/Famix-Java-Entities/FamixJavaImportingContext.class.st
@@ -15,6 +15,7 @@ Class {
 { #category : 'accessing' }
 FamixJavaImportingContext class >> importedMetamodel [
 
+	<ignoreForCoverage>
 	<generated>
 	^ FamixJavaModel metamodel
 ]
@@ -22,6 +23,7 @@ FamixJavaImportingContext class >> importedMetamodel [
 { #category : 'importing' }
 FamixJavaImportingContext >> importAccess [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self importAssociation: (self class fm3ClassNamed: #Access)
 ]
@@ -29,6 +31,7 @@ FamixJavaImportingContext >> importAccess [
 { #category : 'importing' }
 FamixJavaImportingContext >> importAnnotationInstance [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self importConcreteEntity: (self class fm3ClassNamed: #AnnotationInstance)
 ]
@@ -36,6 +39,7 @@ FamixJavaImportingContext >> importAnnotationInstance [
 { #category : 'importing' }
 FamixJavaImportingContext >> importAnnotationInstanceAttribute [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self importConcreteEntity: (self class fm3ClassNamed: #AnnotationInstanceAttribute)
 ]
@@ -43,6 +47,7 @@ FamixJavaImportingContext >> importAnnotationInstanceAttribute [
 { #category : 'importing' }
 FamixJavaImportingContext >> importAnnotationType [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self importConcreteEntity: (self class fm3ClassNamed: #AnnotationType)
 ]
@@ -50,6 +55,7 @@ FamixJavaImportingContext >> importAnnotationType [
 { #category : 'importing' }
 FamixJavaImportingContext >> importAnnotationTypeAttribute [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self importConcreteEntity: (self class fm3ClassNamed: #AnnotationTypeAttribute)
 ]
@@ -57,6 +63,7 @@ FamixJavaImportingContext >> importAnnotationTypeAttribute [
 { #category : 'importing' }
 FamixJavaImportingContext >> importAttribute [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self importConcreteEntity: (self class fm3ClassNamed: #Attribute)
 ]
@@ -64,6 +71,7 @@ FamixJavaImportingContext >> importAttribute [
 { #category : 'importing' }
 FamixJavaImportingContext >> importClass [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self importConcreteEntity: (self class fm3ClassNamed: #Class)
 ]
@@ -71,6 +79,7 @@ FamixJavaImportingContext >> importClass [
 { #category : 'importing' }
 FamixJavaImportingContext >> importComment [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self importConcreteEntity: (self class fm3ClassNamed: #Comment)
 ]
@@ -78,6 +87,7 @@ FamixJavaImportingContext >> importComment [
 { #category : 'importing' }
 FamixJavaImportingContext >> importConcretization [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self importAssociation: (self class fm3ClassNamed: #Concretization)
 ]
@@ -85,6 +95,7 @@ FamixJavaImportingContext >> importConcretization [
 { #category : 'importing' }
 FamixJavaImportingContext >> importEntityTyping [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self importAssociation: (self class fm3ClassNamed: #EntityTyping)
 ]
@@ -92,6 +103,7 @@ FamixJavaImportingContext >> importEntityTyping [
 { #category : 'importing' }
 FamixJavaImportingContext >> importEnum [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self importConcreteEntity: (self class fm3ClassNamed: #Enum)
 ]
@@ -99,6 +111,7 @@ FamixJavaImportingContext >> importEnum [
 { #category : 'importing' }
 FamixJavaImportingContext >> importEnumValue [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self importConcreteEntity: (self class fm3ClassNamed: #EnumValue)
 ]
@@ -106,6 +119,7 @@ FamixJavaImportingContext >> importEnumValue [
 { #category : 'importing' }
 FamixJavaImportingContext >> importException [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self importConcreteEntity: (self class fm3ClassNamed: #Exception)
 ]
@@ -113,6 +127,7 @@ FamixJavaImportingContext >> importException [
 { #category : 'importing' }
 FamixJavaImportingContext >> importImplementation [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self importAssociation: (self class fm3ClassNamed: #Implementation)
 ]
@@ -120,6 +135,7 @@ FamixJavaImportingContext >> importImplementation [
 { #category : 'importing' }
 FamixJavaImportingContext >> importImplicitVariable [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self importConcreteEntity: (self class fm3ClassNamed: #ImplicitVariable)
 ]
@@ -127,6 +143,7 @@ FamixJavaImportingContext >> importImplicitVariable [
 { #category : 'importing' }
 FamixJavaImportingContext >> importImport [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self importAssociation: (self class fm3ClassNamed: #Import)
 ]
@@ -134,6 +151,7 @@ FamixJavaImportingContext >> importImport [
 { #category : 'importing' }
 FamixJavaImportingContext >> importIndexedFileAnchor [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self importConcreteEntity: (self class fm3ClassNamed: #IndexedFileAnchor)
 ]
@@ -141,6 +159,7 @@ FamixJavaImportingContext >> importIndexedFileAnchor [
 { #category : 'importing' }
 FamixJavaImportingContext >> importInheritance [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self importAssociation: (self class fm3ClassNamed: #Inheritance)
 ]
@@ -148,6 +167,7 @@ FamixJavaImportingContext >> importInheritance [
 { #category : 'importing' }
 FamixJavaImportingContext >> importInitializer [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self importConcreteEntity: (self class fm3ClassNamed: #Initializer)
 ]
@@ -155,6 +175,7 @@ FamixJavaImportingContext >> importInitializer [
 { #category : 'importing' }
 FamixJavaImportingContext >> importInterface [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self importConcreteEntity: (self class fm3ClassNamed: #Interface)
 ]
@@ -162,6 +183,7 @@ FamixJavaImportingContext >> importInterface [
 { #category : 'importing' }
 FamixJavaImportingContext >> importInvocation [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self importAssociation: (self class fm3ClassNamed: #Invocation)
 ]
@@ -169,6 +191,7 @@ FamixJavaImportingContext >> importInvocation [
 { #category : 'importing' }
 FamixJavaImportingContext >> importLocalVariable [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self importConcreteEntity: (self class fm3ClassNamed: #LocalVariable)
 ]
@@ -176,6 +199,7 @@ FamixJavaImportingContext >> importLocalVariable [
 { #category : 'importing' }
 FamixJavaImportingContext >> importMethod [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self importConcreteEntity: (self class fm3ClassNamed: #Method)
 ]
@@ -183,6 +207,7 @@ FamixJavaImportingContext >> importMethod [
 { #category : 'importing' }
 FamixJavaImportingContext >> importPackage [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self importConcreteEntity: (self class fm3ClassNamed: #Package)
 ]
@@ -190,6 +215,7 @@ FamixJavaImportingContext >> importPackage [
 { #category : 'importing' }
 FamixJavaImportingContext >> importParameter [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self importConcreteEntity: (self class fm3ClassNamed: #Parameter)
 ]
@@ -197,6 +223,7 @@ FamixJavaImportingContext >> importParameter [
 { #category : 'importing' }
 FamixJavaImportingContext >> importParametricClass [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self importConcreteEntity: (self class fm3ClassNamed: #ParametricClass)
 ]
@@ -204,6 +231,7 @@ FamixJavaImportingContext >> importParametricClass [
 { #category : 'importing' }
 FamixJavaImportingContext >> importParametricEntityTyping [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self importConcreteEntity: (self class fm3ClassNamed: #ParametricEntityTyping)
 ]
@@ -211,6 +239,7 @@ FamixJavaImportingContext >> importParametricEntityTyping [
 { #category : 'importing' }
 FamixJavaImportingContext >> importParametricImplementation [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self importConcreteEntity: (self class fm3ClassNamed: #ParametricImplementation)
 ]
@@ -218,6 +247,7 @@ FamixJavaImportingContext >> importParametricImplementation [
 { #category : 'importing' }
 FamixJavaImportingContext >> importParametricInheritance [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self importConcreteEntity: (self class fm3ClassNamed: #ParametricInheritance)
 ]
@@ -225,6 +255,7 @@ FamixJavaImportingContext >> importParametricInheritance [
 { #category : 'importing' }
 FamixJavaImportingContext >> importParametricInterface [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self importConcreteEntity: (self class fm3ClassNamed: #ParametricInterface)
 ]
@@ -232,6 +263,7 @@ FamixJavaImportingContext >> importParametricInterface [
 { #category : 'importing' }
 FamixJavaImportingContext >> importParametricInvocation [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self importConcreteEntity: (self class fm3ClassNamed: #ParametricInvocation)
 ]
@@ -239,6 +271,7 @@ FamixJavaImportingContext >> importParametricInvocation [
 { #category : 'importing' }
 FamixJavaImportingContext >> importParametricMethod [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self importConcreteEntity: (self class fm3ClassNamed: #ParametricMethod)
 ]
@@ -246,6 +279,7 @@ FamixJavaImportingContext >> importParametricMethod [
 { #category : 'importing' }
 FamixJavaImportingContext >> importParametricReference [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self importConcreteEntity: (self class fm3ClassNamed: #ParametricReference)
 ]
@@ -253,6 +287,7 @@ FamixJavaImportingContext >> importParametricReference [
 { #category : 'importing' }
 FamixJavaImportingContext >> importPrimitiveType [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self importConcreteEntity: (self class fm3ClassNamed: #PrimitiveType)
 ]
@@ -260,6 +295,7 @@ FamixJavaImportingContext >> importPrimitiveType [
 { #category : 'importing' }
 FamixJavaImportingContext >> importReference [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self importAssociation: (self class fm3ClassNamed: #Reference)
 ]
@@ -267,6 +303,7 @@ FamixJavaImportingContext >> importReference [
 { #category : 'importing' }
 FamixJavaImportingContext >> importSourceLanguage [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self importConcreteEntity: (self class fm3ClassNamed: #SourceLanguage)
 ]
@@ -274,6 +311,7 @@ FamixJavaImportingContext >> importSourceLanguage [
 { #category : 'importing' }
 FamixJavaImportingContext >> importSourceTextAnchor [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self importConcreteEntity: (self class fm3ClassNamed: #SourceTextAnchor)
 ]
@@ -281,6 +319,7 @@ FamixJavaImportingContext >> importSourceTextAnchor [
 { #category : 'importing' }
 FamixJavaImportingContext >> importType [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self importConcreteEntity: (self class fm3ClassNamed: #Type)
 ]
@@ -288,6 +327,7 @@ FamixJavaImportingContext >> importType [
 { #category : 'importing' }
 FamixJavaImportingContext >> importTypeParameter [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self importConcreteEntity: (self class fm3ClassNamed: #TypeParameter)
 ]
@@ -295,6 +335,7 @@ FamixJavaImportingContext >> importTypeParameter [
 { #category : 'importing' }
 FamixJavaImportingContext >> importUnknownVariable [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self importConcreteEntity: (self class fm3ClassNamed: #UnknownVariable)
 ]
@@ -302,6 +343,7 @@ FamixJavaImportingContext >> importUnknownVariable [
 { #category : 'importing' }
 FamixJavaImportingContext >> importWildcard [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self importConcreteEntity: (self class fm3ClassNamed: #Wildcard)
 ]
@@ -309,6 +351,7 @@ FamixJavaImportingContext >> importWildcard [
 { #category : 'testing' }
 FamixJavaImportingContext >> shouldImportAccess [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self shouldImport: #Access
 ]
@@ -316,6 +359,7 @@ FamixJavaImportingContext >> shouldImportAccess [
 { #category : 'testing' }
 FamixJavaImportingContext >> shouldImportAnnotationInstance [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self shouldImport: #AnnotationInstance
 ]
@@ -323,6 +367,7 @@ FamixJavaImportingContext >> shouldImportAnnotationInstance [
 { #category : 'testing' }
 FamixJavaImportingContext >> shouldImportAnnotationInstanceAttribute [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self shouldImport: #AnnotationInstanceAttribute
 ]
@@ -330,6 +375,7 @@ FamixJavaImportingContext >> shouldImportAnnotationInstanceAttribute [
 { #category : 'testing' }
 FamixJavaImportingContext >> shouldImportAnnotationType [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self shouldImport: #AnnotationType
 ]
@@ -337,6 +383,7 @@ FamixJavaImportingContext >> shouldImportAnnotationType [
 { #category : 'testing' }
 FamixJavaImportingContext >> shouldImportAnnotationTypeAttribute [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self shouldImport: #AnnotationTypeAttribute
 ]
@@ -344,6 +391,7 @@ FamixJavaImportingContext >> shouldImportAnnotationTypeAttribute [
 { #category : 'testing' }
 FamixJavaImportingContext >> shouldImportAttribute [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self shouldImport: #Attribute
 ]
@@ -351,6 +399,7 @@ FamixJavaImportingContext >> shouldImportAttribute [
 { #category : 'testing' }
 FamixJavaImportingContext >> shouldImportClass [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self shouldImport: #Class
 ]
@@ -358,6 +407,7 @@ FamixJavaImportingContext >> shouldImportClass [
 { #category : 'testing' }
 FamixJavaImportingContext >> shouldImportComment [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self shouldImport: #Comment
 ]
@@ -365,6 +415,7 @@ FamixJavaImportingContext >> shouldImportComment [
 { #category : 'testing' }
 FamixJavaImportingContext >> shouldImportConcretization [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self shouldImport: #Concretization
 ]
@@ -372,6 +423,7 @@ FamixJavaImportingContext >> shouldImportConcretization [
 { #category : 'testing' }
 FamixJavaImportingContext >> shouldImportEntityTyping [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self shouldImport: #EntityTyping
 ]
@@ -379,6 +431,7 @@ FamixJavaImportingContext >> shouldImportEntityTyping [
 { #category : 'testing' }
 FamixJavaImportingContext >> shouldImportEnum [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self shouldImport: #Enum
 ]
@@ -386,6 +439,7 @@ FamixJavaImportingContext >> shouldImportEnum [
 { #category : 'testing' }
 FamixJavaImportingContext >> shouldImportEnumValue [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self shouldImport: #EnumValue
 ]
@@ -393,6 +447,7 @@ FamixJavaImportingContext >> shouldImportEnumValue [
 { #category : 'testing' }
 FamixJavaImportingContext >> shouldImportException [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self shouldImport: #Exception
 ]
@@ -400,6 +455,7 @@ FamixJavaImportingContext >> shouldImportException [
 { #category : 'testing' }
 FamixJavaImportingContext >> shouldImportImplementation [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self shouldImport: #Implementation
 ]
@@ -407,6 +463,7 @@ FamixJavaImportingContext >> shouldImportImplementation [
 { #category : 'testing' }
 FamixJavaImportingContext >> shouldImportImplicitVariable [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self shouldImport: #ImplicitVariable
 ]
@@ -414,6 +471,7 @@ FamixJavaImportingContext >> shouldImportImplicitVariable [
 { #category : 'testing' }
 FamixJavaImportingContext >> shouldImportImport [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self shouldImport: #Import
 ]
@@ -421,6 +479,7 @@ FamixJavaImportingContext >> shouldImportImport [
 { #category : 'testing' }
 FamixJavaImportingContext >> shouldImportIndexedFileAnchor [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self shouldImport: #IndexedFileAnchor
 ]
@@ -428,6 +487,7 @@ FamixJavaImportingContext >> shouldImportIndexedFileAnchor [
 { #category : 'testing' }
 FamixJavaImportingContext >> shouldImportInheritance [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self shouldImport: #Inheritance
 ]
@@ -435,6 +495,7 @@ FamixJavaImportingContext >> shouldImportInheritance [
 { #category : 'testing' }
 FamixJavaImportingContext >> shouldImportInitializer [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self shouldImport: #Initializer
 ]
@@ -442,6 +503,7 @@ FamixJavaImportingContext >> shouldImportInitializer [
 { #category : 'testing' }
 FamixJavaImportingContext >> shouldImportInterface [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self shouldImport: #Interface
 ]
@@ -449,6 +511,7 @@ FamixJavaImportingContext >> shouldImportInterface [
 { #category : 'testing' }
 FamixJavaImportingContext >> shouldImportInvocation [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self shouldImport: #Invocation
 ]
@@ -456,6 +519,7 @@ FamixJavaImportingContext >> shouldImportInvocation [
 { #category : 'testing' }
 FamixJavaImportingContext >> shouldImportLocalVariable [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self shouldImport: #LocalVariable
 ]
@@ -463,6 +527,7 @@ FamixJavaImportingContext >> shouldImportLocalVariable [
 { #category : 'testing' }
 FamixJavaImportingContext >> shouldImportMethod [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self shouldImport: #Method
 ]
@@ -470,6 +535,7 @@ FamixJavaImportingContext >> shouldImportMethod [
 { #category : 'testing' }
 FamixJavaImportingContext >> shouldImportPackage [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self shouldImport: #Package
 ]
@@ -477,6 +543,7 @@ FamixJavaImportingContext >> shouldImportPackage [
 { #category : 'testing' }
 FamixJavaImportingContext >> shouldImportParameter [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self shouldImport: #Parameter
 ]
@@ -484,6 +551,7 @@ FamixJavaImportingContext >> shouldImportParameter [
 { #category : 'testing' }
 FamixJavaImportingContext >> shouldImportParametricClass [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self shouldImport: #ParametricClass
 ]
@@ -491,6 +559,7 @@ FamixJavaImportingContext >> shouldImportParametricClass [
 { #category : 'testing' }
 FamixJavaImportingContext >> shouldImportParametricEntityTyping [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self shouldImport: #ParametricEntityTyping
 ]
@@ -498,6 +567,7 @@ FamixJavaImportingContext >> shouldImportParametricEntityTyping [
 { #category : 'testing' }
 FamixJavaImportingContext >> shouldImportParametricImplementation [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self shouldImport: #ParametricImplementation
 ]
@@ -505,6 +575,7 @@ FamixJavaImportingContext >> shouldImportParametricImplementation [
 { #category : 'testing' }
 FamixJavaImportingContext >> shouldImportParametricInheritance [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self shouldImport: #ParametricInheritance
 ]
@@ -512,6 +583,7 @@ FamixJavaImportingContext >> shouldImportParametricInheritance [
 { #category : 'testing' }
 FamixJavaImportingContext >> shouldImportParametricInterface [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self shouldImport: #ParametricInterface
 ]
@@ -519,6 +591,7 @@ FamixJavaImportingContext >> shouldImportParametricInterface [
 { #category : 'testing' }
 FamixJavaImportingContext >> shouldImportParametricInvocation [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self shouldImport: #ParametricInvocation
 ]
@@ -526,6 +599,7 @@ FamixJavaImportingContext >> shouldImportParametricInvocation [
 { #category : 'testing' }
 FamixJavaImportingContext >> shouldImportParametricMethod [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self shouldImport: #ParametricMethod
 ]
@@ -533,6 +607,7 @@ FamixJavaImportingContext >> shouldImportParametricMethod [
 { #category : 'testing' }
 FamixJavaImportingContext >> shouldImportParametricReference [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self shouldImport: #ParametricReference
 ]
@@ -540,6 +615,7 @@ FamixJavaImportingContext >> shouldImportParametricReference [
 { #category : 'testing' }
 FamixJavaImportingContext >> shouldImportPrimitiveType [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self shouldImport: #PrimitiveType
 ]
@@ -547,6 +623,7 @@ FamixJavaImportingContext >> shouldImportPrimitiveType [
 { #category : 'testing' }
 FamixJavaImportingContext >> shouldImportReference [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self shouldImport: #Reference
 ]
@@ -554,6 +631,7 @@ FamixJavaImportingContext >> shouldImportReference [
 { #category : 'testing' }
 FamixJavaImportingContext >> shouldImportSourceLanguage [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self shouldImport: #SourceLanguage
 ]
@@ -561,6 +639,7 @@ FamixJavaImportingContext >> shouldImportSourceLanguage [
 { #category : 'testing' }
 FamixJavaImportingContext >> shouldImportSourceTextAnchor [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self shouldImport: #SourceTextAnchor
 ]
@@ -568,6 +647,7 @@ FamixJavaImportingContext >> shouldImportSourceTextAnchor [
 { #category : 'testing' }
 FamixJavaImportingContext >> shouldImportType [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self shouldImport: #Type
 ]
@@ -575,6 +655,7 @@ FamixJavaImportingContext >> shouldImportType [
 { #category : 'testing' }
 FamixJavaImportingContext >> shouldImportTypeParameter [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self shouldImport: #TypeParameter
 ]
@@ -582,6 +663,7 @@ FamixJavaImportingContext >> shouldImportTypeParameter [
 { #category : 'testing' }
 FamixJavaImportingContext >> shouldImportUnknownVariable [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self shouldImport: #UnknownVariable
 ]
@@ -589,6 +671,7 @@ FamixJavaImportingContext >> shouldImportUnknownVariable [
 { #category : 'testing' }
 FamixJavaImportingContext >> shouldImportWildcard [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self shouldImport: #Wildcard
 ]

--- a/src/Famix-Java-Entities/FamixJavaIndexedFileAnchor.class.st
+++ b/src/Famix-Java-Entities/FamixJavaIndexedFileAnchor.class.st
@@ -24,6 +24,7 @@ Class {
 { #category : 'meta' }
 FamixJavaIndexedFileAnchor class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #IndexedFileAnchor super: #FamixJavaSourceAnchor>
 	<package: #'Famix-Java-Entities'>
 	<generated>

--- a/src/Famix-Java-Entities/FamixJavaInheritance.class.st
+++ b/src/Famix-Java-Entities/FamixJavaInheritance.class.st
@@ -35,6 +35,7 @@ Class {
 { #category : 'meta' }
 FamixJavaInheritance class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Inheritance super: #FamixJavaEntity>
 	<package: #'Famix-Java-Entities'>
 	<generated>

--- a/src/Famix-Java-Entities/FamixJavaInitializer.class.st
+++ b/src/Famix-Java-Entities/FamixJavaInitializer.class.st
@@ -21,6 +21,7 @@ Class {
 { #category : 'meta' }
 FamixJavaInitializer class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Initializer super: #FamixJavaMethod>
 	<package: #'Famix-Java-Entities'>
 	<generated>
@@ -40,6 +41,7 @@ FamixJavaInitializer >> isConstructor [
 FamixJavaInitializer >> isInitializationBlock [
 
 	<FMProperty: #isInitializationBlock type: #Boolean defaultValue: false>
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'If true, the entity is an initialization block.
 If false, the entity represents the definition of the attributes of a class'>
@@ -48,6 +50,7 @@ If false, the entity represents the definition of the attributes of a class'>
 
 { #category : 'accessing' }
 FamixJavaInitializer >> isInitializationBlock: anObject [
+	<ignoreForCoverage>
 	<generated>
 	isInitializationBlock := anObject
 ]

--- a/src/Famix-Java-Entities/FamixJavaInterface.class.st
+++ b/src/Famix-Java-Entities/FamixJavaInterface.class.st
@@ -57,6 +57,7 @@ Class {
 { #category : 'meta' }
 FamixJavaInterface class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Interface super: #FamixJavaType>
 	<package: #'Famix-Java-Entities'>
 	<generated>
@@ -84,6 +85,7 @@ FamixJavaInterface >> addMethodOverriding: aMethod in: aCollection [
 { #category : 'testing' }
 FamixJavaInterface >> isInterface [
 
+	<ignoreForCoverage>
 	<generated>
 	^ true
 ]

--- a/src/Famix-Java-Entities/FamixJavaInvocation.class.st
+++ b/src/Famix-Java-Entities/FamixJavaInvocation.class.st
@@ -42,6 +42,7 @@ Class {
 { #category : 'meta' }
 FamixJavaInvocation class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Invocation super: #FamixJavaEntity>
 	<package: #'Famix-Java-Entities'>
 	<generated>

--- a/src/Famix-Java-Entities/FamixJavaLocalVariable.class.st
+++ b/src/Famix-Java-Entities/FamixJavaLocalVariable.class.st
@@ -51,6 +51,7 @@ Class {
 { #category : 'meta' }
 FamixJavaLocalVariable class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #LocalVariable super: #FamixJavaVariable>
 	<package: #'Famix-Java-Entities'>
 	<generated>

--- a/src/Famix-Java-Entities/FamixJavaMethod.class.st
+++ b/src/Famix-Java-Entities/FamixJavaMethod.class.st
@@ -67,6 +67,7 @@ Class {
 { #category : 'meta' }
 FamixJavaMethod class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Method super: #FamixJavaContainerEntity>
 	<package: #'Famix-Java-Entities'>
 	<generated>

--- a/src/Famix-Java-Entities/FamixJavaModel.class.st
+++ b/src/Famix-Java-Entities/FamixJavaModel.class.st
@@ -10,6 +10,8 @@ Class {
 
 { #category : 'accessing' }
 FamixJavaModel class >> allSubmetamodelsPackagesNames [
+
+	<ignoreForCoverage>
 	<generated>
 	^ #(#'Moose-Query' #'Famix-Traits')
 ]
@@ -17,6 +19,7 @@ FamixJavaModel class >> allSubmetamodelsPackagesNames [
 { #category : 'meta' }
 FamixJavaModel class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Model super: #MooseModel>
 	<package: #'Famix-Java-Entities'>
 	<generated>
@@ -24,6 +27,8 @@ FamixJavaModel class >> annotation [
 
 { #category : 'testing' }
 FamixJavaModel class >> canBeImportedFromFile [
+
+	<ignoreForCoverage>
 	<generated>
 	^true
 ]
@@ -31,6 +36,7 @@ FamixJavaModel class >> canBeImportedFromFile [
 { #category : 'accessing' }
 FamixJavaModel class >> importingContextClass [
 
+	<ignoreForCoverage>
 	<generated>
 	^ FamixJavaImportingContext
 ]

--- a/src/Famix-Java-Entities/FamixJavaNamedEntity.class.st
+++ b/src/Famix-Java-Entities/FamixJavaNamedEntity.class.st
@@ -29,6 +29,7 @@ Class {
 { #category : 'meta' }
 FamixJavaNamedEntity class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #NamedEntity super: #FamixJavaSourcedEntity>
 	<package: #'Famix-Java-Entities'>
 	<generated>
@@ -38,6 +39,7 @@ FamixJavaNamedEntity class >> annotation [
 { #category : 'testing' }
 FamixJavaNamedEntity class >> isAbstract [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self == FamixJavaNamedEntity
 ]
@@ -45,6 +47,7 @@ FamixJavaNamedEntity class >> isAbstract [
 { #category : 'testing' }
 FamixJavaNamedEntity >> isNamedEntity [
 
+	<ignoreForCoverage>
 	<generated>
 	^ true
 ]

--- a/src/Famix-Java-Entities/FamixJavaPackage.class.st
+++ b/src/Famix-Java-Entities/FamixJavaPackage.class.st
@@ -46,6 +46,7 @@ Class {
 { #category : 'meta' }
 FamixJavaPackage class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Package super: #FamixJavaContainerEntity>
 	<package: #'Famix-Java-Entities'>
 	<generated>

--- a/src/Famix-Java-Entities/FamixJavaParameter.class.st
+++ b/src/Famix-Java-Entities/FamixJavaParameter.class.st
@@ -51,6 +51,7 @@ Class {
 { #category : 'meta' }
 FamixJavaParameter class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Parameter super: #FamixJavaVariable>
 	<package: #'Famix-Java-Entities'>
 	<generated>

--- a/src/Famix-Java-Entities/FamixJavaParametricClass.class.st
+++ b/src/Famix-Java-Entities/FamixJavaParametricClass.class.st
@@ -23,6 +23,7 @@ Class {
 { #category : 'meta' }
 FamixJavaParametricClass class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #ParametricClass super: #FamixJavaClass>
 	<package: #'Famix-Java-Entities'>
 	<generated>

--- a/src/Famix-Java-Entities/FamixJavaParametricEntityTyping.class.st
+++ b/src/Famix-Java-Entities/FamixJavaParametricEntityTyping.class.st
@@ -23,6 +23,7 @@ Class {
 { #category : 'meta' }
 FamixJavaParametricEntityTyping class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #ParametricEntityTyping super: #FamixJavaEntityTyping>
 	<package: #'Famix-Java-Entities'>
 	<generated>

--- a/src/Famix-Java-Entities/FamixJavaParametricImplementation.class.st
+++ b/src/Famix-Java-Entities/FamixJavaParametricImplementation.class.st
@@ -23,6 +23,7 @@ Class {
 { #category : 'meta' }
 FamixJavaParametricImplementation class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #ParametricImplementation super: #FamixJavaImplementation>
 	<package: #'Famix-Java-Entities'>
 	<generated>

--- a/src/Famix-Java-Entities/FamixJavaParametricInheritance.class.st
+++ b/src/Famix-Java-Entities/FamixJavaParametricInheritance.class.st
@@ -23,6 +23,7 @@ Class {
 { #category : 'meta' }
 FamixJavaParametricInheritance class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #ParametricInheritance super: #FamixJavaInheritance>
 	<package: #'Famix-Java-Entities'>
 	<generated>

--- a/src/Famix-Java-Entities/FamixJavaParametricInterface.class.st
+++ b/src/Famix-Java-Entities/FamixJavaParametricInterface.class.st
@@ -23,6 +23,7 @@ Class {
 { #category : 'meta' }
 FamixJavaParametricInterface class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #ParametricInterface super: #FamixJavaInterface>
 	<package: #'Famix-Java-Entities'>
 	<generated>

--- a/src/Famix-Java-Entities/FamixJavaParametricInvocation.class.st
+++ b/src/Famix-Java-Entities/FamixJavaParametricInvocation.class.st
@@ -23,6 +23,7 @@ Class {
 { #category : 'meta' }
 FamixJavaParametricInvocation class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #ParametricInvocation super: #FamixJavaInvocation>
 	<package: #'Famix-Java-Entities'>
 	<generated>

--- a/src/Famix-Java-Entities/FamixJavaParametricMethod.class.st
+++ b/src/Famix-Java-Entities/FamixJavaParametricMethod.class.st
@@ -23,6 +23,7 @@ Class {
 { #category : 'meta' }
 FamixJavaParametricMethod class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #ParametricMethod super: #FamixJavaMethod>
 	<package: #'Famix-Java-Entities'>
 	<generated>

--- a/src/Famix-Java-Entities/FamixJavaParametricReference.class.st
+++ b/src/Famix-Java-Entities/FamixJavaParametricReference.class.st
@@ -23,6 +23,7 @@ Class {
 { #category : 'meta' }
 FamixJavaParametricReference class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #ParametricReference super: #FamixJavaReference>
 	<package: #'Famix-Java-Entities'>
 	<generated>

--- a/src/Famix-Java-Entities/FamixJavaPrimitiveType.class.st
+++ b/src/Famix-Java-Entities/FamixJavaPrimitiveType.class.st
@@ -46,6 +46,7 @@ Class {
 { #category : 'meta' }
 FamixJavaPrimitiveType class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #PrimitiveType super: #FamixJavaType>
 	<package: #'Famix-Java-Entities'>
 	<generated>
@@ -54,6 +55,7 @@ FamixJavaPrimitiveType class >> annotation [
 { #category : 'testing' }
 FamixJavaPrimitiveType >> isPrimitiveType [
 
+	<ignoreForCoverage>
 	<generated>
 	^ true
 ]

--- a/src/Famix-Java-Entities/FamixJavaReference.class.st
+++ b/src/Famix-Java-Entities/FamixJavaReference.class.st
@@ -35,6 +35,7 @@ Class {
 { #category : 'meta' }
 FamixJavaReference class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Reference super: #FamixJavaEntity>
 	<package: #'Famix-Java-Entities'>
 	<generated>

--- a/src/Famix-Java-Entities/FamixJavaSourceAnchor.class.st
+++ b/src/Famix-Java-Entities/FamixJavaSourceAnchor.class.st
@@ -23,6 +23,7 @@ Class {
 { #category : 'meta' }
 FamixJavaSourceAnchor class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #SourceAnchor super: #FamixJavaEntity>
 	<package: #'Famix-Java-Entities'>
 	<generated>
@@ -32,6 +33,7 @@ FamixJavaSourceAnchor class >> annotation [
 { #category : 'testing' }
 FamixJavaSourceAnchor class >> isAbstract [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self == FamixJavaSourceAnchor
 ]

--- a/src/Famix-Java-Entities/FamixJavaSourceLanguage.class.st
+++ b/src/Famix-Java-Entities/FamixJavaSourceLanguage.class.st
@@ -23,6 +23,7 @@ Class {
 { #category : 'meta' }
 FamixJavaSourceLanguage class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #SourceLanguage super: #FamixJavaEntity>
 	<package: #'Famix-Java-Entities'>
 	<generated>

--- a/src/Famix-Java-Entities/FamixJavaSourceTextAnchor.class.st
+++ b/src/Famix-Java-Entities/FamixJavaSourceTextAnchor.class.st
@@ -29,6 +29,7 @@ Class {
 { #category : 'meta' }
 FamixJavaSourceTextAnchor class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #SourceTextAnchor super: #FamixJavaSourceAnchor>
 	<package: #'Famix-Java-Entities'>
 	<generated>

--- a/src/Famix-Java-Entities/FamixJavaSourcedEntity.class.st
+++ b/src/Famix-Java-Entities/FamixJavaSourcedEntity.class.st
@@ -23,6 +23,7 @@ Class {
 { #category : 'meta' }
 FamixJavaSourcedEntity class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #SourcedEntity super: #FamixJavaEntity>
 	<package: #'Famix-Java-Entities'>
 	<generated>
@@ -32,6 +33,7 @@ FamixJavaSourcedEntity class >> annotation [
 { #category : 'testing' }
 FamixJavaSourcedEntity class >> isAbstract [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self == FamixJavaSourcedEntity
 ]

--- a/src/Famix-Java-Entities/FamixJavaTBound.trait.st
+++ b/src/Famix-Java-Entities/FamixJavaTBound.trait.st
@@ -27,6 +27,7 @@ Trait {
 { #category : 'meta' }
 FamixJavaTBound classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TBound super: #Object>
 	<package: #'Famix-Java-Entities'>
 	<generated>
@@ -34,12 +35,16 @@ FamixJavaTBound classSide >> annotation [
 
 { #category : 'adding' }
 FamixJavaTBound >> addLowerBoundedWildcard: anObject [
+
+	<ignoreForCoverage>
 	<generated>
 	^ self lowerBoundedWildcards add: anObject
 ]
 
 { #category : 'adding' }
 FamixJavaTBound >> addUpperBoundedWildcard: anObject [
+
+	<ignoreForCoverage>
 	<generated>
 	^ self upperBoundedWildcards add: anObject
 ]
@@ -48,6 +53,7 @@ FamixJavaTBound >> addUpperBoundedWildcard: anObject [
 FamixJavaTBound >> lowerBoundedWildcards [
 	"Relation named: #lowerBoundedWildcards type: #FamixJavaTBounded opposite: #lowerBound"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'Wildcards lower bounded by this bound.'>
 	<derived>
@@ -57,6 +63,7 @@ FamixJavaTBound >> lowerBoundedWildcards [
 { #category : 'accessing' }
 FamixJavaTBound >> lowerBoundedWildcards: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	lowerBoundedWildcards value: anObject
 ]
@@ -65,6 +72,7 @@ FamixJavaTBound >> lowerBoundedWildcards: anObject [
 FamixJavaTBound >> upperBoundedWildcards [
 	"Relation named: #upperBoundedWildcards type: #FamixJavaTBounded opposite: #upperBound"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'Wildcards upper bounded by this bound.'>
 	<derived>
@@ -74,6 +82,7 @@ FamixJavaTBound >> upperBoundedWildcards [
 { #category : 'accessing' }
 FamixJavaTBound >> upperBoundedWildcards: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	upperBoundedWildcards value: anObject
 ]

--- a/src/Famix-Java-Entities/FamixJavaTBounded.trait.st
+++ b/src/Famix-Java-Entities/FamixJavaTBounded.trait.st
@@ -27,6 +27,7 @@ Trait {
 { #category : 'meta' }
 FamixJavaTBounded classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TBounded super: #Object>
 	<package: #'Famix-Java-Entities'>
 	<generated>
@@ -36,6 +37,7 @@ FamixJavaTBounded classSide >> annotation [
 FamixJavaTBounded >> lowerBound [
 	"Relation named: #lowerBound type: #FamixJavaTBound opposite: #lowerBoundedWildcards"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'Lower bound on wildcard, specified by super keyword.'>
 	^ lowerBound
@@ -44,6 +46,7 @@ FamixJavaTBounded >> lowerBound [
 { #category : 'accessing' }
 FamixJavaTBounded >> lowerBound: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	lowerBound := anObject
 ]
@@ -52,6 +55,7 @@ FamixJavaTBounded >> lowerBound: anObject [
 FamixJavaTBounded >> upperBound [
 	"Relation named: #upperBound type: #FamixJavaTBound opposite: #upperBoundedWildcards"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'Upper bound on wildcard, specified by extends keyword.'>
 	^ upperBound
@@ -60,6 +64,7 @@ FamixJavaTBounded >> upperBound [
 { #category : 'accessing' }
 FamixJavaTBounded >> upperBound: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	upperBound := anObject
 ]

--- a/src/Famix-Java-Entities/FamixJavaTCanBeSynchronized.trait.st
+++ b/src/Famix-Java-Entities/FamixJavaTCanBeSynchronized.trait.st
@@ -33,6 +33,7 @@ Trait {
 { #category : 'meta' }
 FamixJavaTCanBeSynchronized classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TCanBeSynchronized super: #Object>
 	<package: #'Famix-Java-Entities'>
 	<generated>
@@ -42,6 +43,7 @@ FamixJavaTCanBeSynchronized classSide >> annotation [
 FamixJavaTCanBeSynchronized >> isSynchronized [
 
 	<FMProperty: #isSynchronized type: #Boolean defaultValue: false>
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'Entity can be declared synchronized'>
 	^ isSynchronized ifNil: [ isSynchronized := false ]
@@ -49,6 +51,7 @@ FamixJavaTCanBeSynchronized >> isSynchronized [
 
 { #category : 'accessing' }
 FamixJavaTCanBeSynchronized >> isSynchronized: anObject [
+	<ignoreForCoverage>
 	<generated>
 	isSynchronized := anObject
 ]

--- a/src/Famix-Java-Entities/FamixJavaTCanBeTransient.trait.st
+++ b/src/Famix-Java-Entities/FamixJavaTCanBeTransient.trait.st
@@ -29,6 +29,7 @@ Trait {
 { #category : 'meta' }
 FamixJavaTCanBeTransient classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TCanBeTransient super: #Object>
 	<package: #'Famix-Java-Entities'>
 	<generated>
@@ -38,6 +39,7 @@ FamixJavaTCanBeTransient classSide >> annotation [
 FamixJavaTCanBeTransient >> isTransient [
 
 	<FMProperty: #isTransient type: #Boolean defaultValue: false>
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'Entity can be declared transient'>
 	^ isTransient ifNil: [ isTransient := false ]
@@ -45,6 +47,7 @@ FamixJavaTCanBeTransient >> isTransient [
 
 { #category : 'accessing' }
 FamixJavaTCanBeTransient >> isTransient: anObject [
+	<ignoreForCoverage>
 	<generated>
 	isTransient := anObject
 ]

--- a/src/Famix-Java-Entities/FamixJavaTCanBeVolatile.trait.st
+++ b/src/Famix-Java-Entities/FamixJavaTCanBeVolatile.trait.st
@@ -29,6 +29,7 @@ Trait {
 { #category : 'meta' }
 FamixJavaTCanBeVolatile classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TCanBeVolatile super: #Object>
 	<package: #'Famix-Java-Entities'>
 	<generated>
@@ -38,6 +39,7 @@ FamixJavaTCanBeVolatile classSide >> annotation [
 FamixJavaTCanBeVolatile >> isVolatile [
 
 	<FMProperty: #isVolatile type: #Boolean defaultValue: false>
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'Entity can be declared volatile'>
 	^ isVolatile ifNil: [ isVolatile := false ]
@@ -45,6 +47,7 @@ FamixJavaTCanBeVolatile >> isVolatile [
 
 { #category : 'accessing' }
 FamixJavaTCanBeVolatile >> isVolatile: anObject [
+	<ignoreForCoverage>
 	<generated>
 	isVolatile := anObject
 ]

--- a/src/Famix-Java-Entities/FamixJavaTClassMetrics.trait.st
+++ b/src/Famix-Java-Entities/FamixJavaTClassMetrics.trait.st
@@ -8,6 +8,7 @@ Trait {
 { #category : 'meta' }
 FamixJavaTClassMetrics classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TClassMetrics super: #Object>
 	<package: #'Famix-Java-Entities'>
 	<generated>

--- a/src/Famix-Java-Entities/FamixJavaTEntityCreator.trait.st
+++ b/src/Famix-Java-Entities/FamixJavaTEntityCreator.trait.st
@@ -14,6 +14,7 @@ Trait {
 { #category : 'meta' }
 FamixJavaTEntityCreator classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TEntityCreator super: #Object>
 	<package: #'Famix-Java-Entities'>
 	<generated>
@@ -22,6 +23,7 @@ FamixJavaTEntityCreator classSide >> annotation [
 { #category : 'entity creation' }
 FamixJavaTEntityCreator >> newAccess [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixJavaAccess new
 ]
@@ -29,6 +31,7 @@ FamixJavaTEntityCreator >> newAccess [
 { #category : 'entity creation' }
 FamixJavaTEntityCreator >> newAnnotationInstance [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixJavaAnnotationInstance new
 ]
@@ -36,6 +39,7 @@ FamixJavaTEntityCreator >> newAnnotationInstance [
 { #category : 'entity creation' }
 FamixJavaTEntityCreator >> newAnnotationInstanceAttribute [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixJavaAnnotationInstanceAttribute new
 ]
@@ -43,6 +47,7 @@ FamixJavaTEntityCreator >> newAnnotationInstanceAttribute [
 { #category : 'entity creation' }
 FamixJavaTEntityCreator >> newAnnotationType [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixJavaAnnotationType new
 ]
@@ -50,6 +55,7 @@ FamixJavaTEntityCreator >> newAnnotationType [
 { #category : 'entity creation' }
 FamixJavaTEntityCreator >> newAnnotationTypeAttribute [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixJavaAnnotationTypeAttribute new
 ]
@@ -57,6 +63,7 @@ FamixJavaTEntityCreator >> newAnnotationTypeAttribute [
 { #category : 'entity creation' }
 FamixJavaTEntityCreator >> newAnnotationTypeAttributeNamed: aName [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: (FamixJavaAnnotationTypeAttribute named: aName)
 ]
@@ -64,6 +71,7 @@ FamixJavaTEntityCreator >> newAnnotationTypeAttributeNamed: aName [
 { #category : 'entity creation' }
 FamixJavaTEntityCreator >> newAnnotationTypeNamed: aName [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: (FamixJavaAnnotationType named: aName)
 ]
@@ -71,6 +79,7 @@ FamixJavaTEntityCreator >> newAnnotationTypeNamed: aName [
 { #category : 'entity creation' }
 FamixJavaTEntityCreator >> newAttribute [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixJavaAttribute new
 ]
@@ -78,6 +87,7 @@ FamixJavaTEntityCreator >> newAttribute [
 { #category : 'entity creation' }
 FamixJavaTEntityCreator >> newAttributeNamed: aName [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: (FamixJavaAttribute named: aName)
 ]
@@ -85,6 +95,7 @@ FamixJavaTEntityCreator >> newAttributeNamed: aName [
 { #category : 'entity creation' }
 FamixJavaTEntityCreator >> newClass [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixJavaClass new
 ]
@@ -92,6 +103,7 @@ FamixJavaTEntityCreator >> newClass [
 { #category : 'entity creation' }
 FamixJavaTEntityCreator >> newClassNamed: aName [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: (FamixJavaClass named: aName)
 ]
@@ -99,6 +111,7 @@ FamixJavaTEntityCreator >> newClassNamed: aName [
 { #category : 'entity creation' }
 FamixJavaTEntityCreator >> newComment [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixJavaComment new
 ]
@@ -106,6 +119,7 @@ FamixJavaTEntityCreator >> newComment [
 { #category : 'entity creation' }
 FamixJavaTEntityCreator >> newConcretization [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixJavaConcretization new
 ]
@@ -113,6 +127,7 @@ FamixJavaTEntityCreator >> newConcretization [
 { #category : 'entity creation' }
 FamixJavaTEntityCreator >> newEntityTyping [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixJavaEntityTyping new
 ]
@@ -120,6 +135,7 @@ FamixJavaTEntityCreator >> newEntityTyping [
 { #category : 'entity creation' }
 FamixJavaTEntityCreator >> newEnum [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixJavaEnum new
 ]
@@ -127,6 +143,7 @@ FamixJavaTEntityCreator >> newEnum [
 { #category : 'entity creation' }
 FamixJavaTEntityCreator >> newEnumNamed: aName [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: (FamixJavaEnum named: aName)
 ]
@@ -134,6 +151,7 @@ FamixJavaTEntityCreator >> newEnumNamed: aName [
 { #category : 'entity creation' }
 FamixJavaTEntityCreator >> newEnumValue [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixJavaEnumValue new
 ]
@@ -141,6 +159,7 @@ FamixJavaTEntityCreator >> newEnumValue [
 { #category : 'entity creation' }
 FamixJavaTEntityCreator >> newEnumValueNamed: aName [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: (FamixJavaEnumValue named: aName)
 ]
@@ -148,6 +167,7 @@ FamixJavaTEntityCreator >> newEnumValueNamed: aName [
 { #category : 'entity creation' }
 FamixJavaTEntityCreator >> newException [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixJavaException new
 ]
@@ -155,6 +175,7 @@ FamixJavaTEntityCreator >> newException [
 { #category : 'entity creation' }
 FamixJavaTEntityCreator >> newExceptionNamed: aName [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: (FamixJavaException named: aName)
 ]
@@ -162,6 +183,7 @@ FamixJavaTEntityCreator >> newExceptionNamed: aName [
 { #category : 'entity creation' }
 FamixJavaTEntityCreator >> newImplementation [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixJavaImplementation new
 ]
@@ -169,6 +191,7 @@ FamixJavaTEntityCreator >> newImplementation [
 { #category : 'entity creation' }
 FamixJavaTEntityCreator >> newImplicitVariable [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixJavaImplicitVariable new
 ]
@@ -176,6 +199,7 @@ FamixJavaTEntityCreator >> newImplicitVariable [
 { #category : 'entity creation' }
 FamixJavaTEntityCreator >> newImplicitVariableNamed: aName [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: (FamixJavaImplicitVariable named: aName)
 ]
@@ -183,6 +207,7 @@ FamixJavaTEntityCreator >> newImplicitVariableNamed: aName [
 { #category : 'entity creation' }
 FamixJavaTEntityCreator >> newImport [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixJavaImport new
 ]
@@ -190,6 +215,7 @@ FamixJavaTEntityCreator >> newImport [
 { #category : 'entity creation' }
 FamixJavaTEntityCreator >> newIndexedFileAnchor [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixJavaIndexedFileAnchor new
 ]
@@ -197,6 +223,7 @@ FamixJavaTEntityCreator >> newIndexedFileAnchor [
 { #category : 'entity creation' }
 FamixJavaTEntityCreator >> newInheritance [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixJavaInheritance new
 ]
@@ -204,6 +231,7 @@ FamixJavaTEntityCreator >> newInheritance [
 { #category : 'entity creation' }
 FamixJavaTEntityCreator >> newInitializer [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixJavaInitializer new
 ]
@@ -211,6 +239,7 @@ FamixJavaTEntityCreator >> newInitializer [
 { #category : 'entity creation' }
 FamixJavaTEntityCreator >> newInitializerNamed: aName [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: (FamixJavaInitializer named: aName)
 ]
@@ -218,6 +247,7 @@ FamixJavaTEntityCreator >> newInitializerNamed: aName [
 { #category : 'entity creation' }
 FamixJavaTEntityCreator >> newInterface [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixJavaInterface new
 ]
@@ -225,6 +255,7 @@ FamixJavaTEntityCreator >> newInterface [
 { #category : 'entity creation' }
 FamixJavaTEntityCreator >> newInterfaceNamed: aName [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: (FamixJavaInterface named: aName)
 ]
@@ -232,6 +263,7 @@ FamixJavaTEntityCreator >> newInterfaceNamed: aName [
 { #category : 'entity creation' }
 FamixJavaTEntityCreator >> newInvocation [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixJavaInvocation new
 ]
@@ -239,6 +271,7 @@ FamixJavaTEntityCreator >> newInvocation [
 { #category : 'entity creation' }
 FamixJavaTEntityCreator >> newLocalVariable [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixJavaLocalVariable new
 ]
@@ -246,6 +279,7 @@ FamixJavaTEntityCreator >> newLocalVariable [
 { #category : 'entity creation' }
 FamixJavaTEntityCreator >> newLocalVariableNamed: aName [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: (FamixJavaLocalVariable named: aName)
 ]
@@ -253,6 +287,7 @@ FamixJavaTEntityCreator >> newLocalVariableNamed: aName [
 { #category : 'entity creation' }
 FamixJavaTEntityCreator >> newMethod [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixJavaMethod new
 ]
@@ -260,6 +295,7 @@ FamixJavaTEntityCreator >> newMethod [
 { #category : 'entity creation' }
 FamixJavaTEntityCreator >> newMethodNamed: aName [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: (FamixJavaMethod named: aName)
 ]
@@ -267,6 +303,7 @@ FamixJavaTEntityCreator >> newMethodNamed: aName [
 { #category : 'entity creation' }
 FamixJavaTEntityCreator >> newPackage [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixJavaPackage new
 ]
@@ -274,6 +311,7 @@ FamixJavaTEntityCreator >> newPackage [
 { #category : 'entity creation' }
 FamixJavaTEntityCreator >> newPackageNamed: aName [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: (FamixJavaPackage named: aName)
 ]
@@ -281,6 +319,7 @@ FamixJavaTEntityCreator >> newPackageNamed: aName [
 { #category : 'entity creation' }
 FamixJavaTEntityCreator >> newParameter [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixJavaParameter new
 ]
@@ -288,6 +327,7 @@ FamixJavaTEntityCreator >> newParameter [
 { #category : 'entity creation' }
 FamixJavaTEntityCreator >> newParameterNamed: aName [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: (FamixJavaParameter named: aName)
 ]
@@ -295,6 +335,7 @@ FamixJavaTEntityCreator >> newParameterNamed: aName [
 { #category : 'entity creation' }
 FamixJavaTEntityCreator >> newParametricClass [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixJavaParametricClass new
 ]
@@ -302,6 +343,7 @@ FamixJavaTEntityCreator >> newParametricClass [
 { #category : 'entity creation' }
 FamixJavaTEntityCreator >> newParametricClassNamed: aName [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: (FamixJavaParametricClass named: aName)
 ]
@@ -309,6 +351,7 @@ FamixJavaTEntityCreator >> newParametricClassNamed: aName [
 { #category : 'entity creation' }
 FamixJavaTEntityCreator >> newParametricEntityTyping [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixJavaParametricEntityTyping new
 ]
@@ -316,6 +359,7 @@ FamixJavaTEntityCreator >> newParametricEntityTyping [
 { #category : 'entity creation' }
 FamixJavaTEntityCreator >> newParametricImplementation [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixJavaParametricImplementation new
 ]
@@ -323,6 +367,7 @@ FamixJavaTEntityCreator >> newParametricImplementation [
 { #category : 'entity creation' }
 FamixJavaTEntityCreator >> newParametricInheritance [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixJavaParametricInheritance new
 ]
@@ -330,6 +375,7 @@ FamixJavaTEntityCreator >> newParametricInheritance [
 { #category : 'entity creation' }
 FamixJavaTEntityCreator >> newParametricInterface [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixJavaParametricInterface new
 ]
@@ -337,6 +383,7 @@ FamixJavaTEntityCreator >> newParametricInterface [
 { #category : 'entity creation' }
 FamixJavaTEntityCreator >> newParametricInterfaceNamed: aName [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: (FamixJavaParametricInterface named: aName)
 ]
@@ -344,6 +391,7 @@ FamixJavaTEntityCreator >> newParametricInterfaceNamed: aName [
 { #category : 'entity creation' }
 FamixJavaTEntityCreator >> newParametricInvocation [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixJavaParametricInvocation new
 ]
@@ -351,6 +399,7 @@ FamixJavaTEntityCreator >> newParametricInvocation [
 { #category : 'entity creation' }
 FamixJavaTEntityCreator >> newParametricMethod [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixJavaParametricMethod new
 ]
@@ -358,6 +407,7 @@ FamixJavaTEntityCreator >> newParametricMethod [
 { #category : 'entity creation' }
 FamixJavaTEntityCreator >> newParametricMethodNamed: aName [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: (FamixJavaParametricMethod named: aName)
 ]
@@ -365,6 +415,7 @@ FamixJavaTEntityCreator >> newParametricMethodNamed: aName [
 { #category : 'entity creation' }
 FamixJavaTEntityCreator >> newParametricReference [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixJavaParametricReference new
 ]
@@ -372,6 +423,7 @@ FamixJavaTEntityCreator >> newParametricReference [
 { #category : 'entity creation' }
 FamixJavaTEntityCreator >> newPrimitiveType [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixJavaPrimitiveType new
 ]
@@ -379,6 +431,7 @@ FamixJavaTEntityCreator >> newPrimitiveType [
 { #category : 'entity creation' }
 FamixJavaTEntityCreator >> newPrimitiveTypeNamed: aName [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: (FamixJavaPrimitiveType named: aName)
 ]
@@ -386,6 +439,7 @@ FamixJavaTEntityCreator >> newPrimitiveTypeNamed: aName [
 { #category : 'entity creation' }
 FamixJavaTEntityCreator >> newReference [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixJavaReference new
 ]
@@ -393,6 +447,7 @@ FamixJavaTEntityCreator >> newReference [
 { #category : 'entity creation' }
 FamixJavaTEntityCreator >> newSourceLanguage [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixJavaSourceLanguage new
 ]
@@ -400,6 +455,7 @@ FamixJavaTEntityCreator >> newSourceLanguage [
 { #category : 'entity creation' }
 FamixJavaTEntityCreator >> newSourceTextAnchor [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixJavaSourceTextAnchor new
 ]
@@ -407,6 +463,7 @@ FamixJavaTEntityCreator >> newSourceTextAnchor [
 { #category : 'entity creation' }
 FamixJavaTEntityCreator >> newType [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixJavaType new
 ]
@@ -414,6 +471,7 @@ FamixJavaTEntityCreator >> newType [
 { #category : 'entity creation' }
 FamixJavaTEntityCreator >> newTypeNamed: aName [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: (FamixJavaType named: aName)
 ]
@@ -421,6 +479,7 @@ FamixJavaTEntityCreator >> newTypeNamed: aName [
 { #category : 'entity creation' }
 FamixJavaTEntityCreator >> newTypeParameter [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixJavaTypeParameter new
 ]
@@ -428,6 +487,7 @@ FamixJavaTEntityCreator >> newTypeParameter [
 { #category : 'entity creation' }
 FamixJavaTEntityCreator >> newTypeParameterNamed: aName [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: (FamixJavaTypeParameter named: aName)
 ]
@@ -435,6 +495,7 @@ FamixJavaTEntityCreator >> newTypeParameterNamed: aName [
 { #category : 'entity creation' }
 FamixJavaTEntityCreator >> newUnknownVariable [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixJavaUnknownVariable new
 ]
@@ -442,6 +503,7 @@ FamixJavaTEntityCreator >> newUnknownVariable [
 { #category : 'entity creation' }
 FamixJavaTEntityCreator >> newUnknownVariableNamed: aName [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: (FamixJavaUnknownVariable named: aName)
 ]
@@ -449,6 +511,7 @@ FamixJavaTEntityCreator >> newUnknownVariableNamed: aName [
 { #category : 'entity creation' }
 FamixJavaTEntityCreator >> newWildcard [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixJavaWildcard new
 ]
@@ -456,6 +519,7 @@ FamixJavaTEntityCreator >> newWildcard [
 { #category : 'entity creation' }
 FamixJavaTEntityCreator >> newWildcardNamed: aName [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: (FamixJavaWildcard named: aName)
 ]

--- a/src/Famix-Java-Entities/FamixJavaTVisitor.trait.st
+++ b/src/Famix-Java-Entities/FamixJavaTVisitor.trait.st
@@ -14,6 +14,7 @@ Trait {
 { #category : 'meta' }
 FamixJavaTVisitor classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TVisitor super: #Object>
 	<package: #'Famix-Java-Entities'>
 	<generated>
@@ -22,6 +23,7 @@ FamixJavaTVisitor classSide >> annotation [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitCollection: aCollection [
 
+	<ignoreForCoverage>
 	<generated>
 	^ aCollection collect: [ :each | each accept: self ]
 ]
@@ -29,6 +31,7 @@ FamixJavaTVisitor >> visitCollection: aCollection [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitEntity: aFamixEntity [
 
+	<ignoreForCoverage>
 	<generated>
 	^ aFamixEntity ifNotNil: [ aFamixEntity accept: self ]
 ]
@@ -36,6 +39,7 @@ FamixJavaTVisitor >> visitEntity: aFamixEntity [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixJavaAccess: anAccess [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitFamixTAccess: anAccess
 ]
@@ -43,6 +47,7 @@ FamixJavaTVisitor >> visitFamixJavaAccess: anAccess [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixJavaAnnotationInstance: anAnnotationInstance [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitFamixTAnnotationInstance: anAnnotationInstance.
 	self visitFamixJavaSourcedEntity: anAnnotationInstance
@@ -51,6 +56,7 @@ FamixJavaTVisitor >> visitFamixJavaAnnotationInstance: anAnnotationInstance [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixJavaAnnotationInstanceAttribute: anAnnotationInstanceAttribute [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitFamixTAnnotationInstanceAttribute: anAnnotationInstanceAttribute.
 	self visitFamixJavaSourcedEntity: anAnnotationInstanceAttribute
@@ -59,6 +65,7 @@ FamixJavaTVisitor >> visitFamixJavaAnnotationInstanceAttribute: anAnnotationInst
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixJavaAnnotationType: anAnnotationType [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitFamixTAnnotationType: anAnnotationType.
 	self visitFamixTHasVisibility: anAnnotationType.
@@ -74,6 +81,7 @@ FamixJavaTVisitor >> visitFamixJavaAnnotationType: anAnnotationType [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixJavaAnnotationTypeAttribute: anAnnotationTypeAttribute [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitFamixTAnnotationTypeAttribute: anAnnotationTypeAttribute.
 	self visitFamixTWithComments: anAnnotationTypeAttribute.
@@ -83,6 +91,7 @@ FamixJavaTVisitor >> visitFamixJavaAnnotationTypeAttribute: anAnnotationTypeAttr
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixJavaAttribute: anAttribute [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitFamixJavaTCanBeTransient: anAttribute.
 	self visitFamixJavaTCanBeVolatile: anAttribute.
@@ -97,6 +106,7 @@ FamixJavaTVisitor >> visitFamixJavaAttribute: anAttribute [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixJavaClass: aClass [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitFamixJavaTClassMetrics: aClass.
 	self visitFamixTCanBeAbstract: aClass.
@@ -117,6 +127,7 @@ FamixJavaTVisitor >> visitFamixJavaClass: aClass [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixJavaComment: aComment [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitFamixTComment: aComment.
 	self visitFamixJavaSourcedEntity: aComment
@@ -125,6 +136,7 @@ FamixJavaTVisitor >> visitFamixJavaComment: aComment [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixJavaConcretization: aConcretization [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitFamixTConcretization: aConcretization
 ]
@@ -132,6 +144,7 @@ FamixJavaTVisitor >> visitFamixJavaConcretization: aConcretization [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixJavaContainerEntity: aContainerEntity [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitFamixJavaTWithInterfaces: aContainerEntity.
 	self visitFamixTWithAnnotationTypes: aContainerEntity.
@@ -142,6 +155,7 @@ FamixJavaTVisitor >> visitFamixJavaContainerEntity: aContainerEntity [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixJavaEntity: anEntity [
 
+	<ignoreForCoverage>
 	<generated>
 
 ]
@@ -149,6 +163,7 @@ FamixJavaTVisitor >> visitFamixJavaEntity: anEntity [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixJavaEntityTyping: anEntityTyping [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitFamixTEntityTyping: anEntityTyping
 ]
@@ -156,6 +171,7 @@ FamixJavaTVisitor >> visitFamixJavaEntityTyping: anEntityTyping [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixJavaEnum: anEnum [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitFamixTEnum: anEnum.
 	self visitFamixTHasVisibility: anEnum.
@@ -173,6 +189,7 @@ FamixJavaTVisitor >> visitFamixJavaEnum: anEnum [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixJavaEnumValue: anEnumValue [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitFamixTEnumValue: anEnumValue.
 	self visitFamixTWithComments: anEnumValue.
@@ -182,6 +199,7 @@ FamixJavaTVisitor >> visitFamixJavaEnumValue: anEnumValue [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixJavaException: anException [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitFamixTException: anException.
 	self visitFamixJavaClass: anException
@@ -190,6 +208,7 @@ FamixJavaTVisitor >> visitFamixJavaException: anException [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixJavaImplementation: anImplementation [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitFamixTImplementation: anImplementation
 ]
@@ -197,6 +216,7 @@ FamixJavaTVisitor >> visitFamixJavaImplementation: anImplementation [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixJavaImplicitVariable: anImplicitVariable [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitFamixTImplicitVariable: anImplicitVariable.
 	self visitFamixJavaVariable: anImplicitVariable
@@ -205,6 +225,7 @@ FamixJavaTVisitor >> visitFamixJavaImplicitVariable: anImplicitVariable [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixJavaImport: anImport [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitFamixTImport: anImport
 ]
@@ -212,6 +233,7 @@ FamixJavaTVisitor >> visitFamixJavaImport: anImport [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixJavaIndexedFileAnchor: anIndexedFileAnchor [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitFamixTIndexedFileNavigation: anIndexedFileAnchor.
 	self visitFamixJavaSourceAnchor: anIndexedFileAnchor
@@ -220,6 +242,7 @@ FamixJavaTVisitor >> visitFamixJavaIndexedFileAnchor: anIndexedFileAnchor [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixJavaInheritance: anInheritance [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitFamixTInheritance: anInheritance
 ]
@@ -227,6 +250,7 @@ FamixJavaTVisitor >> visitFamixJavaInheritance: anInheritance [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixJavaInitializer: anInitializer [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitFamixJavaMethod: anInitializer
 ]
@@ -234,6 +258,7 @@ FamixJavaTVisitor >> visitFamixJavaInitializer: anInitializer [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixJavaInterface: anInterface [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitFamixTCanBeClassSide: anInterface.
 	self visitFamixTCanBeFinal: anInterface.
@@ -254,6 +279,7 @@ FamixJavaTVisitor >> visitFamixJavaInterface: anInterface [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixJavaInvocation: anInvocation [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitFamixTInvocation: anInvocation
 ]
@@ -261,6 +287,7 @@ FamixJavaTVisitor >> visitFamixJavaInvocation: anInvocation [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixJavaLocalVariable: aLocalVariable [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitFamixTCanBeFinal: aLocalVariable.
 	self visitFamixTLocalVariable: aLocalVariable.
@@ -271,6 +298,7 @@ FamixJavaTVisitor >> visitFamixJavaLocalVariable: aLocalVariable [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixJavaMethod: aMethod [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitFamixJavaTCanBeSynchronized: aMethod.
 	self visitFamixTCanBeAbstract: aMethod.
@@ -288,6 +316,7 @@ FamixJavaTVisitor >> visitFamixJavaMethod: aMethod [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixJavaNamedEntity: aNamedEntity [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitFamixTNamedEntity: aNamedEntity.
 	self visitFamixTWithAnnotationInstances: aNamedEntity.
@@ -298,6 +327,7 @@ FamixJavaTVisitor >> visitFamixJavaNamedEntity: aNamedEntity [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixJavaPackage: aPackage [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitFamixTImportable: aPackage.
 	self visitFamixTPackage: aPackage.
@@ -309,6 +339,7 @@ FamixJavaTVisitor >> visitFamixJavaPackage: aPackage [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixJavaParameter: aParameter [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitFamixTCanBeFinal: aParameter.
 	self visitFamixTParameter: aParameter.
@@ -319,6 +350,7 @@ FamixJavaTVisitor >> visitFamixJavaParameter: aParameter [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixJavaParametricClass: aParametricClass [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitFamixTParametricEntity: aParametricClass.
 	self visitFamixJavaClass: aParametricClass
@@ -327,6 +359,7 @@ FamixJavaTVisitor >> visitFamixJavaParametricClass: aParametricClass [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixJavaParametricEntityTyping: aParametricEntityTyping [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitFamixTParametricAssociation: aParametricEntityTyping.
 	self visitFamixJavaEntityTyping: aParametricEntityTyping
@@ -335,6 +368,7 @@ FamixJavaTVisitor >> visitFamixJavaParametricEntityTyping: aParametricEntityTypi
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixJavaParametricImplementation: aParametricImplementation [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitFamixTParametricAssociation: aParametricImplementation.
 	self visitFamixJavaImplementation: aParametricImplementation
@@ -343,6 +377,7 @@ FamixJavaTVisitor >> visitFamixJavaParametricImplementation: aParametricImplemen
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixJavaParametricInheritance: aParametricInheritance [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitFamixTParametricAssociation: aParametricInheritance.
 	self visitFamixJavaInheritance: aParametricInheritance
@@ -351,6 +386,7 @@ FamixJavaTVisitor >> visitFamixJavaParametricInheritance: aParametricInheritance
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixJavaParametricInterface: aParametricInterface [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitFamixTParametricEntity: aParametricInterface.
 	self visitFamixJavaInterface: aParametricInterface
@@ -359,6 +395,7 @@ FamixJavaTVisitor >> visitFamixJavaParametricInterface: aParametricInterface [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixJavaParametricInvocation: aParametricInvocation [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitFamixTParametricAssociation: aParametricInvocation.
 	self visitFamixJavaInvocation: aParametricInvocation
@@ -367,6 +404,7 @@ FamixJavaTVisitor >> visitFamixJavaParametricInvocation: aParametricInvocation [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixJavaParametricMethod: aParametricMethod [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitFamixTParametricEntity: aParametricMethod.
 	self visitFamixJavaMethod: aParametricMethod
@@ -375,6 +413,7 @@ FamixJavaTVisitor >> visitFamixJavaParametricMethod: aParametricMethod [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixJavaParametricReference: aParametricReference [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitFamixTParametricAssociation: aParametricReference.
 	self visitFamixJavaReference: aParametricReference
@@ -383,6 +422,7 @@ FamixJavaTVisitor >> visitFamixJavaParametricReference: aParametricReference [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixJavaPrimitiveType: aPrimitiveType [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitFamixTPrimitiveType: aPrimitiveType.
 	self visitFamixTTypeArgument: aPrimitiveType.
@@ -392,6 +432,7 @@ FamixJavaTVisitor >> visitFamixJavaPrimitiveType: aPrimitiveType [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixJavaReference: aReference [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitFamixTReference: aReference
 ]
@@ -399,6 +440,7 @@ FamixJavaTVisitor >> visitFamixJavaReference: aReference [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixJavaSourceAnchor: aSourceAnchor [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitFamixTSourceAnchor: aSourceAnchor
 ]
@@ -406,6 +448,7 @@ FamixJavaTVisitor >> visitFamixJavaSourceAnchor: aSourceAnchor [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixJavaSourceLanguage: aSourceLanguage [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitFamixTSourceLanguage: aSourceLanguage
 ]
@@ -413,6 +456,7 @@ FamixJavaTVisitor >> visitFamixJavaSourceLanguage: aSourceLanguage [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixJavaSourceTextAnchor: aSourceTextAnchor [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitFamixTHasImmediateSource: aSourceTextAnchor.
 	self visitFamixJavaSourceAnchor: aSourceTextAnchor
@@ -421,6 +465,7 @@ FamixJavaTVisitor >> visitFamixJavaSourceTextAnchor: aSourceTextAnchor [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixJavaSourcedEntity: aSourcedEntity [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitFamixTSourceEntity: aSourcedEntity
 ]
@@ -428,6 +473,7 @@ FamixJavaTVisitor >> visitFamixJavaSourcedEntity: aSourcedEntity [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixJavaTBound: aTBound [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitCollection: aTBound lowerBoundedWildcards.
 	self visitCollection: aTBound upperBoundedWildcards
@@ -436,6 +482,7 @@ FamixJavaTVisitor >> visitFamixJavaTBound: aTBound [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixJavaTBounded: aTBounded [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitEntity: aTBounded lowerBound.
 	self visitEntity: aTBounded upperBound
@@ -444,6 +491,7 @@ FamixJavaTVisitor >> visitFamixJavaTBounded: aTBounded [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixJavaTCanBeSynchronized: aTCanBeSynchronized [
 
+	<ignoreForCoverage>
 	<generated>
 
 ]
@@ -451,6 +499,7 @@ FamixJavaTVisitor >> visitFamixJavaTCanBeSynchronized: aTCanBeSynchronized [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixJavaTCanBeTransient: aTCanBeTransient [
 
+	<ignoreForCoverage>
 	<generated>
 
 ]
@@ -458,6 +507,7 @@ FamixJavaTVisitor >> visitFamixJavaTCanBeTransient: aTCanBeTransient [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixJavaTCanBeVolatile: aTCanBeVolatile [
 
+	<ignoreForCoverage>
 	<generated>
 
 ]
@@ -465,6 +515,7 @@ FamixJavaTVisitor >> visitFamixJavaTCanBeVolatile: aTCanBeVolatile [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixJavaTClassMetrics: aTClassMetrics [
 
+	<ignoreForCoverage>
 	<generated>
 
 ]
@@ -472,6 +523,7 @@ FamixJavaTVisitor >> visitFamixJavaTClassMetrics: aTClassMetrics [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixJavaTWithInterfaces: aTWithInterfaces [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitFamixTWithTypes: aTWithInterfaces
 ]
@@ -479,6 +531,7 @@ FamixJavaTVisitor >> visitFamixJavaTWithInterfaces: aTWithInterfaces [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixJavaType: aType [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitFamixJavaTBound: aType.
 	self visitFamixTType: aType.
@@ -489,6 +542,7 @@ FamixJavaTVisitor >> visitFamixJavaType: aType [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixJavaTypeParameter: aTypeParameter [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitFamixJavaTBounded: aTypeParameter.
 	self visitFamixTThrowable: aTypeParameter.
@@ -500,6 +554,7 @@ FamixJavaTVisitor >> visitFamixJavaTypeParameter: aTypeParameter [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixJavaUnknownVariable: anUnknownVariable [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitFamixTUnknownVariable: anUnknownVariable.
 	self visitFamixJavaVariable: anUnknownVariable
@@ -508,6 +563,7 @@ FamixJavaTVisitor >> visitFamixJavaUnknownVariable: anUnknownVariable [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixJavaVariable: aVariable [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitFamixTInvocationsReceiver: aVariable.
 	self visitFamixJavaNamedEntity: aVariable
@@ -516,6 +572,7 @@ FamixJavaTVisitor >> visitFamixJavaVariable: aVariable [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixJavaWildcard: aWildcard [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitFamixJavaTBounded: aWildcard.
 	self visitFamixTTypeArgument: aWildcard.
@@ -525,6 +582,7 @@ FamixJavaTVisitor >> visitFamixJavaWildcard: aWildcard [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixTAccess: aTAccess [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitFamixTAssociation: aTAccess.
 
@@ -535,6 +593,7 @@ FamixJavaTVisitor >> visitFamixTAccess: aTAccess [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixTAccessible: aTAccessible [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitCollection: aTAccessible incomingAccesses
 ]
@@ -542,6 +601,7 @@ FamixJavaTVisitor >> visitFamixTAccessible: aTAccessible [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixTAnnotationInstance: aTAnnotationInstance [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitTEntityMetaLevelDependency: aTAnnotationInstance.
 
@@ -553,6 +613,7 @@ FamixJavaTVisitor >> visitFamixTAnnotationInstance: aTAnnotationInstance [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixTAnnotationInstanceAttribute: aTAnnotationInstanceAttribute [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitTEntityMetaLevelDependency: aTAnnotationInstanceAttribute.
 
@@ -562,6 +623,7 @@ FamixJavaTVisitor >> visitFamixTAnnotationInstanceAttribute: aTAnnotationInstanc
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixTAnnotationType: aTAnnotationType [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitCollection: aTAnnotationType instances
 ]
@@ -569,6 +631,7 @@ FamixJavaTVisitor >> visitFamixTAnnotationType: aTAnnotationType [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixTAnnotationTypeAttribute: aTAnnotationTypeAttribute [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitFamixTAttribute: aTAnnotationTypeAttribute.
 
@@ -578,6 +641,7 @@ FamixJavaTVisitor >> visitFamixTAnnotationTypeAttribute: aTAnnotationTypeAttribu
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixTAssociation: aTAssociation [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitFamixTSourceEntity: aTAssociation.
 	self visitTAssociationMetaLevelDependency: aTAssociation.
@@ -589,6 +653,7 @@ FamixJavaTVisitor >> visitFamixTAssociation: aTAssociation [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixTAttribute: aTAttribute [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitFamixTStructuralEntity: aTAttribute.
 
@@ -598,6 +663,7 @@ FamixJavaTVisitor >> visitFamixTAttribute: aTAttribute [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixTCanBeAbstract: aTCanBeAbstract [
 
+	<ignoreForCoverage>
 	<generated>
 
 ]
@@ -605,6 +671,7 @@ FamixJavaTVisitor >> visitFamixTCanBeAbstract: aTCanBeAbstract [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixTCanBeClassSide: aTCanBeClassSide [
 
+	<ignoreForCoverage>
 	<generated>
 
 ]
@@ -612,6 +679,7 @@ FamixJavaTVisitor >> visitFamixTCanBeClassSide: aTCanBeClassSide [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixTCanBeFinal: aTCanBeFinal [
 
+	<ignoreForCoverage>
 	<generated>
 
 ]
@@ -619,6 +687,7 @@ FamixJavaTVisitor >> visitFamixTCanBeFinal: aTCanBeFinal [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixTCanBeStub: aTCanBeStub [
 
+	<ignoreForCoverage>
 	<generated>
 	"We should visit FamixTSourceEntity but all its users in this language already visit it in their superclasses so we skip the call here."
 ]
@@ -626,6 +695,7 @@ FamixJavaTVisitor >> visitFamixTCanBeStub: aTCanBeStub [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixTCanImplement: aTCanImplement [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitCollection: aTCanImplement interfaceImplementations
 ]
@@ -633,6 +703,7 @@ FamixJavaTVisitor >> visitFamixTCanImplement: aTCanImplement [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixTClass: aTClass [
 
+	<ignoreForCoverage>
 	<generated>
 	"We do not visit all behaviorals because some classes already visit it in their superclasses in this language implementation. Visiting them here also would cause a double visit of this trait."
 	({ FamixJavaException } includes: aTClass class)
@@ -653,6 +724,7 @@ FamixJavaTVisitor >> visitFamixTClass: aTClass [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixTClassMetrics: aTClassMetrics [
 
+	<ignoreForCoverage>
 	<generated>
 
 ]
@@ -660,6 +732,7 @@ FamixJavaTVisitor >> visitFamixTClassMetrics: aTClassMetrics [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixTComment: aTComment [
 
+	<ignoreForCoverage>
 	<generated>
 	"We should visit FamixTSourceEntity but all its users in this language already visit it in their superclasses so we skip the call here.".
 	self visitTEntityMetaLevelDependency: aTComment.
@@ -670,6 +743,7 @@ FamixJavaTVisitor >> visitFamixTComment: aTComment [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixTConcretization: aTConcretization [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitFamixTAssociation: aTConcretization.
 
@@ -681,6 +755,7 @@ FamixJavaTVisitor >> visitFamixTConcretization: aTConcretization [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixTEntityTyping: aTEntityTyping [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitFamixTAssociation: aTEntityTyping.
 
@@ -691,6 +766,7 @@ FamixJavaTVisitor >> visitFamixTEntityTyping: aTEntityTyping [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixTEnum: aTEnum [
 
+	<ignoreForCoverage>
 	<generated>
 	"We should visit FamixTType but all its users in this language already visit it in their superclasses so we skip the call here.".
 	self visitFamixTWithEnumValues: aTEnum
@@ -699,6 +775,7 @@ FamixJavaTVisitor >> visitFamixTEnum: aTEnum [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixTEnumValue: aTEnumValue [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitFamixTStructuralEntity: aTEnumValue.
 
@@ -708,6 +785,7 @@ FamixJavaTVisitor >> visitFamixTEnumValue: aTEnumValue [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixTException: aTException [
 
+	<ignoreForCoverage>
 	<generated>
 	"We should visit FamixTClass but all its users in this language already visit it in their superclasses so we skip the call here.".
 	self visitFamixTThrowable: aTException
@@ -716,6 +794,7 @@ FamixJavaTVisitor >> visitFamixTException: aTException [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixTFileAnchor: aTFileAnchor [
 
+	<ignoreForCoverage>
 	<generated>
 
 ]
@@ -723,6 +802,7 @@ FamixJavaTVisitor >> visitFamixTFileAnchor: aTFileAnchor [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixTHasImmediateSource: aTHasImmediateSource [
 
+	<ignoreForCoverage>
 	<generated>
 	"We should visit FamixTSourceAnchor but all its users in this language already visit it in their superclasses so we skip the call here."
 ]
@@ -730,6 +810,7 @@ FamixJavaTVisitor >> visitFamixTHasImmediateSource: aTHasImmediateSource [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixTHasKind: aTHasKind [
 
+	<ignoreForCoverage>
 	<generated>
 
 ]
@@ -737,6 +818,7 @@ FamixJavaTVisitor >> visitFamixTHasKind: aTHasKind [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixTHasSignature: aTHasSignature [
 
+	<ignoreForCoverage>
 	<generated>
 
 ]
@@ -744,6 +826,7 @@ FamixJavaTVisitor >> visitFamixTHasSignature: aTHasSignature [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixTHasVisibility: aTHasVisibility [
 
+	<ignoreForCoverage>
 	<generated>
 
 ]
@@ -751,6 +834,7 @@ FamixJavaTVisitor >> visitFamixTHasVisibility: aTHasVisibility [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixTImplementable: aTImplementable [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitCollection: aTImplementable implementations
 ]
@@ -758,6 +842,7 @@ FamixJavaTVisitor >> visitFamixTImplementable: aTImplementable [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixTImplementation: aTImplementation [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitFamixTAssociation: aTImplementation.
 
@@ -768,6 +853,7 @@ FamixJavaTVisitor >> visitFamixTImplementation: aTImplementation [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixTImplicitVariable: aTImplicitVariable [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitFamixTStructuralEntity: aTImplicitVariable.
 
@@ -777,6 +863,7 @@ FamixJavaTVisitor >> visitFamixTImplicitVariable: aTImplicitVariable [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixTImport: aTImport [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitFamixTAssociation: aTImport.
 
@@ -787,6 +874,7 @@ FamixJavaTVisitor >> visitFamixTImport: aTImport [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixTImportable: aTImportable [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitCollection: aTImportable incomingImports
 ]
@@ -794,6 +882,7 @@ FamixJavaTVisitor >> visitFamixTImportable: aTImportable [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixTIndexedFileNavigation: aTIndexedFileNavigation [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitFamixTFileAnchor: aTIndexedFileNavigation
 ]
@@ -801,6 +890,7 @@ FamixJavaTVisitor >> visitFamixTIndexedFileNavigation: aTIndexedFileNavigation [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixTInheritance: aTInheritance [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitFamixTAssociation: aTInheritance.
 
@@ -811,6 +901,7 @@ FamixJavaTVisitor >> visitFamixTInheritance: aTInheritance [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixTInvocable: aTInvocable [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitCollection: aTInvocable incomingInvocations
 ]
@@ -818,6 +909,7 @@ FamixJavaTVisitor >> visitFamixTInvocable: aTInvocable [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixTInvocation: aTInvocation [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitFamixTAssociation: aTInvocation.
 	self visitFamixTHasSignature: aTInvocation.
@@ -830,6 +922,7 @@ FamixJavaTVisitor >> visitFamixTInvocation: aTInvocation [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixTInvocationsReceiver: aTInvocationsReceiver [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitCollection: aTInvocationsReceiver receivingInvocations
 ]
@@ -837,6 +930,7 @@ FamixJavaTVisitor >> visitFamixTInvocationsReceiver: aTInvocationsReceiver [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixTLCOMMetrics: aTLCOMMetrics [
 
+	<ignoreForCoverage>
 	<generated>
 
 ]
@@ -844,6 +938,7 @@ FamixJavaTVisitor >> visitFamixTLCOMMetrics: aTLCOMMetrics [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixTLocalVariable: aTLocalVariable [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitFamixTStructuralEntity: aTLocalVariable.
 
@@ -853,6 +948,7 @@ FamixJavaTVisitor >> visitFamixTLocalVariable: aTLocalVariable [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixTMethod: aTMethod [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitFamixTHasSignature: aTMethod.
 	self visitFamixTInvocable: aTMethod.
@@ -871,6 +967,7 @@ FamixJavaTVisitor >> visitFamixTMethod: aTMethod [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixTMethodMetrics: aTMethodMetrics [
 
+	<ignoreForCoverage>
 	<generated>
 
 ]
@@ -878,6 +975,7 @@ FamixJavaTVisitor >> visitFamixTMethodMetrics: aTMethodMetrics [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixTNamedEntity: aTNamedEntity [
 
+	<ignoreForCoverage>
 	<generated>
 
 ]
@@ -885,6 +983,7 @@ FamixJavaTVisitor >> visitFamixTNamedEntity: aTNamedEntity [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixTPackage: aTPackage [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitFamixTCanBeStub: aTPackage.
 	"We should visit FamixTNamedEntity but all its users in this language already visit it in their superclasses so we skip the call here.".
@@ -896,6 +995,7 @@ FamixJavaTVisitor >> visitFamixTPackage: aTPackage [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixTPackageable: aTPackageable [
 
+	<ignoreForCoverage>
 	<generated>
 
 ]
@@ -903,6 +1003,7 @@ FamixJavaTVisitor >> visitFamixTPackageable: aTPackageable [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixTParameter: aTParameter [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitFamixTStructuralEntity: aTParameter.
 
@@ -912,6 +1013,7 @@ FamixJavaTVisitor >> visitFamixTParameter: aTParameter [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixTParametricAssociation: aTParametricAssociation [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitCollection: aTParametricAssociation concretizations
 ]
@@ -919,6 +1021,7 @@ FamixJavaTVisitor >> visitFamixTParametricAssociation: aTParametricAssociation [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixTParametricEntity: aTParametricEntity [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitCollection: aTParametricEntity typeParameters
 ]
@@ -926,6 +1029,7 @@ FamixJavaTVisitor >> visitFamixTParametricEntity: aTParametricEntity [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixTPrimitiveType: aTPrimitiveType [
 
+	<ignoreForCoverage>
 	<generated>
 	"We should visit FamixTType but all its users in this language already visit it in their superclasses so we skip the call here."
 ]
@@ -933,6 +1037,7 @@ FamixJavaTVisitor >> visitFamixTPrimitiveType: aTPrimitiveType [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixTReference: aTReference [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitFamixTAssociation: aTReference.
 
@@ -943,6 +1048,7 @@ FamixJavaTVisitor >> visitFamixTReference: aTReference [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixTReferenceable: aTReferenceable [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitCollection: aTReferenceable incomingReferences
 ]
@@ -950,6 +1056,7 @@ FamixJavaTVisitor >> visitFamixTReferenceable: aTReferenceable [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixTSourceAnchor: aTSourceAnchor [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitEntity: aTSourceAnchor element
 ]
@@ -957,6 +1064,7 @@ FamixJavaTVisitor >> visitFamixTSourceAnchor: aTSourceAnchor [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixTSourceEntity: aTSourceEntity [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitEntity: aTSourceEntity sourceAnchor
 ]
@@ -964,6 +1072,7 @@ FamixJavaTVisitor >> visitFamixTSourceEntity: aTSourceEntity [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixTSourceLanguage: aTSourceLanguage [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitCollection: aTSourceLanguage sourcedEntities
 ]
@@ -971,6 +1080,7 @@ FamixJavaTVisitor >> visitFamixTSourceLanguage: aTSourceLanguage [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixTStructuralEntity: aTStructuralEntity [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitFamixTAccessible: aTStructuralEntity.
 	self visitFamixTCanBeStub: aTStructuralEntity.
@@ -982,6 +1092,7 @@ FamixJavaTVisitor >> visitFamixTStructuralEntity: aTStructuralEntity [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixTThrowable: aTThrowable [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitCollection: aTThrowable catchingEntities.
 	self visitCollection: aTThrowable declaringEntities.
@@ -991,6 +1102,7 @@ FamixJavaTVisitor >> visitFamixTThrowable: aTThrowable [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixTType: aTType [
 
+	<ignoreForCoverage>
 	<generated>
 	"We do not visit all behaviorals because some classes already visit it in their superclasses in this language implementation. Visiting them here also would cause a double visit of this trait."
 	({ FamixJavaClass . FamixJavaEnum . FamixJavaException . FamixJavaPrimitiveType } includes: aTType class)
@@ -1007,6 +1119,7 @@ FamixJavaTVisitor >> visitFamixTType: aTType [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixTTypeArgument: aTTypeArgument [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitCollection: aTTypeArgument outgoingConcretizations
 ]
@@ -1014,6 +1127,7 @@ FamixJavaTVisitor >> visitFamixTTypeArgument: aTTypeArgument [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixTTypeParameter: aTTypeParameter [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitCollection: aTTypeParameter concretizations.
 	self visitEntity: aTTypeParameter genericEntity
@@ -1022,6 +1136,7 @@ FamixJavaTVisitor >> visitFamixTTypeParameter: aTTypeParameter [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixTTypedEntity: aTTypedEntity [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitEntity: aTTypedEntity typing
 ]
@@ -1029,6 +1144,7 @@ FamixJavaTVisitor >> visitFamixTTypedEntity: aTTypedEntity [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixTUnknownVariable: aTUnknownVariable [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitFamixTStructuralEntity: aTUnknownVariable
 ]
@@ -1036,6 +1152,7 @@ FamixJavaTVisitor >> visitFamixTUnknownVariable: aTUnknownVariable [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixTWithAccesses: aTWithAccesses [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitCollection: aTWithAccesses accesses
 ]
@@ -1043,6 +1160,7 @@ FamixJavaTVisitor >> visitFamixTWithAccesses: aTWithAccesses [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixTWithAnnotationInstances: aTWithAnnotationInstances [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitCollection: aTWithAnnotationInstances annotationInstances
 ]
@@ -1050,6 +1168,7 @@ FamixJavaTVisitor >> visitFamixTWithAnnotationInstances: aTWithAnnotationInstanc
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixTWithAnnotationTypes: aTWithAnnotationTypes [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitCollection: aTWithAnnotationTypes definedAnnotationTypes
 ]
@@ -1057,6 +1176,7 @@ FamixJavaTVisitor >> visitFamixTWithAnnotationTypes: aTWithAnnotationTypes [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixTWithAttributes: aTWithAttributes [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitCollection: aTWithAttributes attributes
 ]
@@ -1064,6 +1184,7 @@ FamixJavaTVisitor >> visitFamixTWithAttributes: aTWithAttributes [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixTWithClasses: aTWithClasses [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitFamixTWithTypes: aTWithClasses
 ]
@@ -1071,6 +1192,7 @@ FamixJavaTVisitor >> visitFamixTWithClasses: aTWithClasses [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixTWithComments: aTWithComments [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitCollection: aTWithComments comments
 ]
@@ -1078,6 +1200,7 @@ FamixJavaTVisitor >> visitFamixTWithComments: aTWithComments [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixTWithEnumValues: aTWithEnumValues [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitCollection: aTWithEnumValues enumValues
 ]
@@ -1085,6 +1208,7 @@ FamixJavaTVisitor >> visitFamixTWithEnumValues: aTWithEnumValues [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixTWithExceptions: aTWithExceptions [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitCollection: aTWithExceptions caughtExceptions.
 	self visitCollection: aTWithExceptions declaredExceptions.
@@ -1094,6 +1218,7 @@ FamixJavaTVisitor >> visitFamixTWithExceptions: aTWithExceptions [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixTWithImplicitVariables: aTWithImplicitVariables [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitCollection: aTWithImplicitVariables implicitVariables
 ]
@@ -1101,6 +1226,7 @@ FamixJavaTVisitor >> visitFamixTWithImplicitVariables: aTWithImplicitVariables [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixTWithImports: aTWithImports [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitCollection: aTWithImports imports
 ]
@@ -1108,6 +1234,7 @@ FamixJavaTVisitor >> visitFamixTWithImports: aTWithImports [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixTWithInheritances: aTWithInheritances [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitCollection: aTWithInheritances superInheritances.
 	self visitCollection: aTWithInheritances subInheritances
@@ -1116,6 +1243,7 @@ FamixJavaTVisitor >> visitFamixTWithInheritances: aTWithInheritances [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixTWithInvocations: aTWithInvocations [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitCollection: aTWithInvocations outgoingInvocations
 ]
@@ -1123,6 +1251,7 @@ FamixJavaTVisitor >> visitFamixTWithInvocations: aTWithInvocations [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixTWithLocalVariables: aTWithLocalVariables [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitCollection: aTWithLocalVariables localVariables
 ]
@@ -1130,6 +1259,7 @@ FamixJavaTVisitor >> visitFamixTWithLocalVariables: aTWithLocalVariables [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixTWithMethods: aTWithMethods [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitCollection: aTWithMethods methods
 ]
@@ -1137,6 +1267,7 @@ FamixJavaTVisitor >> visitFamixTWithMethods: aTWithMethods [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixTWithParameters: aTWithParameters [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitCollection: aTWithParameters parameters
 ]
@@ -1144,6 +1275,7 @@ FamixJavaTVisitor >> visitFamixTWithParameters: aTWithParameters [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixTWithReferences: aTWithReferences [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitCollection: aTWithReferences outgoingReferences
 ]
@@ -1151,6 +1283,7 @@ FamixJavaTVisitor >> visitFamixTWithReferences: aTWithReferences [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixTWithStatements: aTWithStatements [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitFamixTCanBeStub: aTWithStatements.
 	self visitFamixTWithAccesses: aTWithStatements.
@@ -1161,6 +1294,7 @@ FamixJavaTVisitor >> visitFamixTWithStatements: aTWithStatements [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitFamixTWithTypes: aTWithTypes [
 
+	<ignoreForCoverage>
 	<generated>
 	self visitCollection: aTWithTypes types
 ]
@@ -1168,6 +1302,7 @@ FamixJavaTVisitor >> visitFamixTWithTypes: aTWithTypes [
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitTAssociationMetaLevelDependency: aTAssociationMetaLevelDependency [
 
+	<ignoreForCoverage>
 	<generated>
 
 ]
@@ -1175,6 +1310,7 @@ FamixJavaTVisitor >> visitTAssociationMetaLevelDependency: aTAssociationMetaLeve
 { #category : 'visiting' }
 FamixJavaTVisitor >> visitTEntityMetaLevelDependency: aTEntityMetaLevelDependency [
 
+	<ignoreForCoverage>
 	<generated>
 
 ]

--- a/src/Famix-Java-Entities/FamixJavaTWithInterfaces.trait.st
+++ b/src/Famix-Java-Entities/FamixJavaTWithInterfaces.trait.st
@@ -24,6 +24,7 @@ Trait {
 { #category : 'meta' }
 FamixJavaTWithInterfaces classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TWithInterfaces super: #Object>
 	<package: #'Famix-Java-Entities'>
 	<generated>

--- a/src/Famix-Java-Entities/FamixJavaType.class.st
+++ b/src/Famix-Java-Entities/FamixJavaType.class.st
@@ -48,6 +48,7 @@ Class {
 { #category : 'meta' }
 FamixJavaType class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Type super: #FamixJavaContainerEntity>
 	<package: #'Famix-Java-Entities'>
 	<generated>

--- a/src/Famix-Java-Entities/FamixJavaTypeParameter.class.st
+++ b/src/Famix-Java-Entities/FamixJavaTypeParameter.class.st
@@ -38,6 +38,7 @@ Class {
 { #category : 'meta' }
 FamixJavaTypeParameter class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TypeParameter super: #FamixJavaType>
 	<package: #'Famix-Java-Entities'>
 	<generated>

--- a/src/Famix-Java-Entities/FamixJavaUnknownVariable.class.st
+++ b/src/Famix-Java-Entities/FamixJavaUnknownVariable.class.st
@@ -40,6 +40,7 @@ Class {
 { #category : 'meta' }
 FamixJavaUnknownVariable class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #UnknownVariable super: #FamixJavaVariable>
 	<package: #'Famix-Java-Entities'>
 	<generated>

--- a/src/Famix-Java-Entities/FamixJavaVariable.class.st
+++ b/src/Famix-Java-Entities/FamixJavaVariable.class.st
@@ -23,6 +23,7 @@ Class {
 { #category : 'meta' }
 FamixJavaVariable class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Variable super: #FamixJavaNamedEntity>
 	<package: #'Famix-Java-Entities'>
 	<generated>
@@ -32,6 +33,7 @@ FamixJavaVariable class >> annotation [
 { #category : 'testing' }
 FamixJavaVariable class >> isAbstract [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self == FamixJavaVariable
 ]

--- a/src/Famix-Java-Entities/FamixJavaWildcard.class.st
+++ b/src/Famix-Java-Entities/FamixJavaWildcard.class.st
@@ -29,6 +29,7 @@ Class {
 { #category : 'meta' }
 FamixJavaWildcard class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Wildcard super: #FamixJavaType>
 	<package: #'Famix-Java-Entities'>
 	<generated>

--- a/src/Famix-MetamodelBuilder-Core/FmxMBMethodsFactory.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxMBMethodsFactory.class.st
@@ -17,6 +17,8 @@ Class {
 FmxMBMethodsFactory class >> addToCollectionFor: aName [
 
 	^ 'add{1}: anObject
+
+	<ignoreForCoverage>
 	<generated>
 	^ self {2} add: anObject' format: {
 			  aName capitalized asSingular.
@@ -29,6 +31,8 @@ FmxMBMethodsFactory class >> allSubmetamodelsPackagesNamesFor: subBuilders [
 	^ String streamContents: [ :stream |
 			  | packages |
 			  stream nextPutAll: 'allSubmetamodelsPackagesNames
+
+	<ignoreForCoverage>
 	<generated>
 	^ #('.
 
@@ -44,6 +48,7 @@ FmxMBMethodsFactory class >> annotationFor: aName super: superclassName package:
 
 	^ 'annotation
 
+	<ignoreForCoverage>
 	<FMClass: #{1} super: #{2}>
 	<package: {3}>
 	<generated>{4}' format: {
@@ -61,6 +66,8 @@ FmxMBMethodsFactory class >> annotationFor: aName super: superclassName package:
 FmxMBMethodsFactory class >> canBeImportedFromFile [
 
 	^ 'canBeImportedFromFile
+
+	<ignoreForCoverage>
 	<generated>
 	^true'
 ]
@@ -74,6 +81,7 @@ FmxMBMethodsFactory class >> equalsForVariableNamed: variableName properties: pr
 				  << variableName;
 				  << '
 
+	<ignoreForCoverage>
 	<generated>
 	^ ';
 				  << variableName;
@@ -111,12 +119,13 @@ FmxMBMethodsFactory class >> getTypedProperty: aProperty [
 			  s
 				  nextPutAll: aProperty name;
 				  cr;
-				  cr.
-			  s
+				  cr;
 				  tab;
 				  nextPutAll: propertyDefinition;
-				  cr.
-			  s
+				  cr;
+				  tab;
+				  nextPutAll: '<ignoreForCoverage>';
+				  cr;
 				  tab;
 				  nextPutAll: '<generated>';
 				  cr.
@@ -153,6 +162,8 @@ FmxMBMethodsFactory class >> getTypedProperty: aProperty [
 FmxMBMethodsFactory class >> groupAnnotationNamed: aName [
 
 	^ 'annotation{1}
+
+	<ignoreForCoverage>
 	<generated>
 	<mooseGroup>
 	^ {1}' format: { aName }
@@ -165,6 +176,7 @@ FmxMBMethodsFactory class >> hashForProperties: properties [
 			  stream << 'hash'.
 			  stream << '
 
+	<ignoreForCoverage>
 	<generated>
 	^ '.
 			  stream
@@ -184,6 +196,7 @@ FmxMBMethodsFactory class >> importAssociationNamed: aName [
 
 	^ 'import{1}
 
+	<ignoreForCoverage>
 	<generated>
 	^ self importAssociation: (self class fm3ClassNamed: #{1})' format: { aName }
 ]
@@ -193,6 +206,7 @@ FmxMBMethodsFactory class >> importEntityNamed: aName [
 
 	^ 'import{1}
 
+	<ignoreForCoverage>
 	<generated>
 	^ self importConcreteEntity: (self class fm3ClassNamed: #{1})' format: { aName }
 ]
@@ -202,6 +216,7 @@ FmxMBMethodsFactory class >> importedMetamodelForPrefix: prefix [
 
 	^ 'importedMetamodel
 
+	<ignoreForCoverage>
 	<generated>
 	^ {1}Model metamodel' format: { prefix }
 ]
@@ -211,6 +226,7 @@ FmxMBMethodsFactory class >> importingClassNamed: aName [
 
 	^ 'importingContextClass
 
+	<ignoreForCoverage>
 	<generated>
 	^ {1}' format: { aName }
 ]
@@ -220,6 +236,7 @@ FmxMBMethodsFactory class >> instantiate: aClass [
 
 	^ 'new{1}
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: {2} new' format: {
 			  aClass name.
@@ -231,6 +248,7 @@ FmxMBMethodsFactory class >> instantiateNamed: aClass [
 
 	^ 'new{1}Named: aName
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: ({2} named: aName)' format: {
 			  aClass name.
@@ -242,6 +260,7 @@ FmxMBMethodsFactory class >> isAbstractFor: className [
 
 	^ 'isAbstract
 
+	<ignoreForCoverage>
 	<generated>
 	^ self == {1}' format: { className }
 ]
@@ -251,6 +270,7 @@ FmxMBMethodsFactory class >> metamodelFor: className [
 
 	^ 'metamodel
 
+	<ignoreForCoverage>
 	<generated>
 	^ {1} metamodel' format: { className }
 ]
@@ -260,6 +280,7 @@ FmxMBMethodsFactory class >> setTypedProperty: aName remote: aBoolean [
 
 	^ (String streamContents: [ :stream |
 			   stream nextPutAll: '{1}: anObject
+	<ignoreForCoverage>
 	<generated>
 	'.
 			   aBoolean
@@ -272,6 +293,7 @@ FmxMBMethodsFactory class >> shouldImportNamed: aName [
 
 	^ 'shouldImport{1}
 
+	<ignoreForCoverage>
 	<generated>
 	^ self shouldImport: #{1}' format: { aName }
 ]
@@ -281,6 +303,7 @@ FmxMBMethodsFactory class >> testReturning: aBoolean for: aSelector [
 
 	^ '{1}
 
+	<ignoreForCoverage>
 	<generated>
 	^ {2}' format: {
 			  aSelector.

--- a/src/Famix-MetamodelBuilder-Core/FmxMBRelationAccessorsGenerationStrategy.class.st
+++ b/src/Famix-MetamodelBuilder-Core/FmxMBRelationAccessorsGenerationStrategy.class.st
@@ -40,8 +40,10 @@ FmxMBRelationAccessorsGenerationStrategy >> generateGetterCodeFor: aRelation [
 				  nextPutAll: aRelation oppositeName;
 				  nextPutAll: '"';
 				  cr;
-				  cr.
-			  s
+				  cr;
+				  tab;
+				  nextPutAll: '<ignoreForCoverage>';
+				  cr;
 				  tab;
 				  nextPutAll: '<generated>';
 				  cr.
@@ -88,8 +90,10 @@ FmxMBRelationAccessorsGenerationStrategy >> generateSetterCodeFor: aRelation [
 				  nextPutAll: aRelation name;
 				  nextPutAll: ': anObject';
 				  cr;
-				  cr.
-			  s
+				  cr;
+				  tab;
+				  nextPutAll: '<ignoreForCoverage>';
+				  cr;
 				  tab;
 				  nextPutAll: '<generated>';
 				  cr.

--- a/src/Famix-PharoSmalltalk-Entities/FamixStAccess.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStAccess.class.st
@@ -41,6 +41,7 @@ Class {
 { #category : 'meta' }
 FamixStAccess class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Access super: #FamixStEntity>
 	<package: #'Famix-PharoSmalltalk-Entities'>
 	<generated>

--- a/src/Famix-PharoSmalltalk-Entities/FamixStAnnotationInstance.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStAnnotationInstance.class.st
@@ -29,6 +29,7 @@ Class {
 { #category : 'meta' }
 FamixStAnnotationInstance class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #AnnotationInstance super: #FamixStSourcedEntity>
 	<package: #'Famix-PharoSmalltalk-Entities'>
 	<generated>

--- a/src/Famix-PharoSmalltalk-Entities/FamixStAnnotationInstanceAttribute.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStAnnotationInstanceAttribute.class.st
@@ -34,6 +34,7 @@ Class {
 { #category : 'meta' }
 FamixStAnnotationInstanceAttribute class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #AnnotationInstanceAttribute super: #FamixStSourcedEntity>
 	<package: #'Famix-PharoSmalltalk-Entities'>
 	<generated>

--- a/src/Famix-PharoSmalltalk-Entities/FamixStAnnotationType.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStAnnotationType.class.st
@@ -34,6 +34,7 @@ Class {
 { #category : 'meta' }
 FamixStAnnotationType class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #AnnotationType super: #FamixStNamedEntity>
 	<package: #'Famix-PharoSmalltalk-Entities'>
 	<generated>

--- a/src/Famix-PharoSmalltalk-Entities/FamixStAnnotationTypeAttribute.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStAnnotationTypeAttribute.class.st
@@ -46,6 +46,7 @@ Class {
 { #category : 'meta' }
 FamixStAnnotationTypeAttribute class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #AnnotationTypeAttribute super: #FamixStSourcedEntity>
 	<package: #'Famix-PharoSmalltalk-Entities'>
 	<generated>

--- a/src/Famix-PharoSmalltalk-Entities/FamixStAttribute.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStAttribute.class.st
@@ -47,6 +47,7 @@ Class {
 { #category : 'meta' }
 FamixStAttribute class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Attribute super: #FamixStNamedEntity>
 	<package: #'Famix-PharoSmalltalk-Entities'>
 	<generated>

--- a/src/Famix-PharoSmalltalk-Entities/FamixStClass.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStClass.class.st
@@ -57,6 +57,7 @@ Class {
 { #category : 'meta' }
 FamixStClass class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Class super: #FamixStNamedEntity>
 	<package: #'Famix-PharoSmalltalk-Entities'>
 	<generated>

--- a/src/Famix-PharoSmalltalk-Entities/FamixStComment.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStComment.class.st
@@ -28,6 +28,7 @@ Class {
 { #category : 'meta' }
 FamixStComment class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Comment super: #FamixStSourcedEntity>
 	<package: #'Famix-PharoSmalltalk-Entities'>
 	<generated>

--- a/src/Famix-PharoSmalltalk-Entities/FamixStEntity.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStEntity.class.st
@@ -9,6 +9,7 @@ Class {
 { #category : 'meta' }
 FamixStEntity class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Entity super: #MooseEntity>
 	<package: #'Famix-PharoSmalltalk-Entities'>
 	<generated>
@@ -18,6 +19,7 @@ FamixStEntity class >> annotation [
 { #category : 'testing' }
 FamixStEntity class >> isAbstract [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self == FamixStEntity
 ]
@@ -25,6 +27,7 @@ FamixStEntity class >> isAbstract [
 { #category : 'meta' }
 FamixStEntity class >> metamodel [
 
+	<ignoreForCoverage>
 	<generated>
 	^ FamixStModel metamodel
 ]
@@ -32,6 +35,7 @@ FamixStEntity class >> metamodel [
 { #category : 'testing' }
 FamixStEntity >> canBeStub [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -39,6 +43,7 @@ FamixStEntity >> canBeStub [
 { #category : 'testing' }
 FamixStEntity >> hasImmediateSource [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -46,6 +51,7 @@ FamixStEntity >> hasImmediateSource [
 { #category : 'testing' }
 FamixStEntity >> isAccess [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -53,6 +59,7 @@ FamixStEntity >> isAccess [
 { #category : 'testing' }
 FamixStEntity >> isAssociation [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -60,6 +67,7 @@ FamixStEntity >> isAssociation [
 { #category : 'testing' }
 FamixStEntity >> isAttribute [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -67,6 +75,7 @@ FamixStEntity >> isAttribute [
 { #category : 'testing' }
 FamixStEntity >> isBehavioural [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -74,6 +83,7 @@ FamixStEntity >> isBehavioural [
 { #category : 'testing' }
 FamixStEntity >> isClass [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -81,6 +91,7 @@ FamixStEntity >> isClass [
 { #category : 'testing' }
 FamixStEntity >> isComment [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -88,6 +99,7 @@ FamixStEntity >> isComment [
 { #category : 'testing' }
 FamixStEntity >> isGlobalVariable [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -95,6 +107,7 @@ FamixStEntity >> isGlobalVariable [
 { #category : 'testing' }
 FamixStEntity >> isImplicitVariable [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -102,6 +115,7 @@ FamixStEntity >> isImplicitVariable [
 { #category : 'testing' }
 FamixStEntity >> isInheritance [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -109,6 +123,7 @@ FamixStEntity >> isInheritance [
 { #category : 'testing' }
 FamixStEntity >> isInvocation [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -116,6 +131,7 @@ FamixStEntity >> isInvocation [
 { #category : 'testing' }
 FamixStEntity >> isLocalVariable [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -123,6 +139,7 @@ FamixStEntity >> isLocalVariable [
 { #category : 'testing' }
 FamixStEntity >> isMethod [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -130,6 +147,7 @@ FamixStEntity >> isMethod [
 { #category : 'testing' }
 FamixStEntity >> isNamedEntity [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -137,6 +155,7 @@ FamixStEntity >> isNamedEntity [
 { #category : 'testing' }
 FamixStEntity >> isNamespace [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -144,6 +163,7 @@ FamixStEntity >> isNamespace [
 { #category : 'testing' }
 FamixStEntity >> isPackage [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -157,6 +177,7 @@ FamixStEntity >> isParametricEntity [
 { #category : 'testing' }
 FamixStEntity >> isQueryable [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -164,6 +185,7 @@ FamixStEntity >> isQueryable [
 { #category : 'testing' }
 FamixStEntity >> isReference [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -176,6 +198,7 @@ FamixStEntity >> isSharedVariable [
 { #category : 'testing' }
 FamixStEntity >> isStructuralEntity [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -183,6 +206,7 @@ FamixStEntity >> isStructuralEntity [
 { #category : 'testing' }
 FamixStEntity >> isType [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]

--- a/src/Famix-PharoSmalltalk-Entities/FamixStEntityTyping.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStEntityTyping.class.st
@@ -35,6 +35,7 @@ Class {
 { #category : 'meta' }
 FamixStEntityTyping class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #EntityTyping super: #FamixStEntity>
 	<package: #'Famix-PharoSmalltalk-Entities'>
 	<generated>

--- a/src/Famix-PharoSmalltalk-Entities/FamixStGlobalVariable.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStGlobalVariable.class.st
@@ -46,6 +46,7 @@ Class {
 { #category : 'meta' }
 FamixStGlobalVariable class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #GlobalVariable super: #FamixStNamedEntity>
 	<package: #'Famix-PharoSmalltalk-Entities'>
 	<generated>

--- a/src/Famix-PharoSmalltalk-Entities/FamixStImplicitVariable.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStImplicitVariable.class.st
@@ -46,6 +46,7 @@ Class {
 { #category : 'meta' }
 FamixStImplicitVariable class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #ImplicitVariable super: #FamixStNamedEntity>
 	<package: #'Famix-PharoSmalltalk-Entities'>
 	<generated>

--- a/src/Famix-PharoSmalltalk-Entities/FamixStImportingContext.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStImportingContext.class.st
@@ -15,6 +15,7 @@ Class {
 { #category : 'accessing' }
 FamixStImportingContext class >> importedMetamodel [
 
+	<ignoreForCoverage>
 	<generated>
 	^ FamixStModel metamodel
 ]
@@ -22,6 +23,7 @@ FamixStImportingContext class >> importedMetamodel [
 { #category : 'importing' }
 FamixStImportingContext >> importAccess [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self importAssociation: (self class fm3ClassNamed: #Access)
 ]
@@ -29,6 +31,7 @@ FamixStImportingContext >> importAccess [
 { #category : 'importing' }
 FamixStImportingContext >> importAnnotationInstance [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self importConcreteEntity: (self class fm3ClassNamed: #AnnotationInstance)
 ]
@@ -36,6 +39,7 @@ FamixStImportingContext >> importAnnotationInstance [
 { #category : 'importing' }
 FamixStImportingContext >> importAnnotationInstanceAttribute [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self importConcreteEntity: (self class fm3ClassNamed: #AnnotationInstanceAttribute)
 ]
@@ -43,6 +47,7 @@ FamixStImportingContext >> importAnnotationInstanceAttribute [
 { #category : 'importing' }
 FamixStImportingContext >> importAnnotationType [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self importConcreteEntity: (self class fm3ClassNamed: #AnnotationType)
 ]
@@ -50,6 +55,7 @@ FamixStImportingContext >> importAnnotationType [
 { #category : 'importing' }
 FamixStImportingContext >> importAnnotationTypeAttribute [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self importConcreteEntity: (self class fm3ClassNamed: #AnnotationTypeAttribute)
 ]
@@ -57,6 +63,7 @@ FamixStImportingContext >> importAnnotationTypeAttribute [
 { #category : 'importing' }
 FamixStImportingContext >> importAttribute [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self importConcreteEntity: (self class fm3ClassNamed: #Attribute)
 ]
@@ -64,6 +71,7 @@ FamixStImportingContext >> importAttribute [
 { #category : 'importing' }
 FamixStImportingContext >> importClass [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self importConcreteEntity: (self class fm3ClassNamed: #Class)
 ]
@@ -71,6 +79,7 @@ FamixStImportingContext >> importClass [
 { #category : 'importing' }
 FamixStImportingContext >> importComment [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self importConcreteEntity: (self class fm3ClassNamed: #Comment)
 ]
@@ -78,6 +87,7 @@ FamixStImportingContext >> importComment [
 { #category : 'importing' }
 FamixStImportingContext >> importEntityTyping [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self importAssociation: (self class fm3ClassNamed: #EntityTyping)
 ]
@@ -85,6 +95,7 @@ FamixStImportingContext >> importEntityTyping [
 { #category : 'importing' }
 FamixStImportingContext >> importGlobalVariable [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self importConcreteEntity: (self class fm3ClassNamed: #GlobalVariable)
 ]
@@ -92,6 +103,7 @@ FamixStImportingContext >> importGlobalVariable [
 { #category : 'importing' }
 FamixStImportingContext >> importImplicitVariable [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self importConcreteEntity: (self class fm3ClassNamed: #ImplicitVariable)
 ]
@@ -99,6 +111,7 @@ FamixStImportingContext >> importImplicitVariable [
 { #category : 'importing' }
 FamixStImportingContext >> importInheritance [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self importAssociation: (self class fm3ClassNamed: #Inheritance)
 ]
@@ -106,6 +119,7 @@ FamixStImportingContext >> importInheritance [
 { #category : 'importing' }
 FamixStImportingContext >> importInvocation [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self importAssociation: (self class fm3ClassNamed: #Invocation)
 ]
@@ -113,6 +127,7 @@ FamixStImportingContext >> importInvocation [
 { #category : 'importing' }
 FamixStImportingContext >> importLocalVariable [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self importConcreteEntity: (self class fm3ClassNamed: #LocalVariable)
 ]
@@ -120,6 +135,7 @@ FamixStImportingContext >> importLocalVariable [
 { #category : 'importing' }
 FamixStImportingContext >> importMethod [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self importConcreteEntity: (self class fm3ClassNamed: #Method)
 ]
@@ -127,6 +143,7 @@ FamixStImportingContext >> importMethod [
 { #category : 'importing' }
 FamixStImportingContext >> importNamespace [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self importConcreteEntity: (self class fm3ClassNamed: #Namespace)
 ]
@@ -134,6 +151,7 @@ FamixStImportingContext >> importNamespace [
 { #category : 'importing' }
 FamixStImportingContext >> importPackage [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self importConcreteEntity: (self class fm3ClassNamed: #Package)
 ]
@@ -141,6 +159,7 @@ FamixStImportingContext >> importPackage [
 { #category : 'importing' }
 FamixStImportingContext >> importParameter [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self importConcreteEntity: (self class fm3ClassNamed: #Parameter)
 ]
@@ -148,6 +167,7 @@ FamixStImportingContext >> importParameter [
 { #category : 'importing' }
 FamixStImportingContext >> importPharoEntitySourceAnchor [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self importConcreteEntity: (self class fm3ClassNamed: #PharoEntitySourceAnchor)
 ]
@@ -155,6 +175,7 @@ FamixStImportingContext >> importPharoEntitySourceAnchor [
 { #category : 'importing' }
 FamixStImportingContext >> importReference [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self importAssociation: (self class fm3ClassNamed: #Reference)
 ]
@@ -162,6 +183,7 @@ FamixStImportingContext >> importReference [
 { #category : 'importing' }
 FamixStImportingContext >> importSourceLanguage [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self importConcreteEntity: (self class fm3ClassNamed: #SourceLanguage)
 ]
@@ -169,6 +191,7 @@ FamixStImportingContext >> importSourceLanguage [
 { #category : 'importing' }
 FamixStImportingContext >> importSourceTextAnchor [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self importConcreteEntity: (self class fm3ClassNamed: #SourceTextAnchor)
 ]
@@ -176,6 +199,7 @@ FamixStImportingContext >> importSourceTextAnchor [
 { #category : 'importing' }
 FamixStImportingContext >> importUnknownVariable [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self importConcreteEntity: (self class fm3ClassNamed: #UnknownVariable)
 ]
@@ -183,6 +207,7 @@ FamixStImportingContext >> importUnknownVariable [
 { #category : 'testing' }
 FamixStImportingContext >> shouldImportAccess [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self shouldImport: #Access
 ]
@@ -190,6 +215,7 @@ FamixStImportingContext >> shouldImportAccess [
 { #category : 'testing' }
 FamixStImportingContext >> shouldImportAnnotationInstance [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self shouldImport: #AnnotationInstance
 ]
@@ -197,6 +223,7 @@ FamixStImportingContext >> shouldImportAnnotationInstance [
 { #category : 'testing' }
 FamixStImportingContext >> shouldImportAnnotationInstanceAttribute [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self shouldImport: #AnnotationInstanceAttribute
 ]
@@ -204,6 +231,7 @@ FamixStImportingContext >> shouldImportAnnotationInstanceAttribute [
 { #category : 'testing' }
 FamixStImportingContext >> shouldImportAnnotationType [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self shouldImport: #AnnotationType
 ]
@@ -211,6 +239,7 @@ FamixStImportingContext >> shouldImportAnnotationType [
 { #category : 'testing' }
 FamixStImportingContext >> shouldImportAnnotationTypeAttribute [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self shouldImport: #AnnotationTypeAttribute
 ]
@@ -218,6 +247,7 @@ FamixStImportingContext >> shouldImportAnnotationTypeAttribute [
 { #category : 'testing' }
 FamixStImportingContext >> shouldImportAttribute [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self shouldImport: #Attribute
 ]
@@ -225,6 +255,7 @@ FamixStImportingContext >> shouldImportAttribute [
 { #category : 'testing' }
 FamixStImportingContext >> shouldImportClass [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self shouldImport: #Class
 ]
@@ -232,6 +263,7 @@ FamixStImportingContext >> shouldImportClass [
 { #category : 'testing' }
 FamixStImportingContext >> shouldImportComment [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self shouldImport: #Comment
 ]
@@ -239,6 +271,7 @@ FamixStImportingContext >> shouldImportComment [
 { #category : 'testing' }
 FamixStImportingContext >> shouldImportEntityTyping [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self shouldImport: #EntityTyping
 ]
@@ -246,6 +279,7 @@ FamixStImportingContext >> shouldImportEntityTyping [
 { #category : 'testing' }
 FamixStImportingContext >> shouldImportGlobalVariable [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self shouldImport: #GlobalVariable
 ]
@@ -253,6 +287,7 @@ FamixStImportingContext >> shouldImportGlobalVariable [
 { #category : 'testing' }
 FamixStImportingContext >> shouldImportImplicitVariable [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self shouldImport: #ImplicitVariable
 ]
@@ -260,6 +295,7 @@ FamixStImportingContext >> shouldImportImplicitVariable [
 { #category : 'testing' }
 FamixStImportingContext >> shouldImportInheritance [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self shouldImport: #Inheritance
 ]
@@ -267,6 +303,7 @@ FamixStImportingContext >> shouldImportInheritance [
 { #category : 'testing' }
 FamixStImportingContext >> shouldImportInvocation [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self shouldImport: #Invocation
 ]
@@ -274,6 +311,7 @@ FamixStImportingContext >> shouldImportInvocation [
 { #category : 'testing' }
 FamixStImportingContext >> shouldImportLocalVariable [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self shouldImport: #LocalVariable
 ]
@@ -281,6 +319,7 @@ FamixStImportingContext >> shouldImportLocalVariable [
 { #category : 'testing' }
 FamixStImportingContext >> shouldImportMethod [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self shouldImport: #Method
 ]
@@ -288,6 +327,7 @@ FamixStImportingContext >> shouldImportMethod [
 { #category : 'testing' }
 FamixStImportingContext >> shouldImportNamespace [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self shouldImport: #Namespace
 ]
@@ -295,6 +335,7 @@ FamixStImportingContext >> shouldImportNamespace [
 { #category : 'testing' }
 FamixStImportingContext >> shouldImportPackage [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self shouldImport: #Package
 ]
@@ -302,6 +343,7 @@ FamixStImportingContext >> shouldImportPackage [
 { #category : 'testing' }
 FamixStImportingContext >> shouldImportParameter [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self shouldImport: #Parameter
 ]
@@ -309,6 +351,7 @@ FamixStImportingContext >> shouldImportParameter [
 { #category : 'testing' }
 FamixStImportingContext >> shouldImportPharoEntitySourceAnchor [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self shouldImport: #PharoEntitySourceAnchor
 ]
@@ -316,6 +359,7 @@ FamixStImportingContext >> shouldImportPharoEntitySourceAnchor [
 { #category : 'testing' }
 FamixStImportingContext >> shouldImportReference [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self shouldImport: #Reference
 ]
@@ -323,6 +367,7 @@ FamixStImportingContext >> shouldImportReference [
 { #category : 'testing' }
 FamixStImportingContext >> shouldImportSourceLanguage [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self shouldImport: #SourceLanguage
 ]
@@ -330,6 +375,7 @@ FamixStImportingContext >> shouldImportSourceLanguage [
 { #category : 'testing' }
 FamixStImportingContext >> shouldImportSourceTextAnchor [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self shouldImport: #SourceTextAnchor
 ]
@@ -337,6 +383,7 @@ FamixStImportingContext >> shouldImportSourceTextAnchor [
 { #category : 'testing' }
 FamixStImportingContext >> shouldImportUnknownVariable [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self shouldImport: #UnknownVariable
 ]

--- a/src/Famix-PharoSmalltalk-Entities/FamixStInheritance.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStInheritance.class.st
@@ -35,6 +35,7 @@ Class {
 { #category : 'meta' }
 FamixStInheritance class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Inheritance super: #FamixStEntity>
 	<package: #'Famix-PharoSmalltalk-Entities'>
 	<generated>

--- a/src/Famix-PharoSmalltalk-Entities/FamixStInvocation.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStInvocation.class.st
@@ -42,6 +42,7 @@ Class {
 { #category : 'meta' }
 FamixStInvocation class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Invocation super: #FamixStEntity>
 	<package: #'Famix-PharoSmalltalk-Entities'>
 	<generated>

--- a/src/Famix-PharoSmalltalk-Entities/FamixStLocalVariable.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStLocalVariable.class.st
@@ -46,6 +46,7 @@ Class {
 { #category : 'meta' }
 FamixStLocalVariable class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #LocalVariable super: #FamixStNamedEntity>
 	<package: #'Famix-PharoSmalltalk-Entities'>
 	<generated>

--- a/src/Famix-PharoSmalltalk-Entities/FamixStMethod.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStMethod.class.st
@@ -67,6 +67,7 @@ Class {
 { #category : 'meta' }
 FamixStMethod class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Method super: #FamixStNamedEntity>
 	<package: #'Famix-PharoSmalltalk-Entities'>
 	<generated>
@@ -264,6 +265,7 @@ FamixStMethod >> printProtocol [
 FamixStMethod >> protocol [
 
 	<FMProperty: #protocol type: #String>
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'Protocol of the method'>
 	^ protocol
@@ -271,6 +273,7 @@ FamixStMethod >> protocol [
 
 { #category : 'accessing' }
 FamixStMethod >> protocol: anObject [
+	<ignoreForCoverage>
 	<generated>
 	protocol := anObject
 ]

--- a/src/Famix-PharoSmalltalk-Entities/FamixStModel.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStModel.class.st
@@ -10,6 +10,8 @@ Class {
 
 { #category : 'accessing' }
 FamixStModel class >> allSubmetamodelsPackagesNames [
+
+	<ignoreForCoverage>
 	<generated>
 	^ #(#'Moose-Query' #'Famix-Traits')
 ]
@@ -17,6 +19,7 @@ FamixStModel class >> allSubmetamodelsPackagesNames [
 { #category : 'meta' }
 FamixStModel class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Model super: #MooseModel>
 	<package: #'Famix-PharoSmalltalk-Entities'>
 	<generated>
@@ -24,6 +27,8 @@ FamixStModel class >> annotation [
 
 { #category : 'testing' }
 FamixStModel class >> canBeImportedFromFile [
+
+	<ignoreForCoverage>
 	<generated>
 	^true
 ]
@@ -31,6 +36,7 @@ FamixStModel class >> canBeImportedFromFile [
 { #category : 'accessing' }
 FamixStModel class >> importingContextClass [
 
+	<ignoreForCoverage>
 	<generated>
 	^ FamixStImportingContext
 ]

--- a/src/Famix-PharoSmalltalk-Entities/FamixStNamedEntity.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStNamedEntity.class.st
@@ -29,6 +29,7 @@ Class {
 { #category : 'meta' }
 FamixStNamedEntity class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #NamedEntity super: #FamixStSourcedEntity>
 	<package: #'Famix-PharoSmalltalk-Entities'>
 	<generated>
@@ -38,6 +39,7 @@ FamixStNamedEntity class >> annotation [
 { #category : 'testing' }
 FamixStNamedEntity class >> isAbstract [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self == FamixStNamedEntity
 ]
@@ -45,6 +47,7 @@ FamixStNamedEntity class >> isAbstract [
 { #category : 'testing' }
 FamixStNamedEntity >> isNamedEntity [
 
+	<ignoreForCoverage>
 	<generated>
 	^ true
 ]

--- a/src/Famix-PharoSmalltalk-Entities/FamixStNamespace.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStNamespace.class.st
@@ -37,6 +37,7 @@ Class {
 { #category : 'meta' }
 FamixStNamespace class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Namespace super: #FamixStNamedEntity>
 	<package: #'Famix-PharoSmalltalk-Entities'>
 	<generated>

--- a/src/Famix-PharoSmalltalk-Entities/FamixStPackage.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStPackage.class.st
@@ -37,6 +37,7 @@ Class {
 { #category : 'meta' }
 FamixStPackage class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Package super: #FamixStNamedEntity>
 	<package: #'Famix-PharoSmalltalk-Entities'>
 	<generated>

--- a/src/Famix-PharoSmalltalk-Entities/FamixStParameter.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStParameter.class.st
@@ -46,6 +46,7 @@ Class {
 { #category : 'meta' }
 FamixStParameter class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Parameter super: #FamixStNamedEntity>
 	<package: #'Famix-PharoSmalltalk-Entities'>
 	<generated>

--- a/src/Famix-PharoSmalltalk-Entities/FamixStPharoEntitySourceAnchor.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStPharoEntitySourceAnchor.class.st
@@ -24,6 +24,7 @@ Class {
 { #category : 'meta' }
 FamixStPharoEntitySourceAnchor class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #PharoEntitySourceAnchor super: #FamixStSourceAnchor>
 	<package: #'Famix-PharoSmalltalk-Entities'>
 	<generated>

--- a/src/Famix-PharoSmalltalk-Entities/FamixStReference.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStReference.class.st
@@ -35,6 +35,7 @@ Class {
 { #category : 'meta' }
 FamixStReference class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Reference super: #FamixStEntity>
 	<package: #'Famix-PharoSmalltalk-Entities'>
 	<generated>

--- a/src/Famix-PharoSmalltalk-Entities/FamixStSourceAnchor.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStSourceAnchor.class.st
@@ -23,6 +23,7 @@ Class {
 { #category : 'meta' }
 FamixStSourceAnchor class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #SourceAnchor super: #FamixStEntity>
 	<package: #'Famix-PharoSmalltalk-Entities'>
 	<generated>
@@ -32,6 +33,7 @@ FamixStSourceAnchor class >> annotation [
 { #category : 'testing' }
 FamixStSourceAnchor class >> isAbstract [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self == FamixStSourceAnchor
 ]

--- a/src/Famix-PharoSmalltalk-Entities/FamixStSourceLanguage.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStSourceLanguage.class.st
@@ -23,6 +23,7 @@ Class {
 { #category : 'meta' }
 FamixStSourceLanguage class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #SourceLanguage super: #FamixStEntity>
 	<package: #'Famix-PharoSmalltalk-Entities'>
 	<generated>

--- a/src/Famix-PharoSmalltalk-Entities/FamixStSourceTextAnchor.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStSourceTextAnchor.class.st
@@ -29,6 +29,7 @@ Class {
 { #category : 'meta' }
 FamixStSourceTextAnchor class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #SourceTextAnchor super: #FamixStSourceAnchor>
 	<package: #'Famix-PharoSmalltalk-Entities'>
 	<generated>

--- a/src/Famix-PharoSmalltalk-Entities/FamixStSourcedEntity.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStSourcedEntity.class.st
@@ -23,6 +23,7 @@ Class {
 { #category : 'meta' }
 FamixStSourcedEntity class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #SourcedEntity super: #FamixStEntity>
 	<package: #'Famix-PharoSmalltalk-Entities'>
 	<generated>
@@ -32,6 +33,7 @@ FamixStSourcedEntity class >> annotation [
 { #category : 'testing' }
 FamixStSourcedEntity class >> isAbstract [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self == FamixStSourcedEntity
 ]

--- a/src/Famix-PharoSmalltalk-Entities/FamixStTEntityCreator.trait.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStTEntityCreator.trait.st
@@ -14,6 +14,7 @@ Trait {
 { #category : 'meta' }
 FamixStTEntityCreator classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TEntityCreator super: #Object>
 	<package: #'Famix-PharoSmalltalk-Entities'>
 	<generated>
@@ -22,6 +23,7 @@ FamixStTEntityCreator classSide >> annotation [
 { #category : 'entity creation' }
 FamixStTEntityCreator >> newAccess [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixStAccess new
 ]
@@ -29,6 +31,7 @@ FamixStTEntityCreator >> newAccess [
 { #category : 'entity creation' }
 FamixStTEntityCreator >> newAnnotationInstance [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixStAnnotationInstance new
 ]
@@ -36,6 +39,7 @@ FamixStTEntityCreator >> newAnnotationInstance [
 { #category : 'entity creation' }
 FamixStTEntityCreator >> newAnnotationInstanceAttribute [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixStAnnotationInstanceAttribute new
 ]
@@ -43,6 +47,7 @@ FamixStTEntityCreator >> newAnnotationInstanceAttribute [
 { #category : 'entity creation' }
 FamixStTEntityCreator >> newAnnotationType [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixStAnnotationType new
 ]
@@ -50,6 +55,7 @@ FamixStTEntityCreator >> newAnnotationType [
 { #category : 'entity creation' }
 FamixStTEntityCreator >> newAnnotationTypeAttribute [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixStAnnotationTypeAttribute new
 ]
@@ -57,6 +63,7 @@ FamixStTEntityCreator >> newAnnotationTypeAttribute [
 { #category : 'entity creation' }
 FamixStTEntityCreator >> newAnnotationTypeAttributeNamed: aName [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: (FamixStAnnotationTypeAttribute named: aName)
 ]
@@ -64,6 +71,7 @@ FamixStTEntityCreator >> newAnnotationTypeAttributeNamed: aName [
 { #category : 'entity creation' }
 FamixStTEntityCreator >> newAnnotationTypeNamed: aName [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: (FamixStAnnotationType named: aName)
 ]
@@ -71,6 +79,7 @@ FamixStTEntityCreator >> newAnnotationTypeNamed: aName [
 { #category : 'entity creation' }
 FamixStTEntityCreator >> newAttribute [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixStAttribute new
 ]
@@ -78,6 +87,7 @@ FamixStTEntityCreator >> newAttribute [
 { #category : 'entity creation' }
 FamixStTEntityCreator >> newAttributeNamed: aName [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: (FamixStAttribute named: aName)
 ]
@@ -85,6 +95,7 @@ FamixStTEntityCreator >> newAttributeNamed: aName [
 { #category : 'entity creation' }
 FamixStTEntityCreator >> newClass [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixStClass new
 ]
@@ -92,6 +103,7 @@ FamixStTEntityCreator >> newClass [
 { #category : 'entity creation' }
 FamixStTEntityCreator >> newClassNamed: aName [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: (FamixStClass named: aName)
 ]
@@ -99,6 +111,7 @@ FamixStTEntityCreator >> newClassNamed: aName [
 { #category : 'entity creation' }
 FamixStTEntityCreator >> newComment [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixStComment new
 ]
@@ -106,6 +119,7 @@ FamixStTEntityCreator >> newComment [
 { #category : 'entity creation' }
 FamixStTEntityCreator >> newEntityTyping [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixStEntityTyping new
 ]
@@ -113,6 +127,7 @@ FamixStTEntityCreator >> newEntityTyping [
 { #category : 'entity creation' }
 FamixStTEntityCreator >> newGlobalVariable [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixStGlobalVariable new
 ]
@@ -120,6 +135,7 @@ FamixStTEntityCreator >> newGlobalVariable [
 { #category : 'entity creation' }
 FamixStTEntityCreator >> newGlobalVariableNamed: aName [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: (FamixStGlobalVariable named: aName)
 ]
@@ -127,6 +143,7 @@ FamixStTEntityCreator >> newGlobalVariableNamed: aName [
 { #category : 'entity creation' }
 FamixStTEntityCreator >> newImplicitVariable [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixStImplicitVariable new
 ]
@@ -134,6 +151,7 @@ FamixStTEntityCreator >> newImplicitVariable [
 { #category : 'entity creation' }
 FamixStTEntityCreator >> newImplicitVariableNamed: aName [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: (FamixStImplicitVariable named: aName)
 ]
@@ -141,6 +159,7 @@ FamixStTEntityCreator >> newImplicitVariableNamed: aName [
 { #category : 'entity creation' }
 FamixStTEntityCreator >> newInheritance [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixStInheritance new
 ]
@@ -148,6 +167,7 @@ FamixStTEntityCreator >> newInheritance [
 { #category : 'entity creation' }
 FamixStTEntityCreator >> newInvocation [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixStInvocation new
 ]
@@ -155,6 +175,7 @@ FamixStTEntityCreator >> newInvocation [
 { #category : 'entity creation' }
 FamixStTEntityCreator >> newLocalVariable [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixStLocalVariable new
 ]
@@ -162,6 +183,7 @@ FamixStTEntityCreator >> newLocalVariable [
 { #category : 'entity creation' }
 FamixStTEntityCreator >> newLocalVariableNamed: aName [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: (FamixStLocalVariable named: aName)
 ]
@@ -169,6 +191,7 @@ FamixStTEntityCreator >> newLocalVariableNamed: aName [
 { #category : 'entity creation' }
 FamixStTEntityCreator >> newMethod [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixStMethod new
 ]
@@ -176,6 +199,7 @@ FamixStTEntityCreator >> newMethod [
 { #category : 'entity creation' }
 FamixStTEntityCreator >> newMethodNamed: aName [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: (FamixStMethod named: aName)
 ]
@@ -183,6 +207,7 @@ FamixStTEntityCreator >> newMethodNamed: aName [
 { #category : 'entity creation' }
 FamixStTEntityCreator >> newNamespace [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixStNamespace new
 ]
@@ -190,6 +215,7 @@ FamixStTEntityCreator >> newNamespace [
 { #category : 'entity creation' }
 FamixStTEntityCreator >> newNamespaceNamed: aName [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: (FamixStNamespace named: aName)
 ]
@@ -197,6 +223,7 @@ FamixStTEntityCreator >> newNamespaceNamed: aName [
 { #category : 'entity creation' }
 FamixStTEntityCreator >> newPackage [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixStPackage new
 ]
@@ -204,6 +231,7 @@ FamixStTEntityCreator >> newPackage [
 { #category : 'entity creation' }
 FamixStTEntityCreator >> newPackageNamed: aName [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: (FamixStPackage named: aName)
 ]
@@ -211,6 +239,7 @@ FamixStTEntityCreator >> newPackageNamed: aName [
 { #category : 'entity creation' }
 FamixStTEntityCreator >> newParameter [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixStParameter new
 ]
@@ -218,6 +247,7 @@ FamixStTEntityCreator >> newParameter [
 { #category : 'entity creation' }
 FamixStTEntityCreator >> newParameterNamed: aName [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: (FamixStParameter named: aName)
 ]
@@ -225,6 +255,7 @@ FamixStTEntityCreator >> newParameterNamed: aName [
 { #category : 'entity creation' }
 FamixStTEntityCreator >> newPharoEntitySourceAnchor [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixStPharoEntitySourceAnchor new
 ]
@@ -232,6 +263,7 @@ FamixStTEntityCreator >> newPharoEntitySourceAnchor [
 { #category : 'entity creation' }
 FamixStTEntityCreator >> newReference [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixStReference new
 ]
@@ -239,6 +271,7 @@ FamixStTEntityCreator >> newReference [
 { #category : 'entity creation' }
 FamixStTEntityCreator >> newSourceLanguage [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixStSourceLanguage new
 ]
@@ -246,6 +279,7 @@ FamixStTEntityCreator >> newSourceLanguage [
 { #category : 'entity creation' }
 FamixStTEntityCreator >> newSourceTextAnchor [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixStSourceTextAnchor new
 ]
@@ -253,6 +287,7 @@ FamixStTEntityCreator >> newSourceTextAnchor [
 { #category : 'entity creation' }
 FamixStTEntityCreator >> newUnknownVariable [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixStUnknownVariable new
 ]
@@ -260,6 +295,7 @@ FamixStTEntityCreator >> newUnknownVariable [
 { #category : 'entity creation' }
 FamixStTEntityCreator >> newUnknownVariableNamed: aName [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: (FamixStUnknownVariable named: aName)
 ]

--- a/src/Famix-PharoSmalltalk-Entities/FamixStUnknownVariable.class.st
+++ b/src/Famix-PharoSmalltalk-Entities/FamixStUnknownVariable.class.st
@@ -41,6 +41,7 @@ Class {
 { #category : 'meta' }
 FamixStUnknownVariable class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #UnknownVariable super: #FamixStNamedEntity>
 	<package: #'Famix-PharoSmalltalk-Entities'>
 	<generated>

--- a/src/Famix-Test1-Entities/FamixTest1Association.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1Association.class.st
@@ -25,6 +25,7 @@ Class {
 { #category : 'meta' }
 FamixTest1Association class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Association super: #FamixTest1Entity>
 	<package: #'Famix-Test1-Entities'>
 	<generated>

--- a/src/Famix-Test1-Entities/FamixTest1Attribute.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1Attribute.class.st
@@ -47,6 +47,7 @@ Class {
 { #category : 'meta' }
 FamixTest1Attribute class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Attribute super: #FamixTest1NamedEntity>
 	<package: #'Famix-Test1-Entities'>
 	<generated>

--- a/src/Famix-Test1-Entities/FamixTest1BytesFileAnchor.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1BytesFileAnchor.class.st
@@ -24,6 +24,7 @@ Class {
 { #category : 'meta' }
 FamixTest1BytesFileAnchor class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #BytesFileAnchor super: #FamixTest1SourceAnchor>
 	<package: #'Famix-Test1-Entities'>
 	<generated>

--- a/src/Famix-Test1-Entities/FamixTest1Class.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1Class.class.st
@@ -59,6 +59,7 @@ Class {
 { #category : 'meta' }
 FamixTest1Class class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Class super: #FamixTest1NamedEntity>
 	<package: #'Famix-Test1-Entities'>
 	<generated>

--- a/src/Famix-Test1-Entities/FamixTest1Comment.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1Comment.class.st
@@ -28,6 +28,7 @@ Class {
 { #category : 'meta' }
 FamixTest1Comment class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Comment super: #FamixTest1SourcedEntity>
 	<package: #'Famix-Test1-Entities'>
 	<generated>

--- a/src/Famix-Test1-Entities/FamixTest1Entity.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1Entity.class.st
@@ -9,6 +9,7 @@ Class {
 { #category : 'meta' }
 FamixTest1Entity class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Entity super: #MooseEntity>
 	<package: #'Famix-Test1-Entities'>
 	<generated>
@@ -18,6 +19,7 @@ FamixTest1Entity class >> annotation [
 { #category : 'testing' }
 FamixTest1Entity class >> isAbstract [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self == FamixTest1Entity
 ]
@@ -25,6 +27,7 @@ FamixTest1Entity class >> isAbstract [
 { #category : 'meta' }
 FamixTest1Entity class >> metamodel [
 
+	<ignoreForCoverage>
 	<generated>
 	^ FamixTest1Model metamodel
 ]
@@ -32,6 +35,7 @@ FamixTest1Entity class >> metamodel [
 { #category : 'testing' }
 FamixTest1Entity >> canBeStub [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -39,6 +43,7 @@ FamixTest1Entity >> canBeStub [
 { #category : 'testing' }
 FamixTest1Entity >> hasImmediateSource [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -46,6 +51,7 @@ FamixTest1Entity >> hasImmediateSource [
 { #category : 'testing' }
 FamixTest1Entity >> isAssociation [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -53,6 +59,7 @@ FamixTest1Entity >> isAssociation [
 { #category : 'testing' }
 FamixTest1Entity >> isAttribute [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -60,6 +67,7 @@ FamixTest1Entity >> isAttribute [
 { #category : 'testing' }
 FamixTest1Entity >> isBehavioural [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -67,6 +75,7 @@ FamixTest1Entity >> isBehavioural [
 { #category : 'testing' }
 FamixTest1Entity >> isClass [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -74,6 +83,7 @@ FamixTest1Entity >> isClass [
 { #category : 'testing' }
 FamixTest1Entity >> isComment [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -81,6 +91,7 @@ FamixTest1Entity >> isComment [
 { #category : 'testing' }
 FamixTest1Entity >> isFileAnchor [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -88,6 +99,7 @@ FamixTest1Entity >> isFileAnchor [
 { #category : 'testing' }
 FamixTest1Entity >> isMethod [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -95,6 +107,7 @@ FamixTest1Entity >> isMethod [
 { #category : 'testing' }
 FamixTest1Entity >> isNamedEntity [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -102,6 +115,7 @@ FamixTest1Entity >> isNamedEntity [
 { #category : 'testing' }
 FamixTest1Entity >> isQueryable [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -109,6 +123,7 @@ FamixTest1Entity >> isQueryable [
 { #category : 'testing' }
 FamixTest1Entity >> isStructuralEntity [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -116,6 +131,7 @@ FamixTest1Entity >> isStructuralEntity [
 { #category : 'testing' }
 FamixTest1Entity >> isType [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]

--- a/src/Famix-Test1-Entities/FamixTest1File.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1File.class.st
@@ -34,6 +34,7 @@ Class {
 { #category : 'meta' }
 FamixTest1File class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #File super: #FamixTest1NamedEntity>
 	<package: #'Famix-Test1-Entities'>
 	<generated>

--- a/src/Famix-Test1-Entities/FamixTest1FileAnchor.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1FileAnchor.class.st
@@ -26,6 +26,7 @@ Class {
 { #category : 'meta' }
 FamixTest1FileAnchor class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #FileAnchor super: #FamixTest1SourceAnchor>
 	<package: #'Famix-Test1-Entities'>
 	<generated>

--- a/src/Famix-Test1-Entities/FamixTest1Folder.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1Folder.class.st
@@ -34,6 +34,7 @@ Class {
 { #category : 'meta' }
 FamixTest1Folder class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Folder super: #FamixTest1NamedEntity>
 	<package: #'Famix-Test1-Entities'>
 	<generated>

--- a/src/Famix-Test1-Entities/FamixTest1ImportingContext.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1ImportingContext.class.st
@@ -15,6 +15,7 @@ Class {
 { #category : 'accessing' }
 FamixTest1ImportingContext class >> importedMetamodel [
 
+	<ignoreForCoverage>
 	<generated>
 	^ FamixTest1Model metamodel
 ]
@@ -22,6 +23,7 @@ FamixTest1ImportingContext class >> importedMetamodel [
 { #category : 'importing' }
 FamixTest1ImportingContext >> importAssociation [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self importAssociation: (self class fm3ClassNamed: #Association)
 ]
@@ -29,6 +31,7 @@ FamixTest1ImportingContext >> importAssociation [
 { #category : 'importing' }
 FamixTest1ImportingContext >> importAttribute [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self importConcreteEntity: (self class fm3ClassNamed: #Attribute)
 ]
@@ -36,6 +39,7 @@ FamixTest1ImportingContext >> importAttribute [
 { #category : 'importing' }
 FamixTest1ImportingContext >> importBytesFileAnchor [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self importConcreteEntity: (self class fm3ClassNamed: #BytesFileAnchor)
 ]
@@ -43,6 +47,7 @@ FamixTest1ImportingContext >> importBytesFileAnchor [
 { #category : 'importing' }
 FamixTest1ImportingContext >> importClass [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self importConcreteEntity: (self class fm3ClassNamed: #Class)
 ]
@@ -50,6 +55,7 @@ FamixTest1ImportingContext >> importClass [
 { #category : 'importing' }
 FamixTest1ImportingContext >> importComment [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self importConcreteEntity: (self class fm3ClassNamed: #Comment)
 ]
@@ -57,6 +63,7 @@ FamixTest1ImportingContext >> importComment [
 { #category : 'importing' }
 FamixTest1ImportingContext >> importFile [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self importConcreteEntity: (self class fm3ClassNamed: #File)
 ]
@@ -64,6 +71,7 @@ FamixTest1ImportingContext >> importFile [
 { #category : 'importing' }
 FamixTest1ImportingContext >> importFileAnchor [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self importConcreteEntity: (self class fm3ClassNamed: #FileAnchor)
 ]
@@ -71,6 +79,7 @@ FamixTest1ImportingContext >> importFileAnchor [
 { #category : 'importing' }
 FamixTest1ImportingContext >> importFolder [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self importConcreteEntity: (self class fm3ClassNamed: #Folder)
 ]
@@ -78,6 +87,7 @@ FamixTest1ImportingContext >> importFolder [
 { #category : 'importing' }
 FamixTest1ImportingContext >> importIndexedFileAnchor [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self importConcreteEntity: (self class fm3ClassNamed: #IndexedFileAnchor)
 ]
@@ -85,6 +95,7 @@ FamixTest1ImportingContext >> importIndexedFileAnchor [
 { #category : 'importing' }
 FamixTest1ImportingContext >> importMethod [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self importConcreteEntity: (self class fm3ClassNamed: #Method)
 ]
@@ -92,6 +103,7 @@ FamixTest1ImportingContext >> importMethod [
 { #category : 'importing' }
 FamixTest1ImportingContext >> importMultipleFileAnchor [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self importConcreteEntity: (self class fm3ClassNamed: #MultipleFileAnchor)
 ]
@@ -99,6 +111,7 @@ FamixTest1ImportingContext >> importMultipleFileAnchor [
 { #category : 'importing' }
 FamixTest1ImportingContext >> importSourceLanguage [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self importConcreteEntity: (self class fm3ClassNamed: #SourceLanguage)
 ]
@@ -106,6 +119,7 @@ FamixTest1ImportingContext >> importSourceLanguage [
 { #category : 'importing' }
 FamixTest1ImportingContext >> importSourceTextAnchor [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self importConcreteEntity: (self class fm3ClassNamed: #SourceTextAnchor)
 ]
@@ -113,6 +127,7 @@ FamixTest1ImportingContext >> importSourceTextAnchor [
 { #category : 'testing' }
 FamixTest1ImportingContext >> shouldImportAssociation [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self shouldImport: #Association
 ]
@@ -120,6 +135,7 @@ FamixTest1ImportingContext >> shouldImportAssociation [
 { #category : 'testing' }
 FamixTest1ImportingContext >> shouldImportAttribute [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self shouldImport: #Attribute
 ]
@@ -127,6 +143,7 @@ FamixTest1ImportingContext >> shouldImportAttribute [
 { #category : 'testing' }
 FamixTest1ImportingContext >> shouldImportBytesFileAnchor [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self shouldImport: #BytesFileAnchor
 ]
@@ -134,6 +151,7 @@ FamixTest1ImportingContext >> shouldImportBytesFileAnchor [
 { #category : 'testing' }
 FamixTest1ImportingContext >> shouldImportClass [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self shouldImport: #Class
 ]
@@ -141,6 +159,7 @@ FamixTest1ImportingContext >> shouldImportClass [
 { #category : 'testing' }
 FamixTest1ImportingContext >> shouldImportComment [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self shouldImport: #Comment
 ]
@@ -148,6 +167,7 @@ FamixTest1ImportingContext >> shouldImportComment [
 { #category : 'testing' }
 FamixTest1ImportingContext >> shouldImportFile [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self shouldImport: #File
 ]
@@ -155,6 +175,7 @@ FamixTest1ImportingContext >> shouldImportFile [
 { #category : 'testing' }
 FamixTest1ImportingContext >> shouldImportFileAnchor [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self shouldImport: #FileAnchor
 ]
@@ -162,6 +183,7 @@ FamixTest1ImportingContext >> shouldImportFileAnchor [
 { #category : 'testing' }
 FamixTest1ImportingContext >> shouldImportFolder [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self shouldImport: #Folder
 ]
@@ -169,6 +191,7 @@ FamixTest1ImportingContext >> shouldImportFolder [
 { #category : 'testing' }
 FamixTest1ImportingContext >> shouldImportIndexedFileAnchor [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self shouldImport: #IndexedFileAnchor
 ]
@@ -176,6 +199,7 @@ FamixTest1ImportingContext >> shouldImportIndexedFileAnchor [
 { #category : 'testing' }
 FamixTest1ImportingContext >> shouldImportMethod [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self shouldImport: #Method
 ]
@@ -183,6 +207,7 @@ FamixTest1ImportingContext >> shouldImportMethod [
 { #category : 'testing' }
 FamixTest1ImportingContext >> shouldImportMultipleFileAnchor [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self shouldImport: #MultipleFileAnchor
 ]
@@ -190,6 +215,7 @@ FamixTest1ImportingContext >> shouldImportMultipleFileAnchor [
 { #category : 'testing' }
 FamixTest1ImportingContext >> shouldImportSourceLanguage [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self shouldImport: #SourceLanguage
 ]
@@ -197,6 +223,7 @@ FamixTest1ImportingContext >> shouldImportSourceLanguage [
 { #category : 'testing' }
 FamixTest1ImportingContext >> shouldImportSourceTextAnchor [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self shouldImport: #SourceTextAnchor
 ]

--- a/src/Famix-Test1-Entities/FamixTest1IndexedFileAnchor.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1IndexedFileAnchor.class.st
@@ -24,6 +24,7 @@ Class {
 { #category : 'meta' }
 FamixTest1IndexedFileAnchor class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #IndexedFileAnchor super: #FamixTest1SourceAnchor>
 	<package: #'Famix-Test1-Entities'>
 	<generated>

--- a/src/Famix-Test1-Entities/FamixTest1Method.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1Method.class.st
@@ -60,6 +60,7 @@ Class {
 { #category : 'meta' }
 FamixTest1Method class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Method super: #FamixTest1NamedEntity>
 	<package: #'Famix-Test1-Entities'>
 	<generated>

--- a/src/Famix-Test1-Entities/FamixTest1Model.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1Model.class.st
@@ -24,6 +24,8 @@ Class {
 
 { #category : 'accessing' }
 FamixTest1Model class >> allSubmetamodelsPackagesNames [
+
+	<ignoreForCoverage>
 	<generated>
 	^ #(#'Moose-Query' #'Famix-Traits')
 ]
@@ -31,6 +33,7 @@ FamixTest1Model class >> allSubmetamodelsPackagesNames [
 { #category : 'meta' }
 FamixTest1Model class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Model super: #MooseModel>
 	<package: #'Famix-Test1-Entities'>
 	<generated>
@@ -48,6 +51,7 @@ FamixTest1Model class >> canBeImportedFromFile [
 { #category : 'accessing' }
 FamixTest1Model class >> importingContextClass [
 
+	<ignoreForCoverage>
 	<generated>
 	^ FamixTest1ImportingContext
 ]
@@ -56,12 +60,14 @@ FamixTest1Model class >> importingContextClass [
 FamixTest1Model >> modelHasProperties [
 
 	<FMProperty: #modelHasProperties type: #Object>
+	<ignoreForCoverage>
 	<generated>
 	^ modelHasProperties
 ]
 
 { #category : 'accessing' }
 FamixTest1Model >> modelHasProperties: anObject [
+	<ignoreForCoverage>
 	<generated>
 	modelHasProperties := anObject
 ]

--- a/src/Famix-Test1-Entities/FamixTest1MultipleFileAnchor.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1MultipleFileAnchor.class.st
@@ -29,6 +29,7 @@ Class {
 { #category : 'meta' }
 FamixTest1MultipleFileAnchor class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #MultipleFileAnchor super: #FamixTest1SourceAnchor>
 	<package: #'Famix-Test1-Entities'>
 	<generated>

--- a/src/Famix-Test1-Entities/FamixTest1NamedEntity.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1NamedEntity.class.st
@@ -20,6 +20,7 @@ Class {
 { #category : 'meta' }
 FamixTest1NamedEntity class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #NamedEntity super: #FamixTest1Entity>
 	<package: #'Famix-Test1-Entities'>
 	<generated>
@@ -29,6 +30,7 @@ FamixTest1NamedEntity class >> annotation [
 { #category : 'testing' }
 FamixTest1NamedEntity class >> isAbstract [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self == FamixTest1NamedEntity
 ]
@@ -36,6 +38,7 @@ FamixTest1NamedEntity class >> isAbstract [
 { #category : 'testing' }
 FamixTest1NamedEntity >> isNamedEntity [
 
+	<ignoreForCoverage>
 	<generated>
 	^ true
 ]

--- a/src/Famix-Test1-Entities/FamixTest1SourceAnchor.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1SourceAnchor.class.st
@@ -23,6 +23,7 @@ Class {
 { #category : 'meta' }
 FamixTest1SourceAnchor class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #SourceAnchor super: #FamixTest1Entity>
 	<package: #'Famix-Test1-Entities'>
 	<generated>
@@ -32,6 +33,7 @@ FamixTest1SourceAnchor class >> annotation [
 { #category : 'testing' }
 FamixTest1SourceAnchor class >> isAbstract [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self == FamixTest1SourceAnchor
 ]

--- a/src/Famix-Test1-Entities/FamixTest1SourceLanguage.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1SourceLanguage.class.st
@@ -23,6 +23,7 @@ Class {
 { #category : 'meta' }
 FamixTest1SourceLanguage class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #SourceLanguage super: #FamixTest1Entity>
 	<package: #'Famix-Test1-Entities'>
 	<generated>

--- a/src/Famix-Test1-Entities/FamixTest1SourceTextAnchor.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1SourceTextAnchor.class.st
@@ -29,6 +29,7 @@ Class {
 { #category : 'meta' }
 FamixTest1SourceTextAnchor class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #SourceTextAnchor super: #FamixTest1SourceAnchor>
 	<package: #'Famix-Test1-Entities'>
 	<generated>

--- a/src/Famix-Test1-Entities/FamixTest1SourcedEntity.class.st
+++ b/src/Famix-Test1-Entities/FamixTest1SourcedEntity.class.st
@@ -25,6 +25,7 @@ Class {
 { #category : 'meta' }
 FamixTest1SourcedEntity class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #SourcedEntity super: #FamixTest1Entity>
 	<package: #'Famix-Test1-Entities'>
 	<generated>
@@ -34,6 +35,7 @@ FamixTest1SourcedEntity class >> annotation [
 { #category : 'testing' }
 FamixTest1SourcedEntity class >> isAbstract [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self == FamixTest1SourcedEntity
 ]

--- a/src/Famix-Test1-Entities/FamixTest1TCanBeClassSide.trait.st
+++ b/src/Famix-Test1-Entities/FamixTest1TCanBeClassSide.trait.st
@@ -20,6 +20,7 @@ Trait {
 { #category : 'meta' }
 FamixTest1TCanBeClassSide classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TCanBeClassSide super: #Object>
 	<package: #'Famix-Test1-Entities'>
 	<generated>
@@ -29,6 +30,7 @@ FamixTest1TCanBeClassSide classSide >> annotation [
 FamixTest1TCanBeClassSide >> isClassSide [
 
 	<FMProperty: #isClassSide type: #Boolean>
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'Entity can be declared class side i.e. static'>
 	^ isClassSide
@@ -36,6 +38,7 @@ FamixTest1TCanBeClassSide >> isClassSide [
 
 { #category : 'accessing' }
 FamixTest1TCanBeClassSide >> isClassSide: anObject [
+	<ignoreForCoverage>
 	<generated>
 	isClassSide := anObject
 ]

--- a/src/Famix-Test1-Entities/FamixTest1TEntityCreator.trait.st
+++ b/src/Famix-Test1-Entities/FamixTest1TEntityCreator.trait.st
@@ -14,6 +14,7 @@ Trait {
 { #category : 'meta' }
 FamixTest1TEntityCreator classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TEntityCreator super: #Object>
 	<package: #'Famix-Test1-Entities'>
 	<generated>
@@ -22,6 +23,7 @@ FamixTest1TEntityCreator classSide >> annotation [
 { #category : 'entity creation' }
 FamixTest1TEntityCreator >> newAssociation [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixTest1Association new
 ]
@@ -29,6 +31,7 @@ FamixTest1TEntityCreator >> newAssociation [
 { #category : 'entity creation' }
 FamixTest1TEntityCreator >> newAttribute [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixTest1Attribute new
 ]
@@ -36,6 +39,7 @@ FamixTest1TEntityCreator >> newAttribute [
 { #category : 'entity creation' }
 FamixTest1TEntityCreator >> newAttributeNamed: aName [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: (FamixTest1Attribute named: aName)
 ]
@@ -43,6 +47,7 @@ FamixTest1TEntityCreator >> newAttributeNamed: aName [
 { #category : 'entity creation' }
 FamixTest1TEntityCreator >> newBytesFileAnchor [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixTest1BytesFileAnchor new
 ]
@@ -50,6 +55,7 @@ FamixTest1TEntityCreator >> newBytesFileAnchor [
 { #category : 'entity creation' }
 FamixTest1TEntityCreator >> newClass [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixTest1Class new
 ]
@@ -57,6 +63,7 @@ FamixTest1TEntityCreator >> newClass [
 { #category : 'entity creation' }
 FamixTest1TEntityCreator >> newClassNamed: aName [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: (FamixTest1Class named: aName)
 ]
@@ -64,6 +71,7 @@ FamixTest1TEntityCreator >> newClassNamed: aName [
 { #category : 'entity creation' }
 FamixTest1TEntityCreator >> newComment [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixTest1Comment new
 ]
@@ -71,6 +79,7 @@ FamixTest1TEntityCreator >> newComment [
 { #category : 'entity creation' }
 FamixTest1TEntityCreator >> newFile [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixTest1File new
 ]
@@ -78,6 +87,7 @@ FamixTest1TEntityCreator >> newFile [
 { #category : 'entity creation' }
 FamixTest1TEntityCreator >> newFileAnchor [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixTest1FileAnchor new
 ]
@@ -85,6 +95,7 @@ FamixTest1TEntityCreator >> newFileAnchor [
 { #category : 'entity creation' }
 FamixTest1TEntityCreator >> newFileNamed: aName [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: (FamixTest1File named: aName)
 ]
@@ -92,6 +103,7 @@ FamixTest1TEntityCreator >> newFileNamed: aName [
 { #category : 'entity creation' }
 FamixTest1TEntityCreator >> newFolder [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixTest1Folder new
 ]
@@ -99,6 +111,7 @@ FamixTest1TEntityCreator >> newFolder [
 { #category : 'entity creation' }
 FamixTest1TEntityCreator >> newFolderNamed: aName [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: (FamixTest1Folder named: aName)
 ]
@@ -106,6 +119,7 @@ FamixTest1TEntityCreator >> newFolderNamed: aName [
 { #category : 'entity creation' }
 FamixTest1TEntityCreator >> newIndexedFileAnchor [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixTest1IndexedFileAnchor new
 ]
@@ -113,6 +127,7 @@ FamixTest1TEntityCreator >> newIndexedFileAnchor [
 { #category : 'entity creation' }
 FamixTest1TEntityCreator >> newMethod [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixTest1Method new
 ]
@@ -120,6 +135,7 @@ FamixTest1TEntityCreator >> newMethod [
 { #category : 'entity creation' }
 FamixTest1TEntityCreator >> newMethodNamed: aName [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: (FamixTest1Method named: aName)
 ]
@@ -127,6 +143,7 @@ FamixTest1TEntityCreator >> newMethodNamed: aName [
 { #category : 'entity creation' }
 FamixTest1TEntityCreator >> newMultipleFileAnchor [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixTest1MultipleFileAnchor new
 ]
@@ -134,6 +151,7 @@ FamixTest1TEntityCreator >> newMultipleFileAnchor [
 { #category : 'entity creation' }
 FamixTest1TEntityCreator >> newSourceLanguage [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixTest1SourceLanguage new
 ]
@@ -141,6 +159,7 @@ FamixTest1TEntityCreator >> newSourceLanguage [
 { #category : 'entity creation' }
 FamixTest1TEntityCreator >> newSourceTextAnchor [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixTest1SourceTextAnchor new
 ]

--- a/src/Famix-Test2-Entities/FamixTest2Class.class.st
+++ b/src/Famix-Test2-Entities/FamixTest2Class.class.st
@@ -55,6 +55,7 @@ Class {
 { #category : 'meta' }
 FamixTest2Class class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Class super: #FamixTest2NamedEntity>
 	<package: #'Famix-Test2-Entities'>
 	<generated>

--- a/src/Famix-Test2-Entities/FamixTest2Comment.class.st
+++ b/src/Famix-Test2-Entities/FamixTest2Comment.class.st
@@ -28,6 +28,7 @@ Class {
 { #category : 'meta' }
 FamixTest2Comment class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Comment super: #FamixTest2SourcedEntity>
 	<package: #'Famix-Test2-Entities'>
 	<generated>

--- a/src/Famix-Test2-Entities/FamixTest2Entity.class.st
+++ b/src/Famix-Test2-Entities/FamixTest2Entity.class.st
@@ -9,6 +9,7 @@ Class {
 { #category : 'meta' }
 FamixTest2Entity class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Entity super: #MooseEntity>
 	<package: #'Famix-Test2-Entities'>
 	<generated>
@@ -18,6 +19,7 @@ FamixTest2Entity class >> annotation [
 { #category : 'testing' }
 FamixTest2Entity class >> isAbstract [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self == FamixTest2Entity
 ]
@@ -25,6 +27,7 @@ FamixTest2Entity class >> isAbstract [
 { #category : 'meta' }
 FamixTest2Entity class >> metamodel [
 
+	<ignoreForCoverage>
 	<generated>
 	^ FamixTest2Model metamodel
 ]
@@ -32,6 +35,7 @@ FamixTest2Entity class >> metamodel [
 { #category : 'testing' }
 FamixTest2Entity >> canBeStub [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -39,6 +43,7 @@ FamixTest2Entity >> canBeStub [
 { #category : 'testing' }
 FamixTest2Entity >> hasImmediateSource [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -46,6 +51,7 @@ FamixTest2Entity >> hasImmediateSource [
 { #category : 'testing' }
 FamixTest2Entity >> isAssociation [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -53,6 +59,7 @@ FamixTest2Entity >> isAssociation [
 { #category : 'testing' }
 FamixTest2Entity >> isClass [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -60,6 +67,7 @@ FamixTest2Entity >> isClass [
 { #category : 'testing' }
 FamixTest2Entity >> isComment [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -67,6 +75,7 @@ FamixTest2Entity >> isComment [
 { #category : 'testing' }
 FamixTest2Entity >> isInheritance [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -74,6 +83,7 @@ FamixTest2Entity >> isInheritance [
 { #category : 'testing' }
 FamixTest2Entity >> isNamedEntity [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -81,6 +91,7 @@ FamixTest2Entity >> isNamedEntity [
 { #category : 'testing' }
 FamixTest2Entity >> isQueryable [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -88,6 +99,7 @@ FamixTest2Entity >> isQueryable [
 { #category : 'testing' }
 FamixTest2Entity >> isType [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]

--- a/src/Famix-Test2-Entities/FamixTest2Inheritance.class.st
+++ b/src/Famix-Test2-Entities/FamixTest2Inheritance.class.st
@@ -35,6 +35,7 @@ Class {
 { #category : 'meta' }
 FamixTest2Inheritance class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Inheritance super: #FamixTest2Entity>
 	<package: #'Famix-Test2-Entities'>
 	<generated>

--- a/src/Famix-Test2-Entities/FamixTest2Model.class.st
+++ b/src/Famix-Test2-Entities/FamixTest2Model.class.st
@@ -10,6 +10,8 @@ Class {
 
 { #category : 'accessing' }
 FamixTest2Model class >> allSubmetamodelsPackagesNames [
+
+	<ignoreForCoverage>
 	<generated>
 	^ #(#'Moose-Query' #'Famix-Traits')
 ]
@@ -17,6 +19,7 @@ FamixTest2Model class >> allSubmetamodelsPackagesNames [
 { #category : 'meta' }
 FamixTest2Model class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Model super: #MooseModel>
 	<package: #'Famix-Test2-Entities'>
 	<generated>

--- a/src/Famix-Test2-Entities/FamixTest2NamedEntity.class.st
+++ b/src/Famix-Test2-Entities/FamixTest2NamedEntity.class.st
@@ -20,6 +20,7 @@ Class {
 { #category : 'meta' }
 FamixTest2NamedEntity class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #NamedEntity super: #FamixTest2Entity>
 	<package: #'Famix-Test2-Entities'>
 	<generated>
@@ -29,6 +30,7 @@ FamixTest2NamedEntity class >> annotation [
 { #category : 'testing' }
 FamixTest2NamedEntity class >> isAbstract [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self == FamixTest2NamedEntity
 ]
@@ -36,6 +38,7 @@ FamixTest2NamedEntity class >> isAbstract [
 { #category : 'testing' }
 FamixTest2NamedEntity >> isNamedEntity [
 
+	<ignoreForCoverage>
 	<generated>
 	^ true
 ]

--- a/src/Famix-Test2-Entities/FamixTest2SourceAnchor.class.st
+++ b/src/Famix-Test2-Entities/FamixTest2SourceAnchor.class.st
@@ -23,6 +23,7 @@ Class {
 { #category : 'meta' }
 FamixTest2SourceAnchor class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #SourceAnchor super: #FamixTest2Entity>
 	<package: #'Famix-Test2-Entities'>
 	<generated>
@@ -32,6 +33,7 @@ FamixTest2SourceAnchor class >> annotation [
 { #category : 'testing' }
 FamixTest2SourceAnchor class >> isAbstract [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self == FamixTest2SourceAnchor
 ]

--- a/src/Famix-Test2-Entities/FamixTest2SourceLanguage.class.st
+++ b/src/Famix-Test2-Entities/FamixTest2SourceLanguage.class.st
@@ -23,6 +23,7 @@ Class {
 { #category : 'meta' }
 FamixTest2SourceLanguage class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #SourceLanguage super: #FamixTest2Entity>
 	<package: #'Famix-Test2-Entities'>
 	<generated>

--- a/src/Famix-Test2-Entities/FamixTest2SourceTextAnchor.class.st
+++ b/src/Famix-Test2-Entities/FamixTest2SourceTextAnchor.class.st
@@ -29,6 +29,7 @@ Class {
 { #category : 'meta' }
 FamixTest2SourceTextAnchor class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #SourceTextAnchor super: #FamixTest2SourceAnchor>
 	<package: #'Famix-Test2-Entities'>
 	<generated>

--- a/src/Famix-Test2-Entities/FamixTest2SourcedEntity.class.st
+++ b/src/Famix-Test2-Entities/FamixTest2SourcedEntity.class.st
@@ -23,6 +23,7 @@ Class {
 { #category : 'meta' }
 FamixTest2SourcedEntity class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #SourcedEntity super: #FamixTest2Entity>
 	<package: #'Famix-Test2-Entities'>
 	<generated>
@@ -32,6 +33,7 @@ FamixTest2SourcedEntity class >> annotation [
 { #category : 'testing' }
 FamixTest2SourcedEntity class >> isAbstract [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self == FamixTest2SourcedEntity
 ]

--- a/src/Famix-Test2-Entities/FamixTest2TEntityCreator.trait.st
+++ b/src/Famix-Test2-Entities/FamixTest2TEntityCreator.trait.st
@@ -14,6 +14,7 @@ Trait {
 { #category : 'meta' }
 FamixTest2TEntityCreator classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TEntityCreator super: #Object>
 	<package: #'Famix-Test2-Entities'>
 	<generated>
@@ -22,6 +23,7 @@ FamixTest2TEntityCreator classSide >> annotation [
 { #category : 'entity creation' }
 FamixTest2TEntityCreator >> newClass [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixTest2Class new
 ]
@@ -29,6 +31,7 @@ FamixTest2TEntityCreator >> newClass [
 { #category : 'entity creation' }
 FamixTest2TEntityCreator >> newClassNamed: aName [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: (FamixTest2Class named: aName)
 ]
@@ -36,6 +39,7 @@ FamixTest2TEntityCreator >> newClassNamed: aName [
 { #category : 'entity creation' }
 FamixTest2TEntityCreator >> newComment [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixTest2Comment new
 ]
@@ -43,6 +47,7 @@ FamixTest2TEntityCreator >> newComment [
 { #category : 'entity creation' }
 FamixTest2TEntityCreator >> newInheritance [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixTest2Inheritance new
 ]
@@ -50,6 +55,7 @@ FamixTest2TEntityCreator >> newInheritance [
 { #category : 'entity creation' }
 FamixTest2TEntityCreator >> newSourceLanguage [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixTest2SourceLanguage new
 ]
@@ -57,6 +63,7 @@ FamixTest2TEntityCreator >> newSourceLanguage [
 { #category : 'entity creation' }
 FamixTest2TEntityCreator >> newSourceTextAnchor [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixTest2SourceTextAnchor new
 ]

--- a/src/Famix-Test3-Entities/FamixTest3Access.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3Access.class.st
@@ -41,6 +41,7 @@ Class {
 { #category : 'meta' }
 FamixTest3Access class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Access super: #FamixTest3Entity>
 	<package: #'Famix-Test3-Entities'>
 	<generated>

--- a/src/Famix-Test3-Entities/FamixTest3Attribute.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3Attribute.class.st
@@ -45,6 +45,7 @@ Class {
 { #category : 'meta' }
 FamixTest3Attribute class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Attribute super: #FamixTest3Entity>
 	<package: #'Famix-Test3-Entities'>
 	<generated>

--- a/src/Famix-Test3-Entities/FamixTest3Class.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3Class.class.st
@@ -56,6 +56,7 @@ Class {
 { #category : 'meta' }
 FamixTest3Class class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Class super: #FamixTest3Type>
 	<package: #'Famix-Test3-Entities'>
 	<generated>
@@ -63,6 +64,8 @@ FamixTest3Class class >> annotation [
 
 { #category : 'groups' }
 FamixTest3Class class >> annotationFamixTest3ClassGroup [
+
+	<ignoreForCoverage>
 	<generated>
 	<mooseGroup>
 	^ FamixTest3ClassGroup

--- a/src/Famix-Test3-Entities/FamixTest3Comment.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3Comment.class.st
@@ -28,6 +28,7 @@ Class {
 { #category : 'meta' }
 FamixTest3Comment class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Comment super: #FamixTest3SourcedEntity>
 	<package: #'Famix-Test3-Entities'>
 	<generated>

--- a/src/Famix-Test3-Entities/FamixTest3Entity.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3Entity.class.st
@@ -9,6 +9,7 @@ Class {
 { #category : 'meta' }
 FamixTest3Entity class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Entity super: #MooseEntity>
 	<package: #'Famix-Test3-Entities'>
 	<generated>
@@ -18,6 +19,7 @@ FamixTest3Entity class >> annotation [
 { #category : 'testing' }
 FamixTest3Entity class >> isAbstract [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self == FamixTest3Entity
 ]
@@ -25,6 +27,7 @@ FamixTest3Entity class >> isAbstract [
 { #category : 'meta' }
 FamixTest3Entity class >> metamodel [
 
+	<ignoreForCoverage>
 	<generated>
 	^ FamixTest3Model metamodel
 ]
@@ -32,6 +35,7 @@ FamixTest3Entity class >> metamodel [
 { #category : 'testing' }
 FamixTest3Entity >> canBeStub [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -39,6 +43,7 @@ FamixTest3Entity >> canBeStub [
 { #category : 'testing' }
 FamixTest3Entity >> hasImmediateSource [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -46,6 +51,7 @@ FamixTest3Entity >> hasImmediateSource [
 { #category : 'testing' }
 FamixTest3Entity >> isAccess [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -53,6 +59,7 @@ FamixTest3Entity >> isAccess [
 { #category : 'testing' }
 FamixTest3Entity >> isAssociation [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -60,6 +67,7 @@ FamixTest3Entity >> isAssociation [
 { #category : 'testing' }
 FamixTest3Entity >> isAttribute [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -67,6 +75,7 @@ FamixTest3Entity >> isAttribute [
 { #category : 'testing' }
 FamixTest3Entity >> isBehavioural [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -74,6 +83,7 @@ FamixTest3Entity >> isBehavioural [
 { #category : 'testing' }
 FamixTest3Entity >> isClass [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -81,6 +91,7 @@ FamixTest3Entity >> isClass [
 { #category : 'testing' }
 FamixTest3Entity >> isComment [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -88,6 +99,7 @@ FamixTest3Entity >> isComment [
 { #category : 'testing' }
 FamixTest3Entity >> isInvocation [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -95,6 +107,7 @@ FamixTest3Entity >> isInvocation [
 { #category : 'testing' }
 FamixTest3Entity >> isMethod [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -102,6 +115,7 @@ FamixTest3Entity >> isMethod [
 { #category : 'testing' }
 FamixTest3Entity >> isNamedEntity [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -109,6 +123,7 @@ FamixTest3Entity >> isNamedEntity [
 { #category : 'testing' }
 FamixTest3Entity >> isPackage [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -116,6 +131,7 @@ FamixTest3Entity >> isPackage [
 { #category : 'testing' }
 FamixTest3Entity >> isParametricEntity [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -123,6 +139,7 @@ FamixTest3Entity >> isParametricEntity [
 { #category : 'testing' }
 FamixTest3Entity >> isQueryable [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -130,6 +147,7 @@ FamixTest3Entity >> isQueryable [
 { #category : 'testing' }
 FamixTest3Entity >> isReference [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -137,6 +155,7 @@ FamixTest3Entity >> isReference [
 { #category : 'testing' }
 FamixTest3Entity >> isStructuralEntity [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -144,6 +163,7 @@ FamixTest3Entity >> isStructuralEntity [
 { #category : 'testing' }
 FamixTest3Entity >> isType [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]

--- a/src/Famix-Test3-Entities/FamixTest3Invocation.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3Invocation.class.st
@@ -42,6 +42,7 @@ Class {
 { #category : 'meta' }
 FamixTest3Invocation class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Invocation super: #FamixTest3Entity>
 	<package: #'Famix-Test3-Entities'>
 	<generated>

--- a/src/Famix-Test3-Entities/FamixTest3Method.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3Method.class.st
@@ -56,6 +56,7 @@ Class {
 { #category : 'meta' }
 FamixTest3Method class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Method super: #FamixTest3NamedEntity>
 	<package: #'Famix-Test3-Entities'>
 	<generated>

--- a/src/Famix-Test3-Entities/FamixTest3Model.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3Model.class.st
@@ -10,6 +10,8 @@ Class {
 
 { #category : 'accessing' }
 FamixTest3Model class >> allSubmetamodelsPackagesNames [
+
+	<ignoreForCoverage>
 	<generated>
 	^ #(#'Moose-Query' #'Famix-Traits')
 ]
@@ -17,6 +19,7 @@ FamixTest3Model class >> allSubmetamodelsPackagesNames [
 { #category : 'meta' }
 FamixTest3Model class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Model super: #MooseModel>
 	<package: #'Famix-Test3-Entities'>
 	<generated>

--- a/src/Famix-Test3-Entities/FamixTest3NamedEntity.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3NamedEntity.class.st
@@ -20,6 +20,7 @@ Class {
 { #category : 'meta' }
 FamixTest3NamedEntity class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #NamedEntity super: #FamixTest3Entity>
 	<package: #'Famix-Test3-Entities'>
 	<generated>
@@ -29,6 +30,7 @@ FamixTest3NamedEntity class >> annotation [
 { #category : 'testing' }
 FamixTest3NamedEntity class >> isAbstract [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self == FamixTest3NamedEntity
 ]
@@ -36,6 +38,7 @@ FamixTest3NamedEntity class >> isAbstract [
 { #category : 'testing' }
 FamixTest3NamedEntity >> isNamedEntity [
 
+	<ignoreForCoverage>
 	<generated>
 	^ true
 ]

--- a/src/Famix-Test3-Entities/FamixTest3Package.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3Package.class.st
@@ -35,6 +35,7 @@ Class {
 { #category : 'meta' }
 FamixTest3Package class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Package super: #FamixTest3Entity>
 	<package: #'Famix-Test3-Entities'>
 	<generated>

--- a/src/Famix-Test3-Entities/FamixTest3ParametricClass.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3ParametricClass.class.st
@@ -23,6 +23,7 @@ Class {
 { #category : 'meta' }
 FamixTest3ParametricClass class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #ParametricClass super: #FamixTest3Class>
 	<package: #'Famix-Test3-Entities'>
 	<generated>

--- a/src/Famix-Test3-Entities/FamixTest3PrimitiveType.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3PrimitiveType.class.st
@@ -28,6 +28,7 @@ Class {
 { #category : 'meta' }
 FamixTest3PrimitiveType class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #PrimitiveType super: #FamixTest3Type>
 	<package: #'Famix-Test3-Entities'>
 	<generated>

--- a/src/Famix-Test3-Entities/FamixTest3Reference.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3Reference.class.st
@@ -35,6 +35,7 @@ Class {
 { #category : 'meta' }
 FamixTest3Reference class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Reference super: #FamixTest3Entity>
 	<package: #'Famix-Test3-Entities'>
 	<generated>

--- a/src/Famix-Test3-Entities/FamixTest3SourceAnchor.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3SourceAnchor.class.st
@@ -23,6 +23,7 @@ Class {
 { #category : 'meta' }
 FamixTest3SourceAnchor class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #SourceAnchor super: #FamixTest3Entity>
 	<package: #'Famix-Test3-Entities'>
 	<generated>
@@ -32,6 +33,7 @@ FamixTest3SourceAnchor class >> annotation [
 { #category : 'testing' }
 FamixTest3SourceAnchor class >> isAbstract [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self == FamixTest3SourceAnchor
 ]

--- a/src/Famix-Test3-Entities/FamixTest3SourceLanguage.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3SourceLanguage.class.st
@@ -23,6 +23,7 @@ Class {
 { #category : 'meta' }
 FamixTest3SourceLanguage class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #SourceLanguage super: #FamixTest3Entity>
 	<package: #'Famix-Test3-Entities'>
 	<generated>

--- a/src/Famix-Test3-Entities/FamixTest3SourceTextAnchor.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3SourceTextAnchor.class.st
@@ -29,6 +29,7 @@ Class {
 { #category : 'meta' }
 FamixTest3SourceTextAnchor class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #SourceTextAnchor super: #FamixTest3SourceAnchor>
 	<package: #'Famix-Test3-Entities'>
 	<generated>

--- a/src/Famix-Test3-Entities/FamixTest3SourcedEntity.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3SourcedEntity.class.st
@@ -23,6 +23,7 @@ Class {
 { #category : 'meta' }
 FamixTest3SourcedEntity class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #SourcedEntity super: #FamixTest3Entity>
 	<package: #'Famix-Test3-Entities'>
 	<generated>
@@ -32,6 +33,7 @@ FamixTest3SourcedEntity class >> annotation [
 { #category : 'testing' }
 FamixTest3SourcedEntity class >> isAbstract [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self == FamixTest3SourcedEntity
 ]

--- a/src/Famix-Test3-Entities/FamixTest3TEntityCreator.trait.st
+++ b/src/Famix-Test3-Entities/FamixTest3TEntityCreator.trait.st
@@ -14,6 +14,7 @@ Trait {
 { #category : 'meta' }
 FamixTest3TEntityCreator classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TEntityCreator super: #Object>
 	<package: #'Famix-Test3-Entities'>
 	<generated>
@@ -22,6 +23,7 @@ FamixTest3TEntityCreator classSide >> annotation [
 { #category : 'entity creation' }
 FamixTest3TEntityCreator >> newAccess [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixTest3Access new
 ]
@@ -29,6 +31,7 @@ FamixTest3TEntityCreator >> newAccess [
 { #category : 'entity creation' }
 FamixTest3TEntityCreator >> newAttribute [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixTest3Attribute new
 ]
@@ -36,6 +39,7 @@ FamixTest3TEntityCreator >> newAttribute [
 { #category : 'entity creation' }
 FamixTest3TEntityCreator >> newAttributeNamed: aName [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: (FamixTest3Attribute named: aName)
 ]
@@ -43,6 +47,7 @@ FamixTest3TEntityCreator >> newAttributeNamed: aName [
 { #category : 'entity creation' }
 FamixTest3TEntityCreator >> newClass [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixTest3Class new
 ]
@@ -50,6 +55,7 @@ FamixTest3TEntityCreator >> newClass [
 { #category : 'entity creation' }
 FamixTest3TEntityCreator >> newClassNamed: aName [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: (FamixTest3Class named: aName)
 ]
@@ -57,6 +63,7 @@ FamixTest3TEntityCreator >> newClassNamed: aName [
 { #category : 'entity creation' }
 FamixTest3TEntityCreator >> newComment [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixTest3Comment new
 ]
@@ -64,6 +71,7 @@ FamixTest3TEntityCreator >> newComment [
 { #category : 'entity creation' }
 FamixTest3TEntityCreator >> newInvocation [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixTest3Invocation new
 ]
@@ -71,6 +79,7 @@ FamixTest3TEntityCreator >> newInvocation [
 { #category : 'entity creation' }
 FamixTest3TEntityCreator >> newMethod [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixTest3Method new
 ]
@@ -78,6 +87,7 @@ FamixTest3TEntityCreator >> newMethod [
 { #category : 'entity creation' }
 FamixTest3TEntityCreator >> newMethodNamed: aName [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: (FamixTest3Method named: aName)
 ]
@@ -85,6 +95,7 @@ FamixTest3TEntityCreator >> newMethodNamed: aName [
 { #category : 'entity creation' }
 FamixTest3TEntityCreator >> newPackage [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixTest3Package new
 ]
@@ -92,6 +103,7 @@ FamixTest3TEntityCreator >> newPackage [
 { #category : 'entity creation' }
 FamixTest3TEntityCreator >> newPackageNamed: aName [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: (FamixTest3Package named: aName)
 ]
@@ -99,6 +111,7 @@ FamixTest3TEntityCreator >> newPackageNamed: aName [
 { #category : 'entity creation' }
 FamixTest3TEntityCreator >> newParametricClass [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixTest3ParametricClass new
 ]
@@ -106,6 +119,7 @@ FamixTest3TEntityCreator >> newParametricClass [
 { #category : 'entity creation' }
 FamixTest3TEntityCreator >> newParametricClassNamed: aName [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: (FamixTest3ParametricClass named: aName)
 ]
@@ -113,6 +127,7 @@ FamixTest3TEntityCreator >> newParametricClassNamed: aName [
 { #category : 'entity creation' }
 FamixTest3TEntityCreator >> newPrimitiveType [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixTest3PrimitiveType new
 ]
@@ -120,6 +135,7 @@ FamixTest3TEntityCreator >> newPrimitiveType [
 { #category : 'entity creation' }
 FamixTest3TEntityCreator >> newPrimitiveTypeNamed: aName [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: (FamixTest3PrimitiveType named: aName)
 ]
@@ -127,6 +143,7 @@ FamixTest3TEntityCreator >> newPrimitiveTypeNamed: aName [
 { #category : 'entity creation' }
 FamixTest3TEntityCreator >> newReference [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixTest3Reference new
 ]
@@ -134,6 +151,7 @@ FamixTest3TEntityCreator >> newReference [
 { #category : 'entity creation' }
 FamixTest3TEntityCreator >> newSourceLanguage [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixTest3SourceLanguage new
 ]
@@ -141,6 +159,7 @@ FamixTest3TEntityCreator >> newSourceLanguage [
 { #category : 'entity creation' }
 FamixTest3TEntityCreator >> newSourceTextAnchor [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixTest3SourceTextAnchor new
 ]
@@ -148,6 +167,7 @@ FamixTest3TEntityCreator >> newSourceTextAnchor [
 { #category : 'entity creation' }
 FamixTest3TEntityCreator >> newType [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixTest3Type new
 ]
@@ -155,6 +175,7 @@ FamixTest3TEntityCreator >> newType [
 { #category : 'entity creation' }
 FamixTest3TEntityCreator >> newTypeNamed: aName [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: (FamixTest3Type named: aName)
 ]

--- a/src/Famix-Test3-Entities/FamixTest3Type.class.st
+++ b/src/Famix-Test3-Entities/FamixTest3Type.class.st
@@ -41,6 +41,7 @@ Class {
 { #category : 'meta' }
 FamixTest3Type class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Type super: #FamixTest3NamedEntity>
 	<package: #'Famix-Test3-Entities'>
 	<generated>
@@ -48,6 +49,8 @@ FamixTest3Type class >> annotation [
 
 { #category : 'groups' }
 FamixTest3Type class >> annotationFamixTest3TypeGroup [
+
+	<ignoreForCoverage>
 	<generated>
 	<mooseGroup>
 	^ FamixTest3TypeGroup

--- a/src/Famix-Test4-Entities/FamixTest4Book.class.st
+++ b/src/Famix-Test4-Entities/FamixTest4Book.class.st
@@ -31,6 +31,7 @@ Class {
 { #category : 'meta' }
 FamixTest4Book class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Book super: #FamixTest4Entity>
 	<package: #'Famix-Test4-Entities'>
 	<generated>
@@ -39,6 +40,7 @@ FamixTest4Book class >> annotation [
 { #category : 'comparing' }
 FamixTest4Book >> = aFamixTest4Book [
 
+	<ignoreForCoverage>
 	<generated>
 	^ aFamixTest4Book id = self id
 ]
@@ -46,6 +48,7 @@ FamixTest4Book >> = aFamixTest4Book [
 { #category : 'comparing' }
 FamixTest4Book >> hash [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self id hash 
 ]
@@ -54,12 +57,14 @@ FamixTest4Book >> hash [
 FamixTest4Book >> id [
 
 	<FMProperty: #id type: #Number>
+	<ignoreForCoverage>
 	<generated>
 	^ id
 ]
 
 { #category : 'accessing' }
 FamixTest4Book >> id: anObject [
+	<ignoreForCoverage>
 	<generated>
 	id := anObject
 ]
@@ -68,6 +73,7 @@ FamixTest4Book >> id: anObject [
 FamixTest4Book >> person [
 	"Relation named: #person type: #FamixTest4Person opposite: #books"
 
+	<ignoreForCoverage>
 	<generated>
 	<container>
 	^ person
@@ -76,6 +82,7 @@ FamixTest4Book >> person [
 { #category : 'accessing' }
 FamixTest4Book >> person: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	person := anObject
 ]

--- a/src/Famix-Test4-Entities/FamixTest4Cafeteria.class.st
+++ b/src/Famix-Test4-Entities/FamixTest4Cafeteria.class.st
@@ -9,6 +9,7 @@ Class {
 { #category : 'meta' }
 FamixTest4Cafeteria class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Cafeteria super: #FamixTest4Room>
 	<package: #'Famix-Test4-Entities'>
 	<generated>

--- a/src/Famix-Test4-Entities/FamixTest4Classroom.class.st
+++ b/src/Famix-Test4-Entities/FamixTest4Classroom.class.st
@@ -9,6 +9,7 @@ Class {
 { #category : 'meta' }
 FamixTest4Classroom class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Classroom super: #FamixTest4Room>
 	<package: #'Famix-Test4-Entities'>
 	<generated>

--- a/src/Famix-Test4-Entities/FamixTest4Entity.class.st
+++ b/src/Famix-Test4-Entities/FamixTest4Entity.class.st
@@ -21,6 +21,7 @@ Class {
 { #category : 'meta' }
 FamixTest4Entity class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Entity super: #MooseEntity>
 	<package: #'Famix-Test4-Entities'>
 	<generated>
@@ -30,6 +31,7 @@ FamixTest4Entity class >> annotation [
 { #category : 'testing' }
 FamixTest4Entity class >> isAbstract [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self == FamixTest4Entity
 ]
@@ -37,6 +39,7 @@ FamixTest4Entity class >> isAbstract [
 { #category : 'meta' }
 FamixTest4Entity class >> metamodel [
 
+	<ignoreForCoverage>
 	<generated>
 	^ FamixTest4Model metamodel
 ]
@@ -45,12 +48,14 @@ FamixTest4Entity class >> metamodel [
 FamixTest4Entity >> name [
 
 	<FMProperty: #name type: #String>
+	<ignoreForCoverage>
 	<generated>
 	^ name
 ]
 
 { #category : 'accessing' }
 FamixTest4Entity >> name: anObject [
+	<ignoreForCoverage>
 	<generated>
 	name := anObject
 ]

--- a/src/Famix-Test4-Entities/FamixTest4Model.class.st
+++ b/src/Famix-Test4-Entities/FamixTest4Model.class.st
@@ -11,6 +11,7 @@ Class {
 { #category : 'meta' }
 FamixTest4Model class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Model super: #MooseModel>
 	<package: #'Famix-Test4-Entities'>
 	<generated>

--- a/src/Famix-Test4-Entities/FamixTest4Person.class.st
+++ b/src/Famix-Test4-Entities/FamixTest4Person.class.st
@@ -35,6 +35,7 @@ Class {
 { #category : 'meta' }
 FamixTest4Person class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Person super: #FamixTest4Entity>
 	<package: #'Famix-Test4-Entities'>
 	<generated>
@@ -44,6 +45,7 @@ FamixTest4Person class >> annotation [
 { #category : 'testing' }
 FamixTest4Person class >> isAbstract [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self == FamixTest4Person
 ]
@@ -51,12 +53,15 @@ FamixTest4Person class >> isAbstract [
 { #category : 'comparing' }
 FamixTest4Person >> = aFamixTest4Person [
 
+	<ignoreForCoverage>
 	<generated>
 	^ aFamixTest4Person firstName = self firstName and: [ aFamixTest4Person lastName = self lastName and: [ aFamixTest4Person age = self age] ] 
 ]
 
 { #category : 'adding' }
 FamixTest4Person >> addBook: anObject [
+
+	<ignoreForCoverage>
 	<generated>
 	^ self books add: anObject
 ]
@@ -65,12 +70,14 @@ FamixTest4Person >> addBook: anObject [
 FamixTest4Person >> age [
 
 	<FMProperty: #age type: #Number>
+	<ignoreForCoverage>
 	<generated>
 	^ age
 ]
 
 { #category : 'accessing' }
 FamixTest4Person >> age: anObject [
+	<ignoreForCoverage>
 	<generated>
 	age := anObject
 ]
@@ -79,6 +86,7 @@ FamixTest4Person >> age: anObject [
 FamixTest4Person >> books [
 	"Relation named: #books type: #FamixTest4Book opposite: #person"
 
+	<ignoreForCoverage>
 	<generated>
 	<derived>
 	^ books
@@ -87,6 +95,7 @@ FamixTest4Person >> books [
 { #category : 'accessing' }
 FamixTest4Person >> books: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	books value: anObject
 ]
@@ -95,12 +104,14 @@ FamixTest4Person >> books: anObject [
 FamixTest4Person >> firstName [
 
 	<FMProperty: #firstName type: #String>
+	<ignoreForCoverage>
 	<generated>
 	^ firstName
 ]
 
 { #category : 'accessing' }
 FamixTest4Person >> firstName: anObject [
+	<ignoreForCoverage>
 	<generated>
 	firstName := anObject
 ]
@@ -108,6 +119,7 @@ FamixTest4Person >> firstName: anObject [
 { #category : 'comparing' }
 FamixTest4Person >> hash [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self firstName hash bitXor: self lastName hash bitXor: self age hash 
 ]
@@ -116,12 +128,14 @@ FamixTest4Person >> hash [
 FamixTest4Person >> lastName [
 
 	<FMProperty: #lastName type: #String>
+	<ignoreForCoverage>
 	<generated>
 	^ lastName
 ]
 
 { #category : 'accessing' }
 FamixTest4Person >> lastName: anObject [
+	<ignoreForCoverage>
 	<generated>
 	lastName := anObject
 ]

--- a/src/Famix-Test4-Entities/FamixTest4Principal.class.st
+++ b/src/Famix-Test4-Entities/FamixTest4Principal.class.st
@@ -24,6 +24,7 @@ Class {
 { #category : 'meta' }
 FamixTest4Principal class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Principal super: #FamixTest4Person>
 	<package: #'Famix-Test4-Entities'>
 	<generated>
@@ -33,6 +34,7 @@ FamixTest4Principal class >> annotation [
 FamixTest4Principal >> school [
 	"Relation named: #school type: #FamixTest4School opposite: #principal"
 
+	<ignoreForCoverage>
 	<generated>
 	<container>
 	^ school
@@ -41,6 +43,7 @@ FamixTest4Principal >> school [
 { #category : 'accessing' }
 FamixTest4Principal >> school: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	school := anObject
 ]

--- a/src/Famix-Test4-Entities/FamixTest4Room.class.st
+++ b/src/Famix-Test4-Entities/FamixTest4Room.class.st
@@ -24,6 +24,7 @@ Class {
 { #category : 'meta' }
 FamixTest4Room class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Room super: #FamixTest4Entity>
 	<package: #'Famix-Test4-Entities'>
 	<generated>
@@ -33,6 +34,7 @@ FamixTest4Room class >> annotation [
 FamixTest4Room >> school [
 	"Relation named: #school type: #FamixTest4School opposite: #rooms"
 
+	<ignoreForCoverage>
 	<generated>
 	<container>
 	^ school
@@ -41,6 +43,7 @@ FamixTest4Room >> school [
 { #category : 'accessing' }
 FamixTest4Room >> school: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	school := anObject
 ]

--- a/src/Famix-Test4-Entities/FamixTest4School.class.st
+++ b/src/Famix-Test4-Entities/FamixTest4School.class.st
@@ -30,6 +30,7 @@ Class {
 { #category : 'meta' }
 FamixTest4School class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #School super: #FamixTest4Entity>
 	<package: #'Famix-Test4-Entities'>
 	<generated>
@@ -37,18 +38,24 @@ FamixTest4School class >> annotation [
 
 { #category : 'adding' }
 FamixTest4School >> addRoom: anObject [
+
+	<ignoreForCoverage>
 	<generated>
 	^ self rooms add: anObject
 ]
 
 { #category : 'adding' }
 FamixTest4School >> addStudent: anObject [
+
+	<ignoreForCoverage>
 	<generated>
 	^ self students add: anObject
 ]
 
 { #category : 'adding' }
 FamixTest4School >> addTeacher: anObject [
+
+	<ignoreForCoverage>
 	<generated>
 	^ self teachers add: anObject
 ]
@@ -57,6 +64,7 @@ FamixTest4School >> addTeacher: anObject [
 FamixTest4School >> principal [
 	"Relation named: #principal type: #FamixTest4Principal opposite: #school"
 
+	<ignoreForCoverage>
 	<generated>
 	<derived>
 	^ principal
@@ -65,6 +73,7 @@ FamixTest4School >> principal [
 { #category : 'accessing' }
 FamixTest4School >> principal: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	principal := anObject
 ]
@@ -73,6 +82,7 @@ FamixTest4School >> principal: anObject [
 FamixTest4School >> rooms [
 	"Relation named: #rooms type: #FamixTest4Room opposite: #school"
 
+	<ignoreForCoverage>
 	<generated>
 	<derived>
 	^ rooms
@@ -81,6 +91,7 @@ FamixTest4School >> rooms [
 { #category : 'accessing' }
 FamixTest4School >> rooms: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	rooms value: anObject
 ]
@@ -89,6 +100,7 @@ FamixTest4School >> rooms: anObject [
 FamixTest4School >> students [
 	"Relation named: #students type: #FamixTest4Student opposite: #school"
 
+	<ignoreForCoverage>
 	<generated>
 	<derived>
 	^ students
@@ -97,6 +109,7 @@ FamixTest4School >> students [
 { #category : 'accessing' }
 FamixTest4School >> students: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	students value: anObject
 ]
@@ -105,6 +118,7 @@ FamixTest4School >> students: anObject [
 FamixTest4School >> teachers [
 	"Relation named: #teachers type: #FamixTest4Teacher opposite: #school"
 
+	<ignoreForCoverage>
 	<generated>
 	<derived>
 	^ teachers
@@ -113,6 +127,7 @@ FamixTest4School >> teachers [
 { #category : 'accessing' }
 FamixTest4School >> teachers: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	teachers value: anObject
 ]

--- a/src/Famix-Test4-Entities/FamixTest4Student.class.st
+++ b/src/Famix-Test4-Entities/FamixTest4Student.class.st
@@ -30,6 +30,7 @@ Class {
 { #category : 'meta' }
 FamixTest4Student class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Student super: #FamixTest4Person>
 	<package: #'Famix-Test4-Entities'>
 	<generated>
@@ -37,6 +38,8 @@ FamixTest4Student class >> annotation [
 
 { #category : 'adding' }
 FamixTest4Student >> addTeacher: anObject [
+
+	<ignoreForCoverage>
 	<generated>
 	^ self teachers add: anObject
 ]
@@ -45,6 +48,7 @@ FamixTest4Student >> addTeacher: anObject [
 FamixTest4Student >> school [
 	"Relation named: #school type: #FamixTest4School opposite: #students"
 
+	<ignoreForCoverage>
 	<generated>
 	<container>
 	^ school
@@ -53,6 +57,7 @@ FamixTest4Student >> school [
 { #category : 'accessing' }
 FamixTest4Student >> school: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	school := anObject
 ]
@@ -61,6 +66,7 @@ FamixTest4Student >> school: anObject [
 FamixTest4Student >> teachers [
 	"Relation named: #teachers type: #FamixTest4Teacher opposite: #students"
 
+	<ignoreForCoverage>
 	<generated>
 	<derived>
 	^ teachers
@@ -69,6 +75,7 @@ FamixTest4Student >> teachers [
 { #category : 'accessing' }
 FamixTest4Student >> teachers: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	teachers value: anObject
 ]

--- a/src/Famix-Test4-Entities/FamixTest4TEntityCreator.trait.st
+++ b/src/Famix-Test4-Entities/FamixTest4TEntityCreator.trait.st
@@ -14,6 +14,7 @@ Trait {
 { #category : 'meta' }
 FamixTest4TEntityCreator classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TEntityCreator super: #Object>
 	<package: #'Famix-Test4-Entities'>
 	<generated>
@@ -22,6 +23,7 @@ FamixTest4TEntityCreator classSide >> annotation [
 { #category : 'entity creation' }
 FamixTest4TEntityCreator >> newBook [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixTest4Book new
 ]
@@ -29,6 +31,7 @@ FamixTest4TEntityCreator >> newBook [
 { #category : 'entity creation' }
 FamixTest4TEntityCreator >> newCafeteria [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixTest4Cafeteria new
 ]
@@ -36,6 +39,7 @@ FamixTest4TEntityCreator >> newCafeteria [
 { #category : 'entity creation' }
 FamixTest4TEntityCreator >> newClassroom [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixTest4Classroom new
 ]
@@ -43,6 +47,7 @@ FamixTest4TEntityCreator >> newClassroom [
 { #category : 'entity creation' }
 FamixTest4TEntityCreator >> newPrincipal [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixTest4Principal new
 ]
@@ -50,6 +55,7 @@ FamixTest4TEntityCreator >> newPrincipal [
 { #category : 'entity creation' }
 FamixTest4TEntityCreator >> newRoom [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixTest4Room new
 ]
@@ -57,6 +63,7 @@ FamixTest4TEntityCreator >> newRoom [
 { #category : 'entity creation' }
 FamixTest4TEntityCreator >> newSchool [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixTest4School new
 ]
@@ -64,6 +71,7 @@ FamixTest4TEntityCreator >> newSchool [
 { #category : 'entity creation' }
 FamixTest4TEntityCreator >> newStudent [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixTest4Student new
 ]
@@ -71,6 +79,7 @@ FamixTest4TEntityCreator >> newStudent [
 { #category : 'entity creation' }
 FamixTest4TEntityCreator >> newTeacher [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixTest4Teacher new
 ]

--- a/src/Famix-Test4-Entities/FamixTest4Teacher.class.st
+++ b/src/Famix-Test4-Entities/FamixTest4Teacher.class.st
@@ -30,6 +30,7 @@ Class {
 { #category : 'meta' }
 FamixTest4Teacher class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Teacher super: #FamixTest4Person>
 	<package: #'Famix-Test4-Entities'>
 	<generated>
@@ -37,6 +38,8 @@ FamixTest4Teacher class >> annotation [
 
 { #category : 'adding' }
 FamixTest4Teacher >> addStudent: anObject [
+
+	<ignoreForCoverage>
 	<generated>
 	^ self students add: anObject
 ]
@@ -45,6 +48,7 @@ FamixTest4Teacher >> addStudent: anObject [
 FamixTest4Teacher >> school [
 	"Relation named: #school type: #FamixTest4School opposite: #teachers"
 
+	<ignoreForCoverage>
 	<generated>
 	<container>
 	^ school
@@ -53,6 +57,7 @@ FamixTest4Teacher >> school [
 { #category : 'accessing' }
 FamixTest4Teacher >> school: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	school := anObject
 ]
@@ -61,6 +66,7 @@ FamixTest4Teacher >> school: anObject [
 FamixTest4Teacher >> students [
 	"Relation named: #students type: #FamixTest4Student opposite: #teachers"
 
+	<ignoreForCoverage>
 	<generated>
 	^ students
 ]
@@ -68,6 +74,7 @@ FamixTest4Teacher >> students [
 { #category : 'accessing' }
 FamixTest4Teacher >> students: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	students value: anObject
 ]

--- a/src/Famix-Test5-Entities/FamixTest5AnnotationType1.class.st
+++ b/src/Famix-Test5-Entities/FamixTest5AnnotationType1.class.st
@@ -28,6 +28,7 @@ Class {
 { #category : 'meta' }
 FamixTest5AnnotationType1 class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #AnnotationType1 super: #FamixTest5Entity>
 	<package: #'Famix-Test5-Entities'>
 	<generated>

--- a/src/Famix-Test5-Entities/FamixTest5AnnotationType2.class.st
+++ b/src/Famix-Test5-Entities/FamixTest5AnnotationType2.class.st
@@ -28,6 +28,7 @@ Class {
 { #category : 'meta' }
 FamixTest5AnnotationType2 class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #AnnotationType2 super: #FamixTest5Entity>
 	<package: #'Famix-Test5-Entities'>
 	<generated>

--- a/src/Famix-Test5-Entities/FamixTest5Entity.class.st
+++ b/src/Famix-Test5-Entities/FamixTest5Entity.class.st
@@ -11,6 +11,7 @@ Class {
 { #category : 'meta' }
 FamixTest5Entity class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Entity super: #MooseEntity>
 	<package: #'Famix-Test5-Entities'>
 	<generated>
@@ -20,6 +21,7 @@ FamixTest5Entity class >> annotation [
 { #category : 'testing' }
 FamixTest5Entity class >> isAbstract [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self == FamixTest5Entity
 ]
@@ -27,6 +29,7 @@ FamixTest5Entity class >> isAbstract [
 { #category : 'meta' }
 FamixTest5Entity class >> metamodel [
 
+	<ignoreForCoverage>
 	<generated>
 	^ FamixTest5Model metamodel
 ]

--- a/src/Famix-Test5-Entities/FamixTest5Model.class.st
+++ b/src/Famix-Test5-Entities/FamixTest5Model.class.st
@@ -10,6 +10,8 @@ Class {
 
 { #category : 'accessing' }
 FamixTest5Model class >> allSubmetamodelsPackagesNames [
+
+	<ignoreForCoverage>
 	<generated>
 	^ #(#'Moose-Query' #'Famix-Traits')
 ]
@@ -17,6 +19,7 @@ FamixTest5Model class >> allSubmetamodelsPackagesNames [
 { #category : 'meta' }
 FamixTest5Model class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Model super: #MooseModel>
 	<package: #'Famix-Test5-Entities'>
 	<generated>

--- a/src/Famix-Test5-Entities/FamixTest5TEntity.trait.st
+++ b/src/Famix-Test5-Entities/FamixTest5TEntity.trait.st
@@ -10,6 +10,7 @@ Trait {
 { #category : 'meta' }
 FamixTest5TEntity classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TEntity super: #Object>
 	<package: #'Famix-Test5-Entities'>
 	<generated>

--- a/src/Famix-Test5-Entities/FamixTest5TEntityCreator.trait.st
+++ b/src/Famix-Test5-Entities/FamixTest5TEntityCreator.trait.st
@@ -14,6 +14,7 @@ Trait {
 { #category : 'meta' }
 FamixTest5TEntityCreator classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TEntityCreator super: #Object>
 	<package: #'Famix-Test5-Entities'>
 	<generated>
@@ -22,6 +23,7 @@ FamixTest5TEntityCreator classSide >> annotation [
 { #category : 'entity creation' }
 FamixTest5TEntityCreator >> newAnnotationType1 [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixTest5AnnotationType1 new
 ]
@@ -29,6 +31,7 @@ FamixTest5TEntityCreator >> newAnnotationType1 [
 { #category : 'entity creation' }
 FamixTest5TEntityCreator >> newAnnotationType2 [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixTest5AnnotationType2 new
 ]
@@ -36,6 +39,7 @@ FamixTest5TEntityCreator >> newAnnotationType2 [
 { #category : 'entity creation' }
 FamixTest5TEntityCreator >> newWithAnnotationType1 [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixTest5WithAnnotationType1 new
 ]
@@ -43,6 +47,7 @@ FamixTest5TEntityCreator >> newWithAnnotationType1 [
 { #category : 'entity creation' }
 FamixTest5TEntityCreator >> newWithAnnotationType2 [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixTest5WithAnnotationType2 new
 ]

--- a/src/Famix-Test5-Entities/FamixTest5WithAnnotationType1.class.st
+++ b/src/Famix-Test5-Entities/FamixTest5WithAnnotationType1.class.st
@@ -23,6 +23,7 @@ Class {
 { #category : 'meta' }
 FamixTest5WithAnnotationType1 class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #WithAnnotationType1 super: #FamixTest5Entity>
 	<package: #'Famix-Test5-Entities'>
 	<generated>

--- a/src/Famix-Test5-Entities/FamixTest5WithAnnotationType2.class.st
+++ b/src/Famix-Test5-Entities/FamixTest5WithAnnotationType2.class.st
@@ -23,6 +23,7 @@ Class {
 { #category : 'meta' }
 FamixTest5WithAnnotationType2 class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #WithAnnotationType2 super: #FamixTest5Entity>
 	<package: #'Famix-Test5-Entities'>
 	<generated>

--- a/src/Famix-Test6-Entities/FamixTest6Bacon.class.st
+++ b/src/Famix-Test6-Entities/FamixTest6Bacon.class.st
@@ -25,6 +25,7 @@ Class {
 { #category : 'meta' }
 FamixTest6Bacon class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Bacon super: #FamixTest6Entity>
 	<package: #'Famix-Test6-Entities'>
 	<generated>
@@ -34,12 +35,14 @@ FamixTest6Bacon class >> annotation [
 FamixTest6Bacon >> brand [
 
 	<FMProperty: #brand type: #String defaultValue: ''>
+	<ignoreForCoverage>
 	<generated>
 	^ brand ifNil: [ brand := '' ]
 ]
 
 { #category : 'accessing' }
 FamixTest6Bacon >> brand: anObject [
+	<ignoreForCoverage>
 	<generated>
 	brand := anObject
 ]
@@ -48,12 +51,14 @@ FamixTest6Bacon >> brand: anObject [
 FamixTest6Bacon >> eggs [
 
 	<FMProperty: #eggs type: #Number defaultValue: 12>
+	<ignoreForCoverage>
 	<generated>
 	^ eggs ifNil: [ eggs := 12 ]
 ]
 
 { #category : 'accessing' }
 FamixTest6Bacon >> eggs: anObject [
+	<ignoreForCoverage>
 	<generated>
 	eggs := anObject
 ]
@@ -62,12 +67,14 @@ FamixTest6Bacon >> eggs: anObject [
 FamixTest6Bacon >> isFood [
 
 	<FMProperty: #isFood type: #Boolean defaultValue: true>
+	<ignoreForCoverage>
 	<generated>
 	^ isFood ifNil: [ isFood := true ]
 ]
 
 { #category : 'accessing' }
 FamixTest6Bacon >> isFood: anObject [
+	<ignoreForCoverage>
 	<generated>
 	isFood := anObject
 ]

--- a/src/Famix-Test6-Entities/FamixTest6Comment.class.st
+++ b/src/Famix-Test6-Entities/FamixTest6Comment.class.st
@@ -28,6 +28,7 @@ Class {
 { #category : 'meta' }
 FamixTest6Comment class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Comment super: #FamixTest6SourcedEntity>
 	<package: #'Famix-Test6-Entities'>
 	<generated>

--- a/src/Famix-Test6-Entities/FamixTest6Entity.class.st
+++ b/src/Famix-Test6-Entities/FamixTest6Entity.class.st
@@ -9,6 +9,7 @@ Class {
 { #category : 'meta' }
 FamixTest6Entity class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Entity super: #MooseEntity>
 	<package: #'Famix-Test6-Entities'>
 	<generated>
@@ -18,6 +19,7 @@ FamixTest6Entity class >> annotation [
 { #category : 'testing' }
 FamixTest6Entity class >> isAbstract [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self == FamixTest6Entity
 ]
@@ -25,6 +27,7 @@ FamixTest6Entity class >> isAbstract [
 { #category : 'meta' }
 FamixTest6Entity class >> metamodel [
 
+	<ignoreForCoverage>
 	<generated>
 	^ FamixTest6Model metamodel
 ]
@@ -32,6 +35,7 @@ FamixTest6Entity class >> metamodel [
 { #category : 'testing' }
 FamixTest6Entity >> hasImmediateSource [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -39,6 +43,7 @@ FamixTest6Entity >> hasImmediateSource [
 { #category : 'testing' }
 FamixTest6Entity >> isComment [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -46,6 +51,7 @@ FamixTest6Entity >> isComment [
 { #category : 'testing' }
 FamixTest6Entity >> isNamedEntity [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -53,6 +59,7 @@ FamixTest6Entity >> isNamedEntity [
 { #category : 'testing' }
 FamixTest6Entity >> isQueryable [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]

--- a/src/Famix-Test6-Entities/FamixTest6Model.class.st
+++ b/src/Famix-Test6-Entities/FamixTest6Model.class.st
@@ -10,6 +10,8 @@ Class {
 
 { #category : 'accessing' }
 FamixTest6Model class >> allSubmetamodelsPackagesNames [
+
+	<ignoreForCoverage>
 	<generated>
 	^ #(#'Moose-Query' #'Famix-Traits')
 ]
@@ -17,6 +19,7 @@ FamixTest6Model class >> allSubmetamodelsPackagesNames [
 { #category : 'meta' }
 FamixTest6Model class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Model super: #MooseModel>
 	<package: #'Famix-Test6-Entities'>
 	<generated>

--- a/src/Famix-Test6-Entities/FamixTest6NamedEntity.class.st
+++ b/src/Famix-Test6-Entities/FamixTest6NamedEntity.class.st
@@ -20,6 +20,7 @@ Class {
 { #category : 'meta' }
 FamixTest6NamedEntity class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #NamedEntity super: #FamixTest6Entity>
 	<package: #'Famix-Test6-Entities'>
 	<generated>
@@ -29,6 +30,7 @@ FamixTest6NamedEntity class >> annotation [
 { #category : 'testing' }
 FamixTest6NamedEntity class >> isAbstract [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self == FamixTest6NamedEntity
 ]
@@ -36,6 +38,7 @@ FamixTest6NamedEntity class >> isAbstract [
 { #category : 'testing' }
 FamixTest6NamedEntity >> isNamedEntity [
 
+	<ignoreForCoverage>
 	<generated>
 	^ true
 ]

--- a/src/Famix-Test6-Entities/FamixTest6SourceAnchor.class.st
+++ b/src/Famix-Test6-Entities/FamixTest6SourceAnchor.class.st
@@ -23,6 +23,7 @@ Class {
 { #category : 'meta' }
 FamixTest6SourceAnchor class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #SourceAnchor super: #FamixTest6Entity>
 	<package: #'Famix-Test6-Entities'>
 	<generated>
@@ -32,6 +33,7 @@ FamixTest6SourceAnchor class >> annotation [
 { #category : 'testing' }
 FamixTest6SourceAnchor class >> isAbstract [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self == FamixTest6SourceAnchor
 ]

--- a/src/Famix-Test6-Entities/FamixTest6SourceLanguage.class.st
+++ b/src/Famix-Test6-Entities/FamixTest6SourceLanguage.class.st
@@ -23,6 +23,7 @@ Class {
 { #category : 'meta' }
 FamixTest6SourceLanguage class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #SourceLanguage super: #FamixTest6Entity>
 	<package: #'Famix-Test6-Entities'>
 	<generated>

--- a/src/Famix-Test6-Entities/FamixTest6SourceTextAnchor.class.st
+++ b/src/Famix-Test6-Entities/FamixTest6SourceTextAnchor.class.st
@@ -29,6 +29,7 @@ Class {
 { #category : 'meta' }
 FamixTest6SourceTextAnchor class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #SourceTextAnchor super: #FamixTest6SourceAnchor>
 	<package: #'Famix-Test6-Entities'>
 	<generated>

--- a/src/Famix-Test6-Entities/FamixTest6SourcedEntity.class.st
+++ b/src/Famix-Test6-Entities/FamixTest6SourcedEntity.class.st
@@ -23,6 +23,7 @@ Class {
 { #category : 'meta' }
 FamixTest6SourcedEntity class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #SourcedEntity super: #FamixTest6Entity>
 	<package: #'Famix-Test6-Entities'>
 	<generated>
@@ -32,6 +33,7 @@ FamixTest6SourcedEntity class >> annotation [
 { #category : 'testing' }
 FamixTest6SourcedEntity class >> isAbstract [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self == FamixTest6SourcedEntity
 ]

--- a/src/Famix-Test6-Entities/FamixTest6Spam.class.st
+++ b/src/Famix-Test6-Entities/FamixTest6Spam.class.st
@@ -21,6 +21,7 @@ Class {
 { #category : 'meta' }
 FamixTest6Spam class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Spam super: #FamixTest6Bacon>
 	<package: #'Famix-Test6-Entities'>
 	<generated>
@@ -30,12 +31,14 @@ FamixTest6Spam class >> annotation [
 FamixTest6Spam >> isSomething [
 
 	<FMProperty: #isSomething type: #Boolean defaultValue: false>
+	<ignoreForCoverage>
 	<generated>
 	^ isSomething ifNil: [ isSomething := false ]
 ]
 
 { #category : 'accessing' }
 FamixTest6Spam >> isSomething: anObject [
+	<ignoreForCoverage>
 	<generated>
 	isSomething := anObject
 ]

--- a/src/Famix-Test6-Entities/FamixTest6TEntityCreator.trait.st
+++ b/src/Famix-Test6-Entities/FamixTest6TEntityCreator.trait.st
@@ -14,6 +14,7 @@ Trait {
 { #category : 'meta' }
 FamixTest6TEntityCreator classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TEntityCreator super: #Object>
 	<package: #'Famix-Test6-Entities'>
 	<generated>
@@ -22,6 +23,7 @@ FamixTest6TEntityCreator classSide >> annotation [
 { #category : 'entity creation' }
 FamixTest6TEntityCreator >> newBacon [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixTest6Bacon new
 ]
@@ -29,6 +31,7 @@ FamixTest6TEntityCreator >> newBacon [
 { #category : 'entity creation' }
 FamixTest6TEntityCreator >> newComment [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixTest6Comment new
 ]
@@ -36,6 +39,7 @@ FamixTest6TEntityCreator >> newComment [
 { #category : 'entity creation' }
 FamixTest6TEntityCreator >> newSourceLanguage [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixTest6SourceLanguage new
 ]
@@ -43,6 +47,7 @@ FamixTest6TEntityCreator >> newSourceLanguage [
 { #category : 'entity creation' }
 FamixTest6TEntityCreator >> newSourceTextAnchor [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixTest6SourceTextAnchor new
 ]
@@ -50,6 +55,7 @@ FamixTest6TEntityCreator >> newSourceTextAnchor [
 { #category : 'entity creation' }
 FamixTest6TEntityCreator >> newSpam [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixTest6Spam new
 ]

--- a/src/Famix-Test7-Entities/FamixTest7Class.class.st
+++ b/src/Famix-Test7-Entities/FamixTest7Class.class.st
@@ -55,6 +55,7 @@ Class {
 { #category : 'meta' }
 FamixTest7Class class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Class super: #FamixTest7Entity>
 	<package: #'Famix-Test7-Entities'>
 	<generated>

--- a/src/Famix-Test7-Entities/FamixTest7Comment.class.st
+++ b/src/Famix-Test7-Entities/FamixTest7Comment.class.st
@@ -28,6 +28,7 @@ Class {
 { #category : 'meta' }
 FamixTest7Comment class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Comment super: #FamixTest7SourcedEntity>
 	<package: #'Famix-Test7-Entities'>
 	<generated>

--- a/src/Famix-Test7-Entities/FamixTest7Entity.class.st
+++ b/src/Famix-Test7-Entities/FamixTest7Entity.class.st
@@ -9,6 +9,7 @@ Class {
 { #category : 'meta' }
 FamixTest7Entity class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Entity super: #MooseEntity>
 	<package: #'Famix-Test7-Entities'>
 	<generated>
@@ -18,6 +19,7 @@ FamixTest7Entity class >> annotation [
 { #category : 'testing' }
 FamixTest7Entity class >> isAbstract [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self == FamixTest7Entity
 ]
@@ -25,6 +27,7 @@ FamixTest7Entity class >> isAbstract [
 { #category : 'meta' }
 FamixTest7Entity class >> metamodel [
 
+	<ignoreForCoverage>
 	<generated>
 	^ FamixTest7Model metamodel
 ]
@@ -32,6 +35,7 @@ FamixTest7Entity class >> metamodel [
 { #category : 'testing' }
 FamixTest7Entity >> canBeStub [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -39,6 +43,7 @@ FamixTest7Entity >> canBeStub [
 { #category : 'testing' }
 FamixTest7Entity >> hasImmediateSource [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -46,6 +51,7 @@ FamixTest7Entity >> hasImmediateSource [
 { #category : 'testing' }
 FamixTest7Entity >> isAssociation [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -53,6 +59,7 @@ FamixTest7Entity >> isAssociation [
 { #category : 'testing' }
 FamixTest7Entity >> isBehavioural [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -60,6 +67,7 @@ FamixTest7Entity >> isBehavioural [
 { #category : 'testing' }
 FamixTest7Entity >> isClass [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -67,6 +75,7 @@ FamixTest7Entity >> isClass [
 { #category : 'testing' }
 FamixTest7Entity >> isComment [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -74,6 +83,7 @@ FamixTest7Entity >> isComment [
 { #category : 'testing' }
 FamixTest7Entity >> isInheritance [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -81,6 +91,7 @@ FamixTest7Entity >> isInheritance [
 { #category : 'testing' }
 FamixTest7Entity >> isMethod [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -88,6 +99,7 @@ FamixTest7Entity >> isMethod [
 { #category : 'testing' }
 FamixTest7Entity >> isNamedEntity [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -95,6 +107,7 @@ FamixTest7Entity >> isNamedEntity [
 { #category : 'testing' }
 FamixTest7Entity >> isQueryable [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -102,6 +115,7 @@ FamixTest7Entity >> isQueryable [
 { #category : 'testing' }
 FamixTest7Entity >> isType [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]

--- a/src/Famix-Test7-Entities/FamixTest7Inheritance.class.st
+++ b/src/Famix-Test7-Entities/FamixTest7Inheritance.class.st
@@ -35,6 +35,7 @@ Class {
 { #category : 'meta' }
 FamixTest7Inheritance class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Inheritance super: #FamixTest7Entity>
 	<package: #'Famix-Test7-Entities'>
 	<generated>

--- a/src/Famix-Test7-Entities/FamixTest7Method.class.st
+++ b/src/Famix-Test7-Entities/FamixTest7Method.class.st
@@ -56,6 +56,7 @@ Class {
 { #category : 'meta' }
 FamixTest7Method class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Method super: #FamixTest7Entity>
 	<package: #'Famix-Test7-Entities'>
 	<generated>

--- a/src/Famix-Test7-Entities/FamixTest7Model.class.st
+++ b/src/Famix-Test7-Entities/FamixTest7Model.class.st
@@ -10,6 +10,8 @@ Class {
 
 { #category : 'accessing' }
 FamixTest7Model class >> allSubmetamodelsPackagesNames [
+
+	<ignoreForCoverage>
 	<generated>
 	^ #(#'Moose-Query' #'Famix-Traits')
 ]
@@ -17,6 +19,7 @@ FamixTest7Model class >> allSubmetamodelsPackagesNames [
 { #category : 'meta' }
 FamixTest7Model class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Model super: #MooseModel>
 	<package: #'Famix-Test7-Entities'>
 	<generated>

--- a/src/Famix-Test7-Entities/FamixTest7NamedEntity.class.st
+++ b/src/Famix-Test7-Entities/FamixTest7NamedEntity.class.st
@@ -20,6 +20,7 @@ Class {
 { #category : 'meta' }
 FamixTest7NamedEntity class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #NamedEntity super: #FamixTest7Entity>
 	<package: #'Famix-Test7-Entities'>
 	<generated>
@@ -29,6 +30,7 @@ FamixTest7NamedEntity class >> annotation [
 { #category : 'testing' }
 FamixTest7NamedEntity class >> isAbstract [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self == FamixTest7NamedEntity
 ]
@@ -36,6 +38,7 @@ FamixTest7NamedEntity class >> isAbstract [
 { #category : 'testing' }
 FamixTest7NamedEntity >> isNamedEntity [
 
+	<ignoreForCoverage>
 	<generated>
 	^ true
 ]

--- a/src/Famix-Test7-Entities/FamixTest7SourceAnchor.class.st
+++ b/src/Famix-Test7-Entities/FamixTest7SourceAnchor.class.st
@@ -23,6 +23,7 @@ Class {
 { #category : 'meta' }
 FamixTest7SourceAnchor class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #SourceAnchor super: #FamixTest7Entity>
 	<package: #'Famix-Test7-Entities'>
 	<generated>
@@ -32,6 +33,7 @@ FamixTest7SourceAnchor class >> annotation [
 { #category : 'testing' }
 FamixTest7SourceAnchor class >> isAbstract [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self == FamixTest7SourceAnchor
 ]

--- a/src/Famix-Test7-Entities/FamixTest7SourceLanguage.class.st
+++ b/src/Famix-Test7-Entities/FamixTest7SourceLanguage.class.st
@@ -23,6 +23,7 @@ Class {
 { #category : 'meta' }
 FamixTest7SourceLanguage class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #SourceLanguage super: #FamixTest7Entity>
 	<package: #'Famix-Test7-Entities'>
 	<generated>

--- a/src/Famix-Test7-Entities/FamixTest7SourceTextAnchor.class.st
+++ b/src/Famix-Test7-Entities/FamixTest7SourceTextAnchor.class.st
@@ -29,6 +29,7 @@ Class {
 { #category : 'meta' }
 FamixTest7SourceTextAnchor class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #SourceTextAnchor super: #FamixTest7SourceAnchor>
 	<package: #'Famix-Test7-Entities'>
 	<generated>

--- a/src/Famix-Test7-Entities/FamixTest7SourcedEntity.class.st
+++ b/src/Famix-Test7-Entities/FamixTest7SourcedEntity.class.st
@@ -23,6 +23,7 @@ Class {
 { #category : 'meta' }
 FamixTest7SourcedEntity class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #SourcedEntity super: #FamixTest7Entity>
 	<package: #'Famix-Test7-Entities'>
 	<generated>
@@ -32,6 +33,7 @@ FamixTest7SourcedEntity class >> annotation [
 { #category : 'testing' }
 FamixTest7SourcedEntity class >> isAbstract [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self == FamixTest7SourcedEntity
 ]

--- a/src/Famix-Test7-Entities/FamixTest7TEntityCreator.trait.st
+++ b/src/Famix-Test7-Entities/FamixTest7TEntityCreator.trait.st
@@ -14,6 +14,7 @@ Trait {
 { #category : 'meta' }
 FamixTest7TEntityCreator classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TEntityCreator super: #Object>
 	<package: #'Famix-Test7-Entities'>
 	<generated>
@@ -22,6 +23,7 @@ FamixTest7TEntityCreator classSide >> annotation [
 { #category : 'entity creation' }
 FamixTest7TEntityCreator >> newClass [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixTest7Class new
 ]
@@ -29,6 +31,7 @@ FamixTest7TEntityCreator >> newClass [
 { #category : 'entity creation' }
 FamixTest7TEntityCreator >> newClassNamed: aName [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: (FamixTest7Class named: aName)
 ]
@@ -36,6 +39,7 @@ FamixTest7TEntityCreator >> newClassNamed: aName [
 { #category : 'entity creation' }
 FamixTest7TEntityCreator >> newComment [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixTest7Comment new
 ]
@@ -43,6 +47,7 @@ FamixTest7TEntityCreator >> newComment [
 { #category : 'entity creation' }
 FamixTest7TEntityCreator >> newInheritance [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixTest7Inheritance new
 ]
@@ -50,6 +55,7 @@ FamixTest7TEntityCreator >> newInheritance [
 { #category : 'entity creation' }
 FamixTest7TEntityCreator >> newMethod [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixTest7Method new
 ]
@@ -57,6 +63,7 @@ FamixTest7TEntityCreator >> newMethod [
 { #category : 'entity creation' }
 FamixTest7TEntityCreator >> newMethodNamed: aName [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: (FamixTest7Method named: aName)
 ]
@@ -64,6 +71,7 @@ FamixTest7TEntityCreator >> newMethodNamed: aName [
 { #category : 'entity creation' }
 FamixTest7TEntityCreator >> newSourceLanguage [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixTest7SourceLanguage new
 ]
@@ -71,6 +79,7 @@ FamixTest7TEntityCreator >> newSourceLanguage [
 { #category : 'entity creation' }
 FamixTest7TEntityCreator >> newSourceTextAnchor [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixTest7SourceTextAnchor new
 ]

--- a/src/Famix-Test8-Entities/FamixTest8Animal.class.st
+++ b/src/Famix-Test8-Entities/FamixTest8Animal.class.st
@@ -23,6 +23,7 @@ Class {
 { #category : 'meta' }
 FamixTest8Animal class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Animal super: #FamixTest8LivingBeing>
 	<package: #'Famix-Test8-Entities'>
 	<generated>

--- a/src/Famix-Test8-Entities/FamixTest8Bacteria.class.st
+++ b/src/Famix-Test8-Entities/FamixTest8Bacteria.class.st
@@ -29,6 +29,7 @@ Class {
 { #category : 'meta' }
 FamixTest8Bacteria class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Bacteria super: #FamixTest8LivingBeing>
 	<package: #'Famix-Test8-Entities'>
 	<generated>

--- a/src/Famix-Test8-Entities/FamixTest8Biotope.class.st
+++ b/src/Famix-Test8-Entities/FamixTest8Biotope.class.st
@@ -23,6 +23,7 @@ Class {
 { #category : 'meta' }
 FamixTest8Biotope class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Biotope super: #FamixTest8Entity>
 	<package: #'Famix-Test8-Entities'>
 	<generated>

--- a/src/Famix-Test8-Entities/FamixTest8Entity.class.st
+++ b/src/Famix-Test8-Entities/FamixTest8Entity.class.st
@@ -9,6 +9,7 @@ Class {
 { #category : 'meta' }
 FamixTest8Entity class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Entity super: #MooseEntity>
 	<package: #'Famix-Test8-Entities'>
 	<generated>
@@ -18,6 +19,7 @@ FamixTest8Entity class >> annotation [
 { #category : 'testing' }
 FamixTest8Entity class >> isAbstract [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self == FamixTest8Entity
 ]
@@ -25,6 +27,7 @@ FamixTest8Entity class >> isAbstract [
 { #category : 'meta' }
 FamixTest8Entity class >> metamodel [
 
+	<ignoreForCoverage>
 	<generated>
 	^ FamixTest8Model metamodel
 ]
@@ -32,6 +35,7 @@ FamixTest8Entity class >> metamodel [
 { #category : 'testing' }
 FamixTest8Entity >> isAssociation [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]

--- a/src/Famix-Test8-Entities/FamixTest8Infection.class.st
+++ b/src/Famix-Test8-Entities/FamixTest8Infection.class.st
@@ -46,6 +46,7 @@ Class {
 { #category : 'meta' }
 FamixTest8Infection class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Infection super: #FamixTest8Entity>
 	<package: #'Famix-Test8-Entities'>
 	<generated>
@@ -55,6 +56,7 @@ FamixTest8Infection class >> annotation [
 FamixTest8Infection >> infectable [
 	"Relation named: #infectable type: #FamixTest8TInfectable opposite: #outgoingInfections"
 
+	<ignoreForCoverage>
 	<generated>
 	<source>
 	^ infectable
@@ -63,6 +65,7 @@ FamixTest8Infection >> infectable [
 { #category : 'accessing' }
 FamixTest8Infection >> infectable: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	infectable := anObject
 ]
@@ -71,6 +74,7 @@ FamixTest8Infection >> infectable: anObject [
 FamixTest8Infection >> infectious [
 	"Relation named: #infectious type: #FamixTest8TInfectious opposite: #incomingInfections"
 
+	<ignoreForCoverage>
 	<generated>
 	<target>
 	^ infectious
@@ -79,6 +83,7 @@ FamixTest8Infection >> infectious [
 { #category : 'accessing' }
 FamixTest8Infection >> infectious: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	infectious := anObject
 ]
@@ -87,12 +92,14 @@ FamixTest8Infection >> infectious: anObject [
 FamixTest8Infection >> isInvasive [
 
 	<FMProperty: #isInvasive type: #Boolean defaultValue: false>
+	<ignoreForCoverage>
 	<generated>
 	^ isInvasive ifNil: [ isInvasive := false ]
 ]
 
 { #category : 'accessing' }
 FamixTest8Infection >> isInvasive: anObject [
+	<ignoreForCoverage>
 	<generated>
 	isInvasive := anObject
 ]

--- a/src/Famix-Test8-Entities/FamixTest8LivingBeing.class.st
+++ b/src/Famix-Test8-Entities/FamixTest8LivingBeing.class.st
@@ -23,6 +23,7 @@ Class {
 { #category : 'meta' }
 FamixTest8LivingBeing class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #LivingBeing super: #FamixTest8Entity>
 	<package: #'Famix-Test8-Entities'>
 	<generated>

--- a/src/Famix-Test8-Entities/FamixTest8Model.class.st
+++ b/src/Famix-Test8-Entities/FamixTest8Model.class.st
@@ -10,6 +10,8 @@ Class {
 
 { #category : 'accessing' }
 FamixTest8Model class >> allSubmetamodelsPackagesNames [
+
+	<ignoreForCoverage>
 	<generated>
 	^ #(#'Moose-Query' #'Famix-Traits')
 ]
@@ -17,6 +19,7 @@ FamixTest8Model class >> allSubmetamodelsPackagesNames [
 { #category : 'meta' }
 FamixTest8Model class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Model super: #MooseModel>
 	<package: #'Famix-Test8-Entities'>
 	<generated>

--- a/src/Famix-Test8-Entities/FamixTest8Plant.class.st
+++ b/src/Famix-Test8-Entities/FamixTest8Plant.class.st
@@ -23,6 +23,7 @@ Class {
 { #category : 'meta' }
 FamixTest8Plant class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Plant super: #FamixTest8LivingBeing>
 	<package: #'Famix-Test8-Entities'>
 	<generated>

--- a/src/Famix-Test8-Entities/FamixTest8Residence.class.st
+++ b/src/Famix-Test8-Entities/FamixTest8Residence.class.st
@@ -39,6 +39,7 @@ Class {
 { #category : 'meta' }
 FamixTest8Residence class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Residence super: #FamixTest8Entity>
 	<package: #'Famix-Test8-Entities'>
 	<generated>
@@ -48,6 +49,7 @@ FamixTest8Residence class >> annotation [
 FamixTest8Residence >> biotope [
 	"Relation named: #biotope type: #FamixTest8TBiotope opposite: #incomingResidences"
 
+	<ignoreForCoverage>
 	<generated>
 	<target>
 	^ biotope
@@ -56,6 +58,7 @@ FamixTest8Residence >> biotope [
 { #category : 'accessing' }
 FamixTest8Residence >> biotope: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	biotope := anObject
 ]
@@ -64,6 +67,7 @@ FamixTest8Residence >> biotope: anObject [
 FamixTest8Residence >> resident [
 	"Relation named: #resident type: #FamixTest8TResident opposite: #outgoingResidences"
 
+	<ignoreForCoverage>
 	<generated>
 	<source>
 	^ resident
@@ -72,6 +76,7 @@ FamixTest8Residence >> resident [
 { #category : 'accessing' }
 FamixTest8Residence >> resident: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	resident := anObject
 ]

--- a/src/Famix-Test8-Entities/FamixTest8TBiotope.trait.st
+++ b/src/Famix-Test8-Entities/FamixTest8TBiotope.trait.st
@@ -23,6 +23,7 @@ Trait {
 { #category : 'meta' }
 FamixTest8TBiotope classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TBiotope super: #Object>
 	<package: #'Famix-Test8-Entities'>
 	<generated>
@@ -30,6 +31,8 @@ FamixTest8TBiotope classSide >> annotation [
 
 { #category : 'adding' }
 FamixTest8TBiotope >> addIncomingResidence: anObject [
+
+	<ignoreForCoverage>
 	<generated>
 	^ self incomingResidences add: anObject
 ]
@@ -38,6 +41,7 @@ FamixTest8TBiotope >> addIncomingResidence: anObject [
 FamixTest8TBiotope >> incomingResidences [
 	"Relation named: #incomingResidences type: #FamixTest8Residence opposite: #biotope"
 
+	<ignoreForCoverage>
 	<generated>
 	<derived>
 	^ incomingResidences
@@ -46,6 +50,7 @@ FamixTest8TBiotope >> incomingResidences [
 { #category : 'accessing' }
 FamixTest8TBiotope >> incomingResidences: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	incomingResidences value: anObject
 ]

--- a/src/Famix-Test8-Entities/FamixTest8TEntityCreator.trait.st
+++ b/src/Famix-Test8-Entities/FamixTest8TEntityCreator.trait.st
@@ -14,6 +14,7 @@ Trait {
 { #category : 'meta' }
 FamixTest8TEntityCreator classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TEntityCreator super: #Object>
 	<package: #'Famix-Test8-Entities'>
 	<generated>
@@ -22,6 +23,7 @@ FamixTest8TEntityCreator classSide >> annotation [
 { #category : 'entity creation' }
 FamixTest8TEntityCreator >> newAnimal [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixTest8Animal new
 ]
@@ -29,6 +31,7 @@ FamixTest8TEntityCreator >> newAnimal [
 { #category : 'entity creation' }
 FamixTest8TEntityCreator >> newBacteria [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixTest8Bacteria new
 ]
@@ -36,6 +39,7 @@ FamixTest8TEntityCreator >> newBacteria [
 { #category : 'entity creation' }
 FamixTest8TEntityCreator >> newBiotope [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixTest8Biotope new
 ]
@@ -43,6 +47,7 @@ FamixTest8TEntityCreator >> newBiotope [
 { #category : 'entity creation' }
 FamixTest8TEntityCreator >> newInfection [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixTest8Infection new
 ]
@@ -50,6 +55,7 @@ FamixTest8TEntityCreator >> newInfection [
 { #category : 'entity creation' }
 FamixTest8TEntityCreator >> newLivingBeing [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixTest8LivingBeing new
 ]
@@ -57,6 +63,7 @@ FamixTest8TEntityCreator >> newLivingBeing [
 { #category : 'entity creation' }
 FamixTest8TEntityCreator >> newPlant [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixTest8Plant new
 ]
@@ -64,6 +71,7 @@ FamixTest8TEntityCreator >> newPlant [
 { #category : 'entity creation' }
 FamixTest8TEntityCreator >> newResidence [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixTest8Residence new
 ]
@@ -71,6 +79,7 @@ FamixTest8TEntityCreator >> newResidence [
 { #category : 'entity creation' }
 FamixTest8TEntityCreator >> newVirus [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixTest8Virus new
 ]

--- a/src/Famix-Test8-Entities/FamixTest8TInfectable.trait.st
+++ b/src/Famix-Test8-Entities/FamixTest8TInfectable.trait.st
@@ -30,6 +30,7 @@ Trait {
 { #category : 'meta' }
 FamixTest8TInfectable classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TInfectable super: #Object>
 	<package: #'Famix-Test8-Entities'>
 	<generated>
@@ -37,6 +38,8 @@ FamixTest8TInfectable classSide >> annotation [
 
 { #category : 'adding' }
 FamixTest8TInfectable >> addOutgoingInfection: anObject [
+
+	<ignoreForCoverage>
 	<generated>
 	^ self outgoingInfections add: anObject
 ]
@@ -45,6 +48,7 @@ FamixTest8TInfectable >> addOutgoingInfection: anObject [
 FamixTest8TInfectable >> outgoingInfections [
 	"Relation named: #outgoingInfections type: #FamixTest8Infection opposite: #infectable"
 
+	<ignoreForCoverage>
 	<generated>
 	<derived>
 	^ outgoingInfections
@@ -53,6 +57,7 @@ FamixTest8TInfectable >> outgoingInfections [
 { #category : 'accessing' }
 FamixTest8TInfectable >> outgoingInfections: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	outgoingInfections value: anObject
 ]
@@ -61,12 +66,14 @@ FamixTest8TInfectable >> outgoingInfections: anObject [
 FamixTest8TInfectable >> pathogenicity [
 
 	<FMProperty: #pathogenicity type: #Number>
+	<ignoreForCoverage>
 	<generated>
 	^ pathogenicity
 ]
 
 { #category : 'accessing' }
 FamixTest8TInfectable >> pathogenicity: anObject [
+	<ignoreForCoverage>
 	<generated>
 	pathogenicity := anObject
 ]

--- a/src/Famix-Test8-Entities/FamixTest8TInfectious.trait.st
+++ b/src/Famix-Test8-Entities/FamixTest8TInfectious.trait.st
@@ -23,6 +23,7 @@ Trait {
 { #category : 'meta' }
 FamixTest8TInfectious classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TInfectious super: #Object>
 	<package: #'Famix-Test8-Entities'>
 	<generated>
@@ -30,6 +31,8 @@ FamixTest8TInfectious classSide >> annotation [
 
 { #category : 'adding' }
 FamixTest8TInfectious >> addIncomingInfection: anObject [
+
+	<ignoreForCoverage>
 	<generated>
 	^ self incomingInfections add: anObject
 ]
@@ -38,6 +41,7 @@ FamixTest8TInfectious >> addIncomingInfection: anObject [
 FamixTest8TInfectious >> incomingInfections [
 	"Relation named: #incomingInfections type: #FamixTest8Infection opposite: #infectious"
 
+	<ignoreForCoverage>
 	<generated>
 	<derived>
 	^ incomingInfections
@@ -46,6 +50,7 @@ FamixTest8TInfectious >> incomingInfections [
 { #category : 'accessing' }
 FamixTest8TInfectious >> incomingInfections: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	incomingInfections value: anObject
 ]

--- a/src/Famix-Test8-Entities/FamixTest8TResident.trait.st
+++ b/src/Famix-Test8-Entities/FamixTest8TResident.trait.st
@@ -23,6 +23,7 @@ Trait {
 { #category : 'meta' }
 FamixTest8TResident classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TResident super: #Object>
 	<package: #'Famix-Test8-Entities'>
 	<generated>
@@ -30,6 +31,8 @@ FamixTest8TResident classSide >> annotation [
 
 { #category : 'adding' }
 FamixTest8TResident >> addOutgoingResidence: anObject [
+
+	<ignoreForCoverage>
 	<generated>
 	^ self outgoingResidences add: anObject
 ]
@@ -38,6 +41,7 @@ FamixTest8TResident >> addOutgoingResidence: anObject [
 FamixTest8TResident >> outgoingResidences [
 	"Relation named: #outgoingResidences type: #FamixTest8Residence opposite: #resident"
 
+	<ignoreForCoverage>
 	<generated>
 	<derived>
 	^ outgoingResidences
@@ -46,6 +50,7 @@ FamixTest8TResident >> outgoingResidences [
 { #category : 'accessing' }
 FamixTest8TResident >> outgoingResidences: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	outgoingResidences value: anObject
 ]

--- a/src/Famix-Test8-Entities/FamixTest8Virus.class.st
+++ b/src/Famix-Test8-Entities/FamixTest8Virus.class.st
@@ -29,6 +29,7 @@ Class {
 { #category : 'meta' }
 FamixTest8Virus class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Virus super: #FamixTest8Entity>
 	<package: #'Famix-Test8-Entities'>
 	<generated>

--- a/src/Famix-TestComposed3Metamodel-Entities/FamixTestComposed3Model.class.st
+++ b/src/Famix-TestComposed3Metamodel-Entities/FamixTestComposed3Model.class.st
@@ -10,6 +10,8 @@ Class {
 
 { #category : 'accessing' }
 FamixTestComposed3Model class >> allSubmetamodelsPackagesNames [
+
+	<ignoreForCoverage>
 	<generated>
 	^ #(#'Moose-Query' #'Famix-Traits' 'Famix-TestComposedSubmetamodel2-Entities' 'Famix-TestComposedSubmetamodel1-Entities' 'Famix-TestComposedMetamodel-Entities' 'Famix-TestComposedComposedMetamodel-Entities')
 ]
@@ -17,6 +19,7 @@ FamixTestComposed3Model class >> allSubmetamodelsPackagesNames [
 { #category : 'meta' }
 FamixTestComposed3Model class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Model super: #MooseModel>
 	<package: #'Famix-TestComposed3Metamodel-Entities'>
 	<generated>

--- a/src/Famix-TestComposed3Metamodel-Entities/FamixTestComposed3TEntityCreator.trait.st
+++ b/src/Famix-TestComposed3Metamodel-Entities/FamixTestComposed3TEntityCreator.trait.st
@@ -14,6 +14,7 @@ Trait {
 { #category : 'meta' }
 FamixTestComposed3TEntityCreator classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TEntityCreator super: #Object>
 	<package: #'Famix-TestComposed3Metamodel-Entities'>
 	<generated>

--- a/src/Famix-TestComposedComposedMetamodel-Entities/FamixTestComposedComposedModel.class.st
+++ b/src/Famix-TestComposedComposedMetamodel-Entities/FamixTestComposedComposedModel.class.st
@@ -10,6 +10,8 @@ Class {
 
 { #category : 'accessing' }
 FamixTestComposedComposedModel class >> allSubmetamodelsPackagesNames [
+
+	<ignoreForCoverage>
 	<generated>
 	^ #(#'Moose-Query' #'Famix-Traits' 'Famix-TestComposedSubmetamodel2-Entities' 'Famix-TestComposedSubmetamodel1-Entities' 'Famix-TestComposedMetamodel-Entities')
 ]
@@ -17,6 +19,7 @@ FamixTestComposedComposedModel class >> allSubmetamodelsPackagesNames [
 { #category : 'meta' }
 FamixTestComposedComposedModel class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Model super: #MooseModel>
 	<package: #'Famix-TestComposedComposedMetamodel-Entities'>
 	<generated>

--- a/src/Famix-TestComposedComposedMetamodel-Entities/FamixTestComposedComposedTEntityCreator.trait.st
+++ b/src/Famix-TestComposedComposedMetamodel-Entities/FamixTestComposedComposedTEntityCreator.trait.st
@@ -14,6 +14,7 @@ Trait {
 { #category : 'meta' }
 FamixTestComposedComposedTEntityCreator classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TEntityCreator super: #Object>
 	<package: #'Famix-TestComposedComposedMetamodel-Entities'>
 	<generated>

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed1CustomEntity1.extension.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed1CustomEntity1.extension.st
@@ -4,6 +4,7 @@ Extension { #name : 'FamixTestComposed1CustomEntity1' }
 FamixTestComposed1CustomEntity1 >> c21 [
 	"Relation named: #c21 type: #FamixTestComposed2CustomEntity1 opposite: #c11"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMProperty: #c21 type: #FamixTestComposed2CustomEntity1 opposite: #c11>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
@@ -13,6 +14,7 @@ FamixTestComposed1CustomEntity1 >> c21 [
 { #category : '*Famix-TestComposedMetamodel-Entities' }
 FamixTestComposed1CustomEntity1 >> c21: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 
@@ -30,6 +32,7 @@ FamixTestComposed1CustomEntity1 >> c21: anObject [
 FamixTestComposed1CustomEntity1 >> customEntity1 [
 	"Relation named: #customEntity1 type: #FamixTestComposedCustomEntity1 opposite: #customEntity1"
 
+	<ignoreForCoverage>
 	<generated>
 	<container>
 	<derived>
@@ -41,6 +44,7 @@ FamixTestComposed1CustomEntity1 >> customEntity1 [
 { #category : '*Famix-TestComposedMetamodel-Entities' }
 FamixTestComposed1CustomEntity1 >> customEntity1: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed1CustomEntity2.extension.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed1CustomEntity2.extension.st
@@ -4,6 +4,7 @@ Extension { #name : 'FamixTestComposed1CustomEntity2' }
 FamixTestComposed1CustomEntity2 >> c22s [
 	"Relation named: #c22s type: #FamixTestComposed2CustomEntity2 opposite: #c12"
 
+	<ignoreForCoverage>
 	<generated>
 	<derived>
 	<FMProperty: #c22s type: #FamixTestComposed2CustomEntity2 opposite: #c12>
@@ -15,6 +16,7 @@ FamixTestComposed1CustomEntity2 >> c22s [
 { #category : '*Famix-TestComposedMetamodel-Entities' }
 FamixTestComposed1CustomEntity2 >> c22s: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 
@@ -25,6 +27,7 @@ FamixTestComposed1CustomEntity2 >> c22s: anObject [
 FamixTestComposed1CustomEntity2 >> customEntity2 [
 	"Relation named: #customEntity2 type: #FamixTestComposedCustomEntity2 opposite: #customEntities2"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMProperty: #customEntity2 type: #FamixTestComposedCustomEntity2 opposite: #customEntities2>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
@@ -34,6 +37,7 @@ FamixTestComposed1CustomEntity2 >> customEntity2 [
 { #category : '*Famix-TestComposedMetamodel-Entities' }
 FamixTestComposed1CustomEntity2 >> customEntity2: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed1CustomEntity3.extension.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed1CustomEntity3.extension.st
@@ -4,6 +4,7 @@ Extension { #name : 'FamixTestComposed1CustomEntity3' }
 FamixTestComposed1CustomEntity3 >> c23 [
 	"Relation named: #c23 type: #FamixTestComposed2CustomEntity3 opposite: #c13s"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMProperty: #c23 type: #FamixTestComposed2CustomEntity3 opposite: #c13s>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
@@ -13,6 +14,7 @@ FamixTestComposed1CustomEntity3 >> c23 [
 { #category : '*Famix-TestComposedMetamodel-Entities' }
 FamixTestComposed1CustomEntity3 >> c23: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 
@@ -23,6 +25,7 @@ FamixTestComposed1CustomEntity3 >> c23: anObject [
 FamixTestComposed1CustomEntity3 >> customEntities3 [
 	"Relation named: #customEntities3 type: #FamixTestComposedCustomEntity3 opposite: #customEntity3"
 
+	<ignoreForCoverage>
 	<generated>
 	<derived>
 	<FMProperty: #customEntities3 type: #FamixTestComposedCustomEntity3 opposite: #customEntity3>
@@ -34,6 +37,7 @@ FamixTestComposed1CustomEntity3 >> customEntities3 [
 { #category : '*Famix-TestComposedMetamodel-Entities' }
 FamixTestComposed1CustomEntity3 >> customEntities3: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed1CustomEntity4.extension.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed1CustomEntity4.extension.st
@@ -4,6 +4,7 @@ Extension { #name : 'FamixTestComposed1CustomEntity4' }
 FamixTestComposed1CustomEntity4 >> c24s [
 	"Relation named: #c24s type: #FamixTestComposed2CustomEntity4 opposite: #c14s"
 
+	<ignoreForCoverage>
 	<generated>
 	<derived>
 	<FMProperty: #c24s type: #FamixTestComposed2CustomEntity4 opposite: #c14s>
@@ -15,6 +16,7 @@ FamixTestComposed1CustomEntity4 >> c24s [
 { #category : '*Famix-TestComposedMetamodel-Entities' }
 FamixTestComposed1CustomEntity4 >> c24s: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 
@@ -25,6 +27,7 @@ FamixTestComposed1CustomEntity4 >> c24s: anObject [
 FamixTestComposed1CustomEntity4 >> customEntities4 [
 	"Relation named: #customEntities4 type: #FamixTestComposedCustomEntity4 opposite: #customEntities4"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMProperty: #customEntities4 type: #FamixTestComposedCustomEntity4 opposite: #customEntities4>
 	<multivalued>
@@ -35,6 +38,7 @@ FamixTestComposed1CustomEntity4 >> customEntities4 [
 { #category : '*Famix-TestComposedMetamodel-Entities' }
 FamixTestComposed1CustomEntity4 >> customEntities4: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed1CustomEntity5.extension.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed1CustomEntity5.extension.st
@@ -4,6 +4,7 @@ Extension { #name : 'FamixTestComposed1CustomEntity5' }
 FamixTestComposed1CustomEntity5 >> associations [
 	"Relation named: #associations type: #FamixTestComposedAssociation opposite: #c15"
 
+	<ignoreForCoverage>
 	<generated>
 	<derived>
 	<FMProperty: #associations type: #FamixTestComposedAssociation opposite: #c15>
@@ -15,6 +16,7 @@ FamixTestComposed1CustomEntity5 >> associations [
 { #category : '*Famix-TestComposedMetamodel-Entities' }
 FamixTestComposed1CustomEntity5 >> associations: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed1Method.extension.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed1Method.extension.st
@@ -4,6 +4,7 @@ Extension { #name : 'FamixTestComposed1Method' }
 FamixTestComposed1Method >> standardEntity [
 	"Relation named: #standardEntity type: #FamixTestComposedStandardEntity opposite: #method"
 
+	<ignoreForCoverage>
 	<generated>
 	<derived>
 	<FMProperty: #standardEntity type: #FamixTestComposedStandardEntity opposite: #method>
@@ -14,6 +15,7 @@ FamixTestComposed1Method >> standardEntity [
 { #category : '*Famix-TestComposedMetamodel-Entities' }
 FamixTestComposed1Method >> standardEntity: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed2CustomEntity1.extension.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed2CustomEntity1.extension.st
@@ -4,6 +4,7 @@ Extension { #name : 'FamixTestComposed2CustomEntity1' }
 FamixTestComposed2CustomEntity1 >> c1 [
 	"Relation named: #c1 type: #FamixTestComposedCustomEntity1 opposite: #c21"
 
+	<ignoreForCoverage>
 	<generated>
 	<derived>
 	<FMProperty: #c1 type: #FamixTestComposedCustomEntity1 opposite: #c21>
@@ -15,6 +16,7 @@ FamixTestComposed2CustomEntity1 >> c1 [
 FamixTestComposed2CustomEntity1 >> c11 [
 	"Relation named: #c11 type: #FamixTestComposed1CustomEntity1 opposite: #c21"
 
+	<ignoreForCoverage>
 	<generated>
 	<derived>
 	<FMProperty: #c11 type: #FamixTestComposed1CustomEntity1 opposite: #c21>
@@ -25,6 +27,7 @@ FamixTestComposed2CustomEntity1 >> c11 [
 { #category : '*Famix-TestComposedMetamodel-Entities' }
 FamixTestComposed2CustomEntity1 >> c11: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 
@@ -41,6 +44,7 @@ FamixTestComposed2CustomEntity1 >> c11: anObject [
 { #category : '*Famix-TestComposedMetamodel-Entities' }
 FamixTestComposed2CustomEntity1 >> c1: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed2CustomEntity2.extension.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed2CustomEntity2.extension.st
@@ -4,6 +4,7 @@ Extension { #name : 'FamixTestComposed2CustomEntity2' }
 FamixTestComposed2CustomEntity2 >> c12 [
 	"Relation named: #c12 type: #FamixTestComposed1CustomEntity2 opposite: #c22s"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMProperty: #c12 type: #FamixTestComposed1CustomEntity2 opposite: #c22s>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
@@ -13,6 +14,7 @@ FamixTestComposed2CustomEntity2 >> c12 [
 { #category : '*Famix-TestComposedMetamodel-Entities' }
 FamixTestComposed2CustomEntity2 >> c12: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 
@@ -23,6 +25,7 @@ FamixTestComposed2CustomEntity2 >> c12: anObject [
 FamixTestComposed2CustomEntity2 >> c2 [
 	"Relation named: #c2 type: #FamixTestComposedCustomEntity2 opposite: #c22s"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMProperty: #c2 type: #FamixTestComposedCustomEntity2 opposite: #c22s>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
@@ -32,6 +35,7 @@ FamixTestComposed2CustomEntity2 >> c2 [
 { #category : '*Famix-TestComposedMetamodel-Entities' }
 FamixTestComposed2CustomEntity2 >> c2: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed2CustomEntity3.extension.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed2CustomEntity3.extension.st
@@ -4,6 +4,7 @@ Extension { #name : 'FamixTestComposed2CustomEntity3' }
 FamixTestComposed2CustomEntity3 >> c13s [
 	"Relation named: #c13s type: #FamixTestComposed1CustomEntity3 opposite: #c23"
 
+	<ignoreForCoverage>
 	<generated>
 	<derived>
 	<FMProperty: #c13s type: #FamixTestComposed1CustomEntity3 opposite: #c23>
@@ -15,6 +16,7 @@ FamixTestComposed2CustomEntity3 >> c13s [
 { #category : '*Famix-TestComposedMetamodel-Entities' }
 FamixTestComposed2CustomEntity3 >> c13s: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 
@@ -25,6 +27,7 @@ FamixTestComposed2CustomEntity3 >> c13s: anObject [
 FamixTestComposed2CustomEntity3 >> c3s [
 	"Relation named: #c3s type: #FamixTestComposedCustomEntity3 opposite: #c23"
 
+	<ignoreForCoverage>
 	<generated>
 	<derived>
 	<FMProperty: #c3s type: #FamixTestComposedCustomEntity3 opposite: #c23>
@@ -36,6 +39,7 @@ FamixTestComposed2CustomEntity3 >> c3s [
 { #category : '*Famix-TestComposedMetamodel-Entities' }
 FamixTestComposed2CustomEntity3 >> c3s: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed2CustomEntity4.extension.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed2CustomEntity4.extension.st
@@ -4,6 +4,7 @@ Extension { #name : 'FamixTestComposed2CustomEntity4' }
 FamixTestComposed2CustomEntity4 >> c14s [
 	"Relation named: #c14s type: #FamixTestComposed1CustomEntity4 opposite: #c24s"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMProperty: #c14s type: #FamixTestComposed1CustomEntity4 opposite: #c24s>
 	<multivalued>
@@ -14,6 +15,7 @@ FamixTestComposed2CustomEntity4 >> c14s [
 { #category : '*Famix-TestComposedMetamodel-Entities' }
 FamixTestComposed2CustomEntity4 >> c14s: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 
@@ -24,6 +26,7 @@ FamixTestComposed2CustomEntity4 >> c14s: anObject [
 FamixTestComposed2CustomEntity4 >> c4s [
 	"Relation named: #c4s type: #FamixTestComposedCustomEntity4 opposite: #c24s"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMProperty: #c4s type: #FamixTestComposedCustomEntity4 opposite: #c24s>
 	<multivalued>
@@ -34,6 +37,7 @@ FamixTestComposed2CustomEntity4 >> c4s [
 { #category : '*Famix-TestComposedMetamodel-Entities' }
 FamixTestComposed2CustomEntity4 >> c4s: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed2CustomEntity5.extension.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposed2CustomEntity5.extension.st
@@ -4,6 +4,7 @@ Extension { #name : 'FamixTestComposed2CustomEntity5' }
 FamixTestComposed2CustomEntity5 >> associations [
 	"Relation named: #associations type: #FamixTestComposedAssociation opposite: #c25"
 
+	<ignoreForCoverage>
 	<generated>
 	<derived>
 	<FMProperty: #associations type: #FamixTestComposedAssociation opposite: #c25>
@@ -15,6 +16,7 @@ FamixTestComposed2CustomEntity5 >> associations [
 { #category : '*Famix-TestComposedMetamodel-Entities' }
 FamixTestComposed2CustomEntity5 >> associations: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedAssociation.class.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedAssociation.class.st
@@ -35,6 +35,7 @@ Class {
 { #category : 'meta' }
 FamixTestComposedAssociation class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Association super: #FamixTestComposedStandardEntity>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 	<generated>
@@ -44,6 +45,7 @@ FamixTestComposedAssociation class >> annotation [
 FamixTestComposedAssociation >> c15 [
 	"Relation named: #c15 type: #FamixTestComposed1CustomEntity5 opposite: #associations"
 
+	<ignoreForCoverage>
 	<generated>
 	<target>
 	<FMProperty: #c15 type: #FamixTestComposed1CustomEntity5 opposite: #associations>
@@ -53,6 +55,7 @@ FamixTestComposedAssociation >> c15 [
 { #category : 'accessing' }
 FamixTestComposedAssociation >> c15: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	self attributeAt: #c15 put: (FMMultivalueLink on: self update: #associations from: self c15 to: anObject).
 ]
@@ -61,6 +64,7 @@ FamixTestComposedAssociation >> c15: anObject [
 FamixTestComposedAssociation >> c25 [
 	"Relation named: #c25 type: #FamixTestComposed2CustomEntity5 opposite: #associations"
 
+	<ignoreForCoverage>
 	<generated>
 	<source>
 	<FMProperty: #c25 type: #FamixTestComposed2CustomEntity5 opposite: #associations>
@@ -70,6 +74,7 @@ FamixTestComposedAssociation >> c25 [
 { #category : 'accessing' }
 FamixTestComposedAssociation >> c25: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	self attributeAt: #c25 put: (FMMultivalueLink on: self update: #associations from: self c25 to: anObject).
 ]

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedCustomEntity1.class.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedCustomEntity1.class.st
@@ -26,6 +26,7 @@ Class {
 { #category : 'meta' }
 FamixTestComposedCustomEntity1 class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #CustomEntity1 super: #FamixTestComposedEntity>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 	<generated>
@@ -35,6 +36,7 @@ FamixTestComposedCustomEntity1 class >> annotation [
 FamixTestComposedCustomEntity1 >> c21 [
 	"Relation named: #c21 type: #FamixTestComposed2CustomEntity1 opposite: #c1"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMProperty: #c21 type: #FamixTestComposed2CustomEntity1 opposite: #c1>
 	^ self attributeAt: #c21 ifAbsent: [ nil ]
@@ -43,6 +45,7 @@ FamixTestComposedCustomEntity1 >> c21 [
 { #category : 'accessing' }
 FamixTestComposedCustomEntity1 >> c21: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	(self attributeAt: #c21 ifAbsentPut: [nil]) == anObject ifTrue: [ ^ anObject ].
 	anObject ifNil: [ | otherSide |
@@ -58,6 +61,7 @@ FamixTestComposedCustomEntity1 >> c21: anObject [
 FamixTestComposedCustomEntity1 >> customEntity1 [
 	"Relation named: #customEntity1 type: #FamixTestComposed1CustomEntity1 opposite: #customEntity1"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMProperty: #customEntity1 type: #FamixTestComposed1CustomEntity1 opposite: #customEntity1>
 	^ self attributeAt: #customEntity1 ifAbsent: [ nil ]
@@ -66,6 +70,7 @@ FamixTestComposedCustomEntity1 >> customEntity1 [
 { #category : 'accessing' }
 FamixTestComposedCustomEntity1 >> customEntity1: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	(self attributeAt: #customEntity1 ifAbsentPut: [nil]) == anObject ifTrue: [ ^ anObject ].
 	anObject ifNil: [ | otherSide |

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedCustomEntity2.class.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedCustomEntity2.class.st
@@ -22,6 +22,7 @@ Class {
 { #category : 'meta' }
 FamixTestComposedCustomEntity2 class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #CustomEntity2 super: #FamixTestComposedEntity>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 	<generated>
@@ -29,12 +30,16 @@ FamixTestComposedCustomEntity2 class >> annotation [
 
 { #category : 'adding' }
 FamixTestComposedCustomEntity2 >> addC22: anObject [
+
+	<ignoreForCoverage>
 	<generated>
 	^ self c22s add: anObject
 ]
 
 { #category : 'adding' }
 FamixTestComposedCustomEntity2 >> addCustomEntities2: anObject [
+
+	<ignoreForCoverage>
 	<generated>
 	^ self customEntities2 add: anObject
 ]
@@ -43,6 +48,7 @@ FamixTestComposedCustomEntity2 >> addCustomEntities2: anObject [
 FamixTestComposedCustomEntity2 >> c22s [
 	"Relation named: #c22s type: #FamixTestComposed2CustomEntity2 opposite: #c2"
 
+	<ignoreForCoverage>
 	<generated>
 	<derived>
 	<FMProperty: #c22s type: #FamixTestComposed2CustomEntity2 opposite: #c2>
@@ -53,6 +59,7 @@ FamixTestComposedCustomEntity2 >> c22s [
 { #category : 'accessing' }
 FamixTestComposedCustomEntity2 >> c22s: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	self c22s value: anObject
 ]
@@ -61,6 +68,7 @@ FamixTestComposedCustomEntity2 >> c22s: anObject [
 FamixTestComposedCustomEntity2 >> customEntities2 [
 	"Relation named: #customEntities2 type: #FamixTestComposed1CustomEntity2 opposite: #customEntity2"
 
+	<ignoreForCoverage>
 	<generated>
 	<derived>
 	<FMProperty: #customEntities2 type: #FamixTestComposed1CustomEntity2 opposite: #customEntity2>
@@ -71,6 +79,7 @@ FamixTestComposedCustomEntity2 >> customEntities2 [
 { #category : 'accessing' }
 FamixTestComposedCustomEntity2 >> customEntities2: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	self customEntities2 value: anObject
 ]

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedCustomEntity3.class.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedCustomEntity3.class.st
@@ -22,6 +22,7 @@ Class {
 { #category : 'meta' }
 FamixTestComposedCustomEntity3 class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #CustomEntity3 super: #FamixTestComposedEntity>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 	<generated>
@@ -31,6 +32,7 @@ FamixTestComposedCustomEntity3 class >> annotation [
 FamixTestComposedCustomEntity3 >> c23 [
 	"Relation named: #c23 type: #FamixTestComposed2CustomEntity3 opposite: #c3s"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMProperty: #c23 type: #FamixTestComposed2CustomEntity3 opposite: #c3s>
 	^ self attributeAt: #c23 ifAbsent: [ nil ]
@@ -39,6 +41,7 @@ FamixTestComposedCustomEntity3 >> c23 [
 { #category : 'accessing' }
 FamixTestComposedCustomEntity3 >> c23: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	self attributeAt: #c23 put: (FMMultivalueLink on: self update: #c3s from: self c23 to: anObject).
 ]
@@ -47,6 +50,7 @@ FamixTestComposedCustomEntity3 >> c23: anObject [
 FamixTestComposedCustomEntity3 >> customEntity3 [
 	"Relation named: #customEntity3 type: #FamixTestComposed1CustomEntity3 opposite: #customEntities3"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMProperty: #customEntity3 type: #FamixTestComposed1CustomEntity3 opposite: #customEntities3>
 	^ self attributeAt: #customEntity3 ifAbsent: [ nil ]
@@ -55,6 +59,7 @@ FamixTestComposedCustomEntity3 >> customEntity3 [
 { #category : 'accessing' }
 FamixTestComposedCustomEntity3 >> customEntity3: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	self attributeAt: #customEntity3 put: (FMMultivalueLink on: self update: #customEntities3 from: self customEntity3 to: anObject).
 ]

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedCustomEntity4.class.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedCustomEntity4.class.st
@@ -22,6 +22,7 @@ Class {
 { #category : 'meta' }
 FamixTestComposedCustomEntity4 class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #CustomEntity4 super: #FamixTestComposedEntity>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 	<generated>
@@ -29,12 +30,16 @@ FamixTestComposedCustomEntity4 class >> annotation [
 
 { #category : 'adding' }
 FamixTestComposedCustomEntity4 >> addC24: anObject [
+
+	<ignoreForCoverage>
 	<generated>
 	^ self c24s add: anObject
 ]
 
 { #category : 'adding' }
 FamixTestComposedCustomEntity4 >> addCustomEntities4: anObject [
+
+	<ignoreForCoverage>
 	<generated>
 	^ self customEntities4 add: anObject
 ]
@@ -43,6 +48,7 @@ FamixTestComposedCustomEntity4 >> addCustomEntities4: anObject [
 FamixTestComposedCustomEntity4 >> c24s [
 	"Relation named: #c24s type: #FamixTestComposed2CustomEntity4 opposite: #c4s"
 
+	<ignoreForCoverage>
 	<generated>
 	<derived>
 	<FMProperty: #c24s type: #FamixTestComposed2CustomEntity4 opposite: #c4s>
@@ -53,6 +59,7 @@ FamixTestComposedCustomEntity4 >> c24s [
 { #category : 'accessing' }
 FamixTestComposedCustomEntity4 >> c24s: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	self c24s value: anObject
 ]
@@ -61,6 +68,7 @@ FamixTestComposedCustomEntity4 >> c24s: anObject [
 FamixTestComposedCustomEntity4 >> customEntities4 [
 	"Relation named: #customEntities4 type: #FamixTestComposed1CustomEntity4 opposite: #customEntities4"
 
+	<ignoreForCoverage>
 	<generated>
 	<derived>
 	<FMProperty: #customEntities4 type: #FamixTestComposed1CustomEntity4 opposite: #customEntities4>
@@ -71,6 +79,7 @@ FamixTestComposedCustomEntity4 >> customEntities4 [
 { #category : 'accessing' }
 FamixTestComposedCustomEntity4 >> customEntities4: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	self customEntities4 value: anObject
 ]

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedEntity.class.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedEntity.class.st
@@ -9,6 +9,7 @@ Class {
 { #category : 'meta' }
 FamixTestComposedEntity class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Entity super: #MooseEntity>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 	<generated>
@@ -18,6 +19,7 @@ FamixTestComposedEntity class >> annotation [
 { #category : 'testing' }
 FamixTestComposedEntity class >> isAbstract [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self == FamixTestComposedEntity
 ]
@@ -25,6 +27,7 @@ FamixTestComposedEntity class >> isAbstract [
 { #category : 'meta' }
 FamixTestComposedEntity class >> metamodel [
 
+	<ignoreForCoverage>
 	<generated>
 	^ FamixTestComposedModel metamodel
 ]
@@ -32,6 +35,7 @@ FamixTestComposedEntity class >> metamodel [
 { #category : 'testing' }
 FamixTestComposedEntity >> isAssociation [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedModel.class.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedModel.class.st
@@ -10,6 +10,8 @@ Class {
 
 { #category : 'accessing' }
 FamixTestComposedModel class >> allSubmetamodelsPackagesNames [
+
+	<ignoreForCoverage>
 	<generated>
 	^ #(#'Moose-Query' #'Famix-Traits' 'Famix-TestComposedSubmetamodel2-Entities' 'Famix-TestComposedSubmetamodel1-Entities')
 ]
@@ -17,6 +19,7 @@ FamixTestComposedModel class >> allSubmetamodelsPackagesNames [
 { #category : 'meta' }
 FamixTestComposedModel class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Model super: #MooseModel>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 	<generated>

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedStandardEntity.class.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedStandardEntity.class.st
@@ -21,6 +21,7 @@ Class {
 { #category : 'meta' }
 FamixTestComposedStandardEntity class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #StandardEntity super: #FamixTestComposedEntity>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 	<generated>
@@ -30,6 +31,7 @@ FamixTestComposedStandardEntity class >> annotation [
 FamixTestComposedStandardEntity >> method [
 	"Relation named: #method type: #FamixTestComposed1Method opposite: #standardEntity"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMProperty: #method type: #FamixTestComposed1Method opposite: #standardEntity>
 	^ self attributeAt: #method ifAbsent: [ nil ]
@@ -38,6 +40,7 @@ FamixTestComposedStandardEntity >> method [
 { #category : 'accessing' }
 FamixTestComposedStandardEntity >> method: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	(self attributeAt: #method ifAbsentPut: [nil]) == anObject ifTrue: [ ^ anObject ].
 	anObject ifNil: [ | otherSide |

--- a/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedTEntityCreator.trait.st
+++ b/src/Famix-TestComposedMetamodel-Entities/FamixTestComposedTEntityCreator.trait.st
@@ -14,6 +14,7 @@ Trait {
 { #category : 'meta' }
 FamixTestComposedTEntityCreator classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TEntityCreator super: #Object>
 	<package: #'Famix-TestComposedMetamodel-Entities'>
 	<generated>
@@ -22,6 +23,7 @@ FamixTestComposedTEntityCreator classSide >> annotation [
 { #category : 'entity creation' }
 FamixTestComposedTEntityCreator >> newAssociation [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixTestComposedAssociation new
 ]
@@ -29,6 +31,7 @@ FamixTestComposedTEntityCreator >> newAssociation [
 { #category : 'entity creation' }
 FamixTestComposedTEntityCreator >> newCustomEntity1 [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixTestComposedCustomEntity1 new
 ]
@@ -36,6 +39,7 @@ FamixTestComposedTEntityCreator >> newCustomEntity1 [
 { #category : 'entity creation' }
 FamixTestComposedTEntityCreator >> newCustomEntity2 [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixTestComposedCustomEntity2 new
 ]
@@ -43,6 +47,7 @@ FamixTestComposedTEntityCreator >> newCustomEntity2 [
 { #category : 'entity creation' }
 FamixTestComposedTEntityCreator >> newCustomEntity3 [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixTestComposedCustomEntity3 new
 ]
@@ -50,6 +55,7 @@ FamixTestComposedTEntityCreator >> newCustomEntity3 [
 { #category : 'entity creation' }
 FamixTestComposedTEntityCreator >> newCustomEntity4 [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixTestComposedCustomEntity4 new
 ]
@@ -57,6 +63,7 @@ FamixTestComposedTEntityCreator >> newCustomEntity4 [
 { #category : 'entity creation' }
 FamixTestComposedTEntityCreator >> newStandardEntity [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixTestComposedStandardEntity new
 ]

--- a/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1Class.class.st
+++ b/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1Class.class.st
@@ -55,6 +55,7 @@ Class {
 { #category : 'meta' }
 FamixTestComposed1Class class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Class super: #FamixTestComposed1NamedEntity>
 	<package: #'Famix-TestComposedSubmetamodel1-Entities'>
 	<generated>

--- a/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1Comment.class.st
+++ b/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1Comment.class.st
@@ -28,6 +28,7 @@ Class {
 { #category : 'meta' }
 FamixTestComposed1Comment class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Comment super: #FamixTestComposed1SourcedEntity>
 	<package: #'Famix-TestComposedSubmetamodel1-Entities'>
 	<generated>

--- a/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1CustomEntity1.class.st
+++ b/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1CustomEntity1.class.st
@@ -9,6 +9,7 @@ Class {
 { #category : 'meta' }
 FamixTestComposed1CustomEntity1 class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #CustomEntity1 super: #FamixTestComposed1Entity>
 	<package: #'Famix-TestComposedSubmetamodel1-Entities'>
 	<generated>

--- a/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1CustomEntity2.class.st
+++ b/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1CustomEntity2.class.st
@@ -9,6 +9,7 @@ Class {
 { #category : 'meta' }
 FamixTestComposed1CustomEntity2 class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #CustomEntity2 super: #FamixTestComposed1Entity>
 	<package: #'Famix-TestComposedSubmetamodel1-Entities'>
 	<generated>

--- a/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1CustomEntity3.class.st
+++ b/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1CustomEntity3.class.st
@@ -9,6 +9,7 @@ Class {
 { #category : 'meta' }
 FamixTestComposed1CustomEntity3 class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #CustomEntity3 super: #FamixTestComposed1Entity>
 	<package: #'Famix-TestComposedSubmetamodel1-Entities'>
 	<generated>

--- a/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1CustomEntity4.class.st
+++ b/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1CustomEntity4.class.st
@@ -9,6 +9,7 @@ Class {
 { #category : 'meta' }
 FamixTestComposed1CustomEntity4 class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #CustomEntity4 super: #FamixTestComposed1Entity>
 	<package: #'Famix-TestComposedSubmetamodel1-Entities'>
 	<generated>

--- a/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1CustomEntity5.class.st
+++ b/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1CustomEntity5.class.st
@@ -11,6 +11,7 @@ Class {
 { #category : 'meta' }
 FamixTestComposed1CustomEntity5 class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #CustomEntity5 super: #FamixTestComposed1Entity>
 	<package: #'Famix-TestComposedSubmetamodel1-Entities'>
 	<generated>

--- a/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1Entity.class.st
+++ b/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1Entity.class.st
@@ -9,6 +9,7 @@ Class {
 { #category : 'meta' }
 FamixTestComposed1Entity class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Entity super: #MooseEntity>
 	<package: #'Famix-TestComposedSubmetamodel1-Entities'>
 	<generated>
@@ -18,6 +19,7 @@ FamixTestComposed1Entity class >> annotation [
 { #category : 'testing' }
 FamixTestComposed1Entity class >> isAbstract [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self == FamixTestComposed1Entity
 ]
@@ -25,6 +27,7 @@ FamixTestComposed1Entity class >> isAbstract [
 { #category : 'meta' }
 FamixTestComposed1Entity class >> metamodel [
 
+	<ignoreForCoverage>
 	<generated>
 	^ FamixTestComposed1Model metamodel
 ]
@@ -32,6 +35,7 @@ FamixTestComposed1Entity class >> metamodel [
 { #category : 'testing' }
 FamixTestComposed1Entity >> canBeStub [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -39,6 +43,7 @@ FamixTestComposed1Entity >> canBeStub [
 { #category : 'testing' }
 FamixTestComposed1Entity >> hasImmediateSource [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -46,6 +51,7 @@ FamixTestComposed1Entity >> hasImmediateSource [
 { #category : 'testing' }
 FamixTestComposed1Entity >> isBehavioural [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -53,6 +59,7 @@ FamixTestComposed1Entity >> isBehavioural [
 { #category : 'testing' }
 FamixTestComposed1Entity >> isClass [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -60,6 +67,7 @@ FamixTestComposed1Entity >> isClass [
 { #category : 'testing' }
 FamixTestComposed1Entity >> isComment [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -67,6 +75,7 @@ FamixTestComposed1Entity >> isComment [
 { #category : 'testing' }
 FamixTestComposed1Entity >> isMethod [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -74,6 +83,7 @@ FamixTestComposed1Entity >> isMethod [
 { #category : 'testing' }
 FamixTestComposed1Entity >> isNamedEntity [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -81,6 +91,7 @@ FamixTestComposed1Entity >> isNamedEntity [
 { #category : 'testing' }
 FamixTestComposed1Entity >> isQueryable [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -88,6 +99,7 @@ FamixTestComposed1Entity >> isQueryable [
 { #category : 'testing' }
 FamixTestComposed1Entity >> isType [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]

--- a/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1Method.class.st
+++ b/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1Method.class.st
@@ -56,6 +56,7 @@ Class {
 { #category : 'meta' }
 FamixTestComposed1Method class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Method super: #FamixTestComposed1NamedEntity>
 	<package: #'Famix-TestComposedSubmetamodel1-Entities'>
 	<generated>

--- a/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1Model.class.st
+++ b/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1Model.class.st
@@ -10,6 +10,8 @@ Class {
 
 { #category : 'accessing' }
 FamixTestComposed1Model class >> allSubmetamodelsPackagesNames [
+
+	<ignoreForCoverage>
 	<generated>
 	^ #(#'Moose-Query' #'Famix-Traits')
 ]
@@ -17,6 +19,7 @@ FamixTestComposed1Model class >> allSubmetamodelsPackagesNames [
 { #category : 'meta' }
 FamixTestComposed1Model class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Model super: #MooseModel>
 	<package: #'Famix-TestComposedSubmetamodel1-Entities'>
 	<generated>

--- a/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1NamedEntity.class.st
+++ b/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1NamedEntity.class.st
@@ -20,6 +20,7 @@ Class {
 { #category : 'meta' }
 FamixTestComposed1NamedEntity class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #NamedEntity super: #FamixTestComposed1Entity>
 	<package: #'Famix-TestComposedSubmetamodel1-Entities'>
 	<generated>
@@ -29,6 +30,7 @@ FamixTestComposed1NamedEntity class >> annotation [
 { #category : 'testing' }
 FamixTestComposed1NamedEntity class >> isAbstract [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self == FamixTestComposed1NamedEntity
 ]
@@ -36,6 +38,7 @@ FamixTestComposed1NamedEntity class >> isAbstract [
 { #category : 'testing' }
 FamixTestComposed1NamedEntity >> isNamedEntity [
 
+	<ignoreForCoverage>
 	<generated>
 	^ true
 ]

--- a/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1SourceAnchor.class.st
+++ b/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1SourceAnchor.class.st
@@ -23,6 +23,7 @@ Class {
 { #category : 'meta' }
 FamixTestComposed1SourceAnchor class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #SourceAnchor super: #FamixTestComposed1Entity>
 	<package: #'Famix-TestComposedSubmetamodel1-Entities'>
 	<generated>
@@ -32,6 +33,7 @@ FamixTestComposed1SourceAnchor class >> annotation [
 { #category : 'testing' }
 FamixTestComposed1SourceAnchor class >> isAbstract [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self == FamixTestComposed1SourceAnchor
 ]

--- a/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1SourceLanguage.class.st
+++ b/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1SourceLanguage.class.st
@@ -23,6 +23,7 @@ Class {
 { #category : 'meta' }
 FamixTestComposed1SourceLanguage class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #SourceLanguage super: #FamixTestComposed1Entity>
 	<package: #'Famix-TestComposedSubmetamodel1-Entities'>
 	<generated>

--- a/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1SourceTextAnchor.class.st
+++ b/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1SourceTextAnchor.class.st
@@ -29,6 +29,7 @@ Class {
 { #category : 'meta' }
 FamixTestComposed1SourceTextAnchor class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #SourceTextAnchor super: #FamixTestComposed1SourceAnchor>
 	<package: #'Famix-TestComposedSubmetamodel1-Entities'>
 	<generated>

--- a/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1SourcedEntity.class.st
+++ b/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1SourcedEntity.class.st
@@ -23,6 +23,7 @@ Class {
 { #category : 'meta' }
 FamixTestComposed1SourcedEntity class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #SourcedEntity super: #FamixTestComposed1Entity>
 	<package: #'Famix-TestComposedSubmetamodel1-Entities'>
 	<generated>
@@ -32,6 +33,7 @@ FamixTestComposed1SourcedEntity class >> annotation [
 { #category : 'testing' }
 FamixTestComposed1SourcedEntity class >> isAbstract [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self == FamixTestComposed1SourcedEntity
 ]

--- a/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1TEntityCreator.trait.st
+++ b/src/Famix-TestComposedSubmetamodel1-Entities/FamixTestComposed1TEntityCreator.trait.st
@@ -14,6 +14,7 @@ Trait {
 { #category : 'meta' }
 FamixTestComposed1TEntityCreator classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TEntityCreator super: #Object>
 	<package: #'Famix-TestComposedSubmetamodel1-Entities'>
 	<generated>
@@ -22,6 +23,7 @@ FamixTestComposed1TEntityCreator classSide >> annotation [
 { #category : 'entity creation' }
 FamixTestComposed1TEntityCreator >> newClass [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixTestComposed1Class new
 ]
@@ -29,6 +31,7 @@ FamixTestComposed1TEntityCreator >> newClass [
 { #category : 'entity creation' }
 FamixTestComposed1TEntityCreator >> newClassNamed: aName [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: (FamixTestComposed1Class named: aName)
 ]
@@ -36,6 +39,7 @@ FamixTestComposed1TEntityCreator >> newClassNamed: aName [
 { #category : 'entity creation' }
 FamixTestComposed1TEntityCreator >> newComment [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixTestComposed1Comment new
 ]
@@ -43,6 +47,7 @@ FamixTestComposed1TEntityCreator >> newComment [
 { #category : 'entity creation' }
 FamixTestComposed1TEntityCreator >> newCustomEntity1 [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixTestComposed1CustomEntity1 new
 ]
@@ -50,6 +55,7 @@ FamixTestComposed1TEntityCreator >> newCustomEntity1 [
 { #category : 'entity creation' }
 FamixTestComposed1TEntityCreator >> newCustomEntity2 [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixTestComposed1CustomEntity2 new
 ]
@@ -57,6 +63,7 @@ FamixTestComposed1TEntityCreator >> newCustomEntity2 [
 { #category : 'entity creation' }
 FamixTestComposed1TEntityCreator >> newCustomEntity3 [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixTestComposed1CustomEntity3 new
 ]
@@ -64,6 +71,7 @@ FamixTestComposed1TEntityCreator >> newCustomEntity3 [
 { #category : 'entity creation' }
 FamixTestComposed1TEntityCreator >> newCustomEntity4 [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixTestComposed1CustomEntity4 new
 ]
@@ -71,6 +79,7 @@ FamixTestComposed1TEntityCreator >> newCustomEntity4 [
 { #category : 'entity creation' }
 FamixTestComposed1TEntityCreator >> newCustomEntity5 [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixTestComposed1CustomEntity5 new
 ]
@@ -78,6 +87,7 @@ FamixTestComposed1TEntityCreator >> newCustomEntity5 [
 { #category : 'entity creation' }
 FamixTestComposed1TEntityCreator >> newMethod [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixTestComposed1Method new
 ]
@@ -85,6 +95,7 @@ FamixTestComposed1TEntityCreator >> newMethod [
 { #category : 'entity creation' }
 FamixTestComposed1TEntityCreator >> newMethodNamed: aName [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: (FamixTestComposed1Method named: aName)
 ]
@@ -92,6 +103,7 @@ FamixTestComposed1TEntityCreator >> newMethodNamed: aName [
 { #category : 'entity creation' }
 FamixTestComposed1TEntityCreator >> newSourceLanguage [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixTestComposed1SourceLanguage new
 ]
@@ -99,6 +111,7 @@ FamixTestComposed1TEntityCreator >> newSourceLanguage [
 { #category : 'entity creation' }
 FamixTestComposed1TEntityCreator >> newSourceTextAnchor [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixTestComposed1SourceTextAnchor new
 ]

--- a/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2Class.class.st
+++ b/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2Class.class.st
@@ -55,6 +55,7 @@ Class {
 { #category : 'meta' }
 FamixTestComposed2Class class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Class super: #FamixTestComposed2NamedEntity>
 	<package: #'Famix-TestComposedSubmetamodel2-Entities'>
 	<generated>

--- a/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2Comment.class.st
+++ b/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2Comment.class.st
@@ -28,6 +28,7 @@ Class {
 { #category : 'meta' }
 FamixTestComposed2Comment class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Comment super: #FamixTestComposed2SourcedEntity>
 	<package: #'Famix-TestComposedSubmetamodel2-Entities'>
 	<generated>

--- a/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2CustomEntity1.class.st
+++ b/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2CustomEntity1.class.st
@@ -9,6 +9,7 @@ Class {
 { #category : 'meta' }
 FamixTestComposed2CustomEntity1 class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #CustomEntity1 super: #FamixTestComposed2Entity>
 	<package: #'Famix-TestComposedSubmetamodel2-Entities'>
 	<generated>

--- a/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2CustomEntity2.class.st
+++ b/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2CustomEntity2.class.st
@@ -9,6 +9,7 @@ Class {
 { #category : 'meta' }
 FamixTestComposed2CustomEntity2 class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #CustomEntity2 super: #FamixTestComposed2Entity>
 	<package: #'Famix-TestComposedSubmetamodel2-Entities'>
 	<generated>

--- a/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2CustomEntity3.class.st
+++ b/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2CustomEntity3.class.st
@@ -9,6 +9,7 @@ Class {
 { #category : 'meta' }
 FamixTestComposed2CustomEntity3 class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #CustomEntity3 super: #FamixTestComposed2Entity>
 	<package: #'Famix-TestComposedSubmetamodel2-Entities'>
 	<generated>

--- a/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2CustomEntity4.class.st
+++ b/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2CustomEntity4.class.st
@@ -9,6 +9,7 @@ Class {
 { #category : 'meta' }
 FamixTestComposed2CustomEntity4 class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #CustomEntity4 super: #FamixTestComposed2Entity>
 	<package: #'Famix-TestComposedSubmetamodel2-Entities'>
 	<generated>

--- a/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2CustomEntity5.class.st
+++ b/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2CustomEntity5.class.st
@@ -11,6 +11,7 @@ Class {
 { #category : 'meta' }
 FamixTestComposed2CustomEntity5 class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #CustomEntity5 super: #FamixTestComposed2Entity>
 	<package: #'Famix-TestComposedSubmetamodel2-Entities'>
 	<generated>

--- a/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2Entity.class.st
+++ b/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2Entity.class.st
@@ -9,6 +9,7 @@ Class {
 { #category : 'meta' }
 FamixTestComposed2Entity class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Entity super: #MooseEntity>
 	<package: #'Famix-TestComposedSubmetamodel2-Entities'>
 	<generated>
@@ -18,6 +19,7 @@ FamixTestComposed2Entity class >> annotation [
 { #category : 'testing' }
 FamixTestComposed2Entity class >> isAbstract [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self == FamixTestComposed2Entity
 ]
@@ -25,6 +27,7 @@ FamixTestComposed2Entity class >> isAbstract [
 { #category : 'meta' }
 FamixTestComposed2Entity class >> metamodel [
 
+	<ignoreForCoverage>
 	<generated>
 	^ FamixTestComposed2Model metamodel
 ]
@@ -32,6 +35,7 @@ FamixTestComposed2Entity class >> metamodel [
 { #category : 'testing' }
 FamixTestComposed2Entity >> canBeStub [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -39,6 +43,7 @@ FamixTestComposed2Entity >> canBeStub [
 { #category : 'testing' }
 FamixTestComposed2Entity >> hasImmediateSource [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -46,6 +51,7 @@ FamixTestComposed2Entity >> hasImmediateSource [
 { #category : 'testing' }
 FamixTestComposed2Entity >> isBehavioural [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -53,6 +59,7 @@ FamixTestComposed2Entity >> isBehavioural [
 { #category : 'testing' }
 FamixTestComposed2Entity >> isClass [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -60,6 +67,7 @@ FamixTestComposed2Entity >> isClass [
 { #category : 'testing' }
 FamixTestComposed2Entity >> isComment [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -67,6 +75,7 @@ FamixTestComposed2Entity >> isComment [
 { #category : 'testing' }
 FamixTestComposed2Entity >> isMethod [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -74,6 +83,7 @@ FamixTestComposed2Entity >> isMethod [
 { #category : 'testing' }
 FamixTestComposed2Entity >> isNamedEntity [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -81,6 +91,7 @@ FamixTestComposed2Entity >> isNamedEntity [
 { #category : 'testing' }
 FamixTestComposed2Entity >> isQueryable [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -88,6 +99,7 @@ FamixTestComposed2Entity >> isQueryable [
 { #category : 'testing' }
 FamixTestComposed2Entity >> isType [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]

--- a/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2Method.class.st
+++ b/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2Method.class.st
@@ -56,6 +56,7 @@ Class {
 { #category : 'meta' }
 FamixTestComposed2Method class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Method super: #FamixTestComposed2NamedEntity>
 	<package: #'Famix-TestComposedSubmetamodel2-Entities'>
 	<generated>

--- a/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2Model.class.st
+++ b/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2Model.class.st
@@ -10,6 +10,8 @@ Class {
 
 { #category : 'accessing' }
 FamixTestComposed2Model class >> allSubmetamodelsPackagesNames [
+
+	<ignoreForCoverage>
 	<generated>
 	^ #(#'Moose-Query' #'Famix-Traits')
 ]
@@ -17,6 +19,7 @@ FamixTestComposed2Model class >> allSubmetamodelsPackagesNames [
 { #category : 'meta' }
 FamixTestComposed2Model class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Model super: #MooseModel>
 	<package: #'Famix-TestComposedSubmetamodel2-Entities'>
 	<generated>

--- a/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2NamedEntity.class.st
+++ b/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2NamedEntity.class.st
@@ -20,6 +20,7 @@ Class {
 { #category : 'meta' }
 FamixTestComposed2NamedEntity class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #NamedEntity super: #FamixTestComposed2Entity>
 	<package: #'Famix-TestComposedSubmetamodel2-Entities'>
 	<generated>
@@ -29,6 +30,7 @@ FamixTestComposed2NamedEntity class >> annotation [
 { #category : 'testing' }
 FamixTestComposed2NamedEntity class >> isAbstract [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self == FamixTestComposed2NamedEntity
 ]
@@ -36,6 +38,7 @@ FamixTestComposed2NamedEntity class >> isAbstract [
 { #category : 'testing' }
 FamixTestComposed2NamedEntity >> isNamedEntity [
 
+	<ignoreForCoverage>
 	<generated>
 	^ true
 ]

--- a/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2SourceAnchor.class.st
+++ b/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2SourceAnchor.class.st
@@ -23,6 +23,7 @@ Class {
 { #category : 'meta' }
 FamixTestComposed2SourceAnchor class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #SourceAnchor super: #FamixTestComposed2Entity>
 	<package: #'Famix-TestComposedSubmetamodel2-Entities'>
 	<generated>
@@ -32,6 +33,7 @@ FamixTestComposed2SourceAnchor class >> annotation [
 { #category : 'testing' }
 FamixTestComposed2SourceAnchor class >> isAbstract [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self == FamixTestComposed2SourceAnchor
 ]

--- a/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2SourceLanguage.class.st
+++ b/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2SourceLanguage.class.st
@@ -23,6 +23,7 @@ Class {
 { #category : 'meta' }
 FamixTestComposed2SourceLanguage class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #SourceLanguage super: #FamixTestComposed2Entity>
 	<package: #'Famix-TestComposedSubmetamodel2-Entities'>
 	<generated>

--- a/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2SourceTextAnchor.class.st
+++ b/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2SourceTextAnchor.class.st
@@ -29,6 +29,7 @@ Class {
 { #category : 'meta' }
 FamixTestComposed2SourceTextAnchor class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #SourceTextAnchor super: #FamixTestComposed2SourceAnchor>
 	<package: #'Famix-TestComposedSubmetamodel2-Entities'>
 	<generated>

--- a/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2SourcedEntity.class.st
+++ b/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2SourcedEntity.class.st
@@ -23,6 +23,7 @@ Class {
 { #category : 'meta' }
 FamixTestComposed2SourcedEntity class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #SourcedEntity super: #FamixTestComposed2Entity>
 	<package: #'Famix-TestComposedSubmetamodel2-Entities'>
 	<generated>
@@ -32,6 +33,7 @@ FamixTestComposed2SourcedEntity class >> annotation [
 { #category : 'testing' }
 FamixTestComposed2SourcedEntity class >> isAbstract [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self == FamixTestComposed2SourcedEntity
 ]

--- a/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2TEntityCreator.trait.st
+++ b/src/Famix-TestComposedSubmetamodel2-Entities/FamixTestComposed2TEntityCreator.trait.st
@@ -14,6 +14,7 @@ Trait {
 { #category : 'meta' }
 FamixTestComposed2TEntityCreator classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TEntityCreator super: #Object>
 	<package: #'Famix-TestComposedSubmetamodel2-Entities'>
 	<generated>
@@ -22,6 +23,7 @@ FamixTestComposed2TEntityCreator classSide >> annotation [
 { #category : 'entity creation' }
 FamixTestComposed2TEntityCreator >> newClass [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixTestComposed2Class new
 ]
@@ -29,6 +31,7 @@ FamixTestComposed2TEntityCreator >> newClass [
 { #category : 'entity creation' }
 FamixTestComposed2TEntityCreator >> newClassNamed: aName [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: (FamixTestComposed2Class named: aName)
 ]
@@ -36,6 +39,7 @@ FamixTestComposed2TEntityCreator >> newClassNamed: aName [
 { #category : 'entity creation' }
 FamixTestComposed2TEntityCreator >> newComment [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixTestComposed2Comment new
 ]
@@ -43,6 +47,7 @@ FamixTestComposed2TEntityCreator >> newComment [
 { #category : 'entity creation' }
 FamixTestComposed2TEntityCreator >> newCustomEntity1 [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixTestComposed2CustomEntity1 new
 ]
@@ -50,6 +55,7 @@ FamixTestComposed2TEntityCreator >> newCustomEntity1 [
 { #category : 'entity creation' }
 FamixTestComposed2TEntityCreator >> newCustomEntity2 [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixTestComposed2CustomEntity2 new
 ]
@@ -57,6 +63,7 @@ FamixTestComposed2TEntityCreator >> newCustomEntity2 [
 { #category : 'entity creation' }
 FamixTestComposed2TEntityCreator >> newCustomEntity3 [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixTestComposed2CustomEntity3 new
 ]
@@ -64,6 +71,7 @@ FamixTestComposed2TEntityCreator >> newCustomEntity3 [
 { #category : 'entity creation' }
 FamixTestComposed2TEntityCreator >> newCustomEntity4 [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixTestComposed2CustomEntity4 new
 ]
@@ -71,6 +79,7 @@ FamixTestComposed2TEntityCreator >> newCustomEntity4 [
 { #category : 'entity creation' }
 FamixTestComposed2TEntityCreator >> newCustomEntity5 [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixTestComposed2CustomEntity5 new
 ]
@@ -78,6 +87,7 @@ FamixTestComposed2TEntityCreator >> newCustomEntity5 [
 { #category : 'entity creation' }
 FamixTestComposed2TEntityCreator >> newMethod [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixTestComposed2Method new
 ]
@@ -85,6 +95,7 @@ FamixTestComposed2TEntityCreator >> newMethod [
 { #category : 'entity creation' }
 FamixTestComposed2TEntityCreator >> newMethodNamed: aName [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: (FamixTestComposed2Method named: aName)
 ]
@@ -92,6 +103,7 @@ FamixTestComposed2TEntityCreator >> newMethodNamed: aName [
 { #category : 'entity creation' }
 FamixTestComposed2TEntityCreator >> newSourceLanguage [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixTestComposed2SourceLanguage new
 ]
@@ -99,6 +111,7 @@ FamixTestComposed2TEntityCreator >> newSourceLanguage [
 { #category : 'entity creation' }
 FamixTestComposed2TEntityCreator >> newSourceTextAnchor [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FamixTestComposed2SourceTextAnchor new
 ]

--- a/src/Famix-Traits/FamixTAccess.trait.st
+++ b/src/Famix-Traits/FamixTAccess.trait.st
@@ -58,6 +58,7 @@ Trait {
 { #category : 'meta' }
 FamixTAccess classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TAccess super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -67,6 +68,7 @@ FamixTAccess classSide >> annotation [
 FamixTAccess >> accessor [
 	"Relation named: #accessor type: #FamixTWithAccesses opposite: #accesses"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'Behavioural entity making the access to the variable. from-side of the association'>
 	<source>
@@ -76,12 +78,15 @@ FamixTAccess >> accessor [
 { #category : 'accessing' }
 FamixTAccess >> accessor: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	accessor := anObject
 ]
 
 { #category : 'adding' }
 FamixTAccess >> addCandidate: anObject [
+
+	<ignoreForCoverage>
 	<generated>
 	^ self candidates add: anObject
 ]
@@ -90,6 +95,7 @@ FamixTAccess >> addCandidate: anObject [
 FamixTAccess >> candidates [
 	"Relation named: #candidates type: #FamixTAccessible opposite: #incomingAccesses"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'Variables that cas be the accessed variable. to-side of the association. Most of the time it will be only one variable, but some languages might have candidates such as Python.'>
 	<derived>
@@ -100,6 +106,7 @@ FamixTAccess >> candidates [
 { #category : 'accessing' }
 FamixTAccess >> candidates: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	candidates value: anObject
 ]
@@ -127,6 +134,7 @@ FamixTAccess >> displayStringOn: aStream [
 { #category : 'testing' }
 FamixTAccess >> isAccess [
 
+	<ignoreForCoverage>
 	<generated>
 	^ true
 ]
@@ -157,6 +165,7 @@ FamixTAccess >> isWrite [
 
 { #category : 'accessing' }
 FamixTAccess >> isWrite: anObject [
+	<ignoreForCoverage>
 	<generated>
 	isWrite := anObject
 ]

--- a/src/Famix-Traits/FamixTAccessible.trait.st
+++ b/src/Famix-Traits/FamixTAccessible.trait.st
@@ -23,6 +23,7 @@ Trait {
 { #category : 'meta' }
 FamixTAccessible classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TAccessible super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -72,6 +73,7 @@ FamixTAccessible >> globalAccesses [
 FamixTAccessible >> incomingAccesses [
 	"Relation named: #incomingAccesses type: #FamixTAccess opposite: #candidates"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'All Famix accesses pointing to this structural entity'>
 	^ incomingAccesses
@@ -80,6 +82,7 @@ FamixTAccessible >> incomingAccesses [
 { #category : 'accessing' }
 FamixTAccessible >> incomingAccesses: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	incomingAccesses value: anObject
 ]

--- a/src/Famix-Traits/FamixTAnnotationInstance.trait.st
+++ b/src/Famix-Traits/FamixTAnnotationInstance.trait.st
@@ -45,6 +45,7 @@ Trait {
 { #category : 'meta' }
 FamixTAnnotationInstance classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TAnnotationInstance super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -52,6 +53,8 @@ FamixTAnnotationInstance classSide >> annotation [
 
 { #category : 'groups' }
 FamixTAnnotationInstance classSide >> annotationFamixAnnotationInstanceGroup [
+
+	<ignoreForCoverage>
 	<generated>
 	<mooseGroup>
 	^ FamixAnnotationInstanceGroup
@@ -59,6 +62,8 @@ FamixTAnnotationInstance classSide >> annotationFamixAnnotationInstanceGroup [
 
 { #category : 'adding' }
 FamixTAnnotationInstance >> addAttribute: anObject [
+
+	<ignoreForCoverage>
 	<generated>
 	^ self attributes add: anObject
 ]
@@ -67,6 +72,7 @@ FamixTAnnotationInstance >> addAttribute: anObject [
 FamixTAnnotationInstance >> annotatedEntity [
 	"Relation named: #annotatedEntity type: #FamixTWithAnnotationInstances opposite: #annotationInstances"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'The NamedEntity on which the annotation occurs.'>
 	^ annotatedEntity
@@ -75,6 +81,7 @@ FamixTAnnotationInstance >> annotatedEntity [
 { #category : 'accessing' }
 FamixTAnnotationInstance >> annotatedEntity: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	annotatedEntity := anObject
 ]
@@ -83,6 +90,7 @@ FamixTAnnotationInstance >> annotatedEntity: anObject [
 FamixTAnnotationInstance >> annotationType [
 	"Relation named: #annotationType type: #FamixTAnnotationType opposite: #instances"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'Refers to the type of an annotation. (In some languages, Java and C#, an annotation as an explicit type). '>
 	^ annotationType
@@ -91,6 +99,7 @@ FamixTAnnotationInstance >> annotationType [
 { #category : 'accessing' }
 FamixTAnnotationInstance >> annotationType: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	annotationType := anObject
 ]
@@ -99,6 +108,7 @@ FamixTAnnotationInstance >> annotationType: anObject [
 FamixTAnnotationInstance >> attributes [
 	"Relation named: #attributes type: #FamixTAnnotationInstanceAttribute opposite: #parentAnnotationInstance"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'This corresponds to the actual values of the attributes in an AnnotationInstance'>
 	<derived>
@@ -108,6 +118,7 @@ FamixTAnnotationInstance >> attributes [
 { #category : 'accessing' }
 FamixTAnnotationInstance >> attributes: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	attributes value: anObject
 ]

--- a/src/Famix-Traits/FamixTAnnotationInstanceAttribute.trait.st
+++ b/src/Famix-Traits/FamixTAnnotationInstanceAttribute.trait.st
@@ -48,6 +48,7 @@ Trait {
 { #category : 'meta' }
 FamixTAnnotationInstanceAttribute classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TAnnotationInstanceAttribute super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -57,6 +58,7 @@ FamixTAnnotationInstanceAttribute classSide >> annotation [
 FamixTAnnotationInstanceAttribute >> annotationTypeAttribute [
 	"Relation named: #annotationTypeAttribute type: #FamixTAnnotationTypeAttribute opposite: #annotationAttributeInstances"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'This corresponds to the type of the attribute in an AnnotationInstance'>
 	^ annotationTypeAttribute
@@ -65,6 +67,7 @@ FamixTAnnotationInstanceAttribute >> annotationTypeAttribute [
 { #category : 'accessing' }
 FamixTAnnotationInstanceAttribute >> annotationTypeAttribute: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	annotationTypeAttribute := anObject
 ]
@@ -73,6 +76,7 @@ FamixTAnnotationInstanceAttribute >> annotationTypeAttribute: anObject [
 FamixTAnnotationInstanceAttribute >> parentAnnotationInstance [
 	"Relation named: #parentAnnotationInstance type: #FamixTAnnotationInstance opposite: #attributes"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'The instance of the annotation in which the attribute is used.'>
 	<container>
@@ -82,6 +86,7 @@ FamixTAnnotationInstanceAttribute >> parentAnnotationInstance [
 { #category : 'accessing' }
 FamixTAnnotationInstanceAttribute >> parentAnnotationInstance: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	parentAnnotationInstance := anObject
 ]
@@ -90,6 +95,7 @@ FamixTAnnotationInstanceAttribute >> parentAnnotationInstance: anObject [
 FamixTAnnotationInstanceAttribute >> value [
 
 	<FMProperty: #value type: #Object>
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'Actual value of the attribute used in an annotation'>
 	^ value
@@ -97,6 +103,7 @@ FamixTAnnotationInstanceAttribute >> value [
 
 { #category : 'accessing' }
 FamixTAnnotationInstanceAttribute >> value: anObject [
+	<ignoreForCoverage>
 	<generated>
 	value := anObject
 ]

--- a/src/Famix-Traits/FamixTAnnotationType.trait.st
+++ b/src/Famix-Traits/FamixTAnnotationType.trait.st
@@ -35,6 +35,7 @@ Trait {
 { #category : 'meta' }
 FamixTAnnotationType classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TAnnotationType super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -42,6 +43,8 @@ FamixTAnnotationType classSide >> annotation [
 
 { #category : 'groups' }
 FamixTAnnotationType classSide >> annotationFamixAnnotationTypeGroup [
+
+	<ignoreForCoverage>
 	<generated>
 	<mooseGroup>
 	^ FamixAnnotationTypeGroup
@@ -58,6 +61,7 @@ FamixTAnnotationType >> addInstance: anObject [
 FamixTAnnotationType >> annotationTypesContainer [
 	"Relation named: #annotationTypesContainer type: #FamixTWithAnnotationTypes opposite: #definedAnnotationTypes"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'Container in which an AnnotationType may reside'>
 	<container>
@@ -67,6 +71,7 @@ FamixTAnnotationType >> annotationTypesContainer [
 { #category : 'accessing' }
 FamixTAnnotationType >> annotationTypesContainer: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	annotationTypesContainer := anObject
 ]
@@ -81,6 +86,7 @@ FamixTAnnotationType >> displayStringOn: aStream [
 FamixTAnnotationType >> instances [
 	"Relation named: #instances type: #FamixTAnnotationInstance opposite: #annotationType"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'Annotations of this type'>
 	<derived>
@@ -90,6 +96,7 @@ FamixTAnnotationType >> instances [
 { #category : 'accessing' }
 FamixTAnnotationType >> instances: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	instances value: anObject
 ]

--- a/src/Famix-Traits/FamixTAnnotationTypeAttribute.trait.st
+++ b/src/Famix-Traits/FamixTAnnotationTypeAttribute.trait.st
@@ -65,6 +65,7 @@ Trait {
 { #category : 'meta' }
 FamixTAnnotationTypeAttribute classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TAnnotationTypeAttribute super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -80,6 +81,7 @@ FamixTAnnotationTypeAttribute >> addAnnotationAttributeInstance: anObject [
 FamixTAnnotationTypeAttribute >> annotationAttributeInstances [
 	"Relation named: #annotationAttributeInstances type: #FamixTAnnotationInstanceAttribute opposite: #annotationTypeAttribute"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'A collection of AnnotationInstanceAttribute which hold the usages of this attribute in actual AnnotationInstances'>
 	<derived>
@@ -89,6 +91,7 @@ FamixTAnnotationTypeAttribute >> annotationAttributeInstances [
 { #category : 'accessing' }
 FamixTAnnotationTypeAttribute >> annotationAttributeInstances: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	annotationAttributeInstances value: anObject
 ]

--- a/src/Famix-Traits/FamixTAssociation.trait.st
+++ b/src/Famix-Traits/FamixTAssociation.trait.st
@@ -46,6 +46,7 @@ Trait {
 { #category : 'meta' }
 FamixTAssociation classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TAssociation super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -106,6 +107,7 @@ FamixTAssociation >> displayStringOn: aStream [
 { #category : 'testing' }
 FamixTAssociation >> isAssociation [
 
+	<ignoreForCoverage>
 	<generated>
 	^ true
 ]
@@ -114,6 +116,7 @@ FamixTAssociation >> isAssociation [
 FamixTAssociation >> next [
 	"Relation named: #next type: #FamixTAssociation opposite: #previous"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'Next association in an ordered collection of associations. Currently not supported by the Moose importer'>
 	<derived>
@@ -123,6 +126,7 @@ FamixTAssociation >> next [
 { #category : 'accessing' }
 FamixTAssociation >> next: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	next := anObject
 ]
@@ -131,6 +135,7 @@ FamixTAssociation >> next: anObject [
 FamixTAssociation >> previous [
 	"Relation named: #previous type: #FamixTAssociation opposite: #next"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'Previous association in an ordered collection of associations. Currently not supported by the Moose importer'>
 	^ previous
@@ -139,6 +144,7 @@ FamixTAssociation >> previous [
 { #category : 'accessing' }
 FamixTAssociation >> previous: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	previous := anObject
 ]

--- a/src/Famix-Traits/FamixTAttribute.trait.st
+++ b/src/Famix-Traits/FamixTAttribute.trait.st
@@ -50,6 +50,7 @@ Trait {
 { #category : 'meta' }
 FamixTAttribute classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TAttribute super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -79,6 +80,7 @@ FamixTAttribute >> hierarchyNestingLevel: aNumber [
 { #category : 'testing' }
 FamixTAttribute >> isAttribute [
 
+	<ignoreForCoverage>
 	<generated>
 	^ true
 ]
@@ -104,6 +106,7 @@ FamixTAttribute >> mooseNameOn: aStream [
 FamixTAttribute >> parentType [
 	"Relation named: #parentType type: #FamixTWithAttributes opposite: #attributes"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'Type declaring the attribute. belongsTo implementation'>
 	<container>

--- a/src/Famix-Traits/FamixTBytesFileAnchor.trait.st
+++ b/src/Famix-Traits/FamixTBytesFileAnchor.trait.st
@@ -29,6 +29,7 @@ Trait {
 { #category : 'meta' }
 FamixTBytesFileAnchor classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TBytesFileAnchor super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -38,6 +39,7 @@ FamixTBytesFileAnchor classSide >> annotation [
 FamixTBytesFileAnchor >> endByte [
 
 	<FMProperty: #endByte type: #Number>
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'Stop position in the source in number of bytes'>
 	^ endByte
@@ -45,6 +47,7 @@ FamixTBytesFileAnchor >> endByte [
 
 { #category : 'accessing' }
 FamixTBytesFileAnchor >> endByte: anObject [
+	<ignoreForCoverage>
 	<generated>
 	endByte := anObject
 ]
@@ -74,6 +77,7 @@ FamixTBytesFileAnchor >> sourceText [
 FamixTBytesFileAnchor >> startByte [
 
 	<FMProperty: #startByte type: #Number>
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'Start position in the source in number of bytes'>
 	^ startByte
@@ -81,6 +85,7 @@ FamixTBytesFileAnchor >> startByte [
 
 { #category : 'accessing' }
 FamixTBytesFileAnchor >> startByte: anObject [
+	<ignoreForCoverage>
 	<generated>
 	startByte := anObject
 ]

--- a/src/Famix-Traits/FamixTCanBeAbstract.trait.st
+++ b/src/Famix-Traits/FamixTCanBeAbstract.trait.st
@@ -20,6 +20,7 @@ Trait {
 { #category : 'meta' }
 FamixTCanBeAbstract classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TCanBeAbstract super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -29,6 +30,7 @@ FamixTCanBeAbstract classSide >> annotation [
 FamixTCanBeAbstract >> isAbstract [
 
 	<FMProperty: #isAbstract type: #Boolean defaultValue: false>
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'Entity can be declared abstract'>
 	^ isAbstract ifNil: [ isAbstract := false ]
@@ -36,6 +38,7 @@ FamixTCanBeAbstract >> isAbstract [
 
 { #category : 'accessing' }
 FamixTCanBeAbstract >> isAbstract: anObject [
+	<ignoreForCoverage>
 	<generated>
 	isAbstract := anObject
 ]

--- a/src/Famix-Traits/FamixTCanBeClassSide.trait.st
+++ b/src/Famix-Traits/FamixTCanBeClassSide.trait.st
@@ -20,6 +20,7 @@ Trait {
 { #category : 'meta' }
 FamixTCanBeClassSide classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TCanBeClassSide super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -29,6 +30,7 @@ FamixTCanBeClassSide classSide >> annotation [
 FamixTCanBeClassSide >> isClassSide [
 
 	<FMProperty: #isClassSide type: #Boolean defaultValue: false>
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'Entity can be declared class side i.e. static'>
 	^ isClassSide ifNil: [ isClassSide := false ]
@@ -36,6 +38,7 @@ FamixTCanBeClassSide >> isClassSide [
 
 { #category : 'accessing' }
 FamixTCanBeClassSide >> isClassSide: anObject [
+	<ignoreForCoverage>
 	<generated>
 	isClassSide := anObject
 ]

--- a/src/Famix-Traits/FamixTCanBeFinal.trait.st
+++ b/src/Famix-Traits/FamixTCanBeFinal.trait.st
@@ -20,6 +20,7 @@ Trait {
 { #category : 'meta' }
 FamixTCanBeFinal classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TCanBeFinal super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -29,6 +30,7 @@ FamixTCanBeFinal classSide >> annotation [
 FamixTCanBeFinal >> isFinal [
 
 	<FMProperty: #isFinal type: #Boolean defaultValue: false>
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'Entity can be declared final'>
 	^ isFinal ifNil: [ isFinal := false ]
@@ -36,6 +38,7 @@ FamixTCanBeFinal >> isFinal [
 
 { #category : 'accessing' }
 FamixTCanBeFinal >> isFinal: anObject [
+	<ignoreForCoverage>
 	<generated>
 	isFinal := anObject
 ]

--- a/src/Famix-Traits/FamixTCanBeStub.trait.st
+++ b/src/Famix-Traits/FamixTCanBeStub.trait.st
@@ -31,6 +31,7 @@ Trait {
 { #category : 'meta' }
 FamixTCanBeStub classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TCanBeStub super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -39,6 +40,7 @@ FamixTCanBeStub classSide >> annotation [
 { #category : 'testing' }
 FamixTCanBeStub >> canBeStub [
 
+	<ignoreForCoverage>
 	<generated>
 	^ true
 ]
@@ -47,6 +49,7 @@ FamixTCanBeStub >> canBeStub [
 FamixTCanBeStub >> isStub [
 
 	<FMProperty: #isStub type: #Boolean defaultValue: false>
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'Flag true if the entity attributes are incomplete, either because the entity is missing or not imported.'>
 	^ isStub ifNil: [ isStub := false ]
@@ -54,6 +57,7 @@ FamixTCanBeStub >> isStub [
 
 { #category : 'accessing' }
 FamixTCanBeStub >> isStub: anObject [
+	<ignoreForCoverage>
 	<generated>
 	isStub := anObject
 ]

--- a/src/Famix-Traits/FamixTCanImplement.trait.st
+++ b/src/Famix-Traits/FamixTCanImplement.trait.st
@@ -25,6 +25,7 @@ Trait {
 { #category : 'meta' }
 FamixTCanImplement classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TCanImplement super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -32,6 +33,8 @@ FamixTCanImplement classSide >> annotation [
 
 { #category : 'adding' }
 FamixTCanImplement >> addInterfaceImplementation: anObject [
+
+	<ignoreForCoverage>
 	<generated>
 	^ self interfaceImplementations add: anObject
 ]
@@ -68,6 +71,7 @@ FamixTCanImplement >> directImplementedInterfaces [
 FamixTCanImplement >> interfaceImplementations [
 	"Relation named: #interfaceImplementations type: #FamixTImplementation opposite: #implementingClass"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'Implementation relationships'>
 	<derived>
@@ -77,6 +81,7 @@ FamixTCanImplement >> interfaceImplementations [
 { #category : 'accessing' }
 FamixTCanImplement >> interfaceImplementations: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	interfaceImplementations value: anObject
 ]

--- a/src/Famix-Traits/FamixTClass.trait.st
+++ b/src/Famix-Traits/FamixTClass.trait.st
@@ -60,6 +60,7 @@ Trait {
 { #category : 'meta' }
 FamixTClass classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TClass super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -67,6 +68,8 @@ FamixTClass classSide >> annotation [
 
 { #category : 'groups' }
 FamixTClass classSide >> annotationFamixClassGroup [
+
+	<ignoreForCoverage>
 	<generated>
 	<mooseGroup>
 	^ FamixClassGroup
@@ -177,6 +180,7 @@ FamixTClass >> inheritedSignaturesToMethod [
 { #category : 'testing' }
 FamixTClass >> isClass [
 
+	<ignoreForCoverage>
 	<generated>
 	^ true
 ]

--- a/src/Famix-Traits/FamixTClassMetrics.trait.st
+++ b/src/Famix-Traits/FamixTClassMetrics.trait.st
@@ -8,6 +8,7 @@ Trait {
 { #category : 'meta' }
 FamixTClassMetrics classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TClassMetrics super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>

--- a/src/Famix-Traits/FamixTCohesionCouplingMetrics.trait.st
+++ b/src/Famix-Traits/FamixTCohesionCouplingMetrics.trait.st
@@ -34,6 +34,7 @@ Trait {
 { #category : 'meta' }
 FamixTCohesionCouplingMetrics classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TCohesionCouplingMetrics super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>

--- a/src/Famix-Traits/FamixTComment.trait.st
+++ b/src/Famix-Traits/FamixTComment.trait.st
@@ -32,6 +32,7 @@ Trait {
 { #category : 'meta' }
 FamixTComment classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TComment super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -41,6 +42,7 @@ FamixTComment classSide >> annotation [
 FamixTComment >> commentedEntity [
 	"Relation named: #commentedEntity type: #FamixTWithComments opposite: #comments"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'Source code commented by the comment'>
 	<container>
@@ -50,6 +52,7 @@ FamixTComment >> commentedEntity [
 { #category : 'accessing' }
 FamixTComment >> commentedEntity: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	commentedEntity := anObject
 ]
@@ -64,6 +67,7 @@ FamixTComment >> displayStringOn: aStream [
 { #category : 'testing' }
 FamixTComment >> isComment [
 
+	<ignoreForCoverage>
 	<generated>
 	^ true
 ]

--- a/src/Famix-Traits/FamixTCompilationUnit.trait.st
+++ b/src/Famix-Traits/FamixTCompilationUnit.trait.st
@@ -39,6 +39,7 @@ Trait {
 { #category : 'meta' }
 FamixTCompilationUnit classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TCompilationUnit super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -48,6 +49,7 @@ FamixTCompilationUnit classSide >> annotation [
 FamixTCompilationUnit >> compilationUnitOwner [
 	"Relation named: #compilationUnitOwner type: #FamixTWithCompilationUnits opposite: #compilationUnit"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'The compilation unit that defines this module'>
 	<container>
@@ -57,6 +59,7 @@ FamixTCompilationUnit >> compilationUnitOwner [
 { #category : 'accessing' }
 FamixTCompilationUnit >> compilationUnitOwner: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	compilationUnitOwner := anObject
 ]

--- a/src/Famix-Traits/FamixTConcretization.trait.st
+++ b/src/Famix-Traits/FamixTConcretization.trait.st
@@ -43,6 +43,7 @@ Trait {
 { #category : 'meta' }
 FamixTConcretization classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TConcretization super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -52,6 +53,7 @@ FamixTConcretization classSide >> annotation [
 FamixTConcretization >> triggeringAssociation [
 	"Relation named: #triggeringAssociation type: #FamixTParametricAssociation opposite: #concretizations"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'The association that triggers this concretization.'>
 	^ triggeringAssociation
@@ -60,6 +62,7 @@ FamixTConcretization >> triggeringAssociation [
 { #category : 'accessing' }
 FamixTConcretization >> triggeringAssociation: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	triggeringAssociation := anObject
 ]
@@ -68,6 +71,7 @@ FamixTConcretization >> triggeringAssociation: anObject [
 FamixTConcretization >> typeArgument [
 	"Relation named: #typeArgument type: #FamixTTypeArgument opposite: #outgoingConcretizations"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'The type argument that concretizes the type parameter'>
 	<source>
@@ -77,6 +81,7 @@ FamixTConcretization >> typeArgument [
 { #category : 'accessing' }
 FamixTConcretization >> typeArgument: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	typeArgument := anObject
 ]
@@ -85,6 +90,7 @@ FamixTConcretization >> typeArgument: anObject [
 FamixTConcretization >> typeParameter [
 	"Relation named: #typeParameter type: #FamixTTypeParameter opposite: #concretizations"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'Type parameter linked to in this relationship.'>
 	<target>
@@ -94,6 +100,7 @@ FamixTConcretization >> typeParameter [
 { #category : 'accessing' }
 FamixTConcretization >> typeParameter: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	typeParameter := anObject
 ]

--- a/src/Famix-Traits/FamixTDefinedInModule.trait.st
+++ b/src/Famix-Traits/FamixTDefinedInModule.trait.st
@@ -23,6 +23,7 @@ Trait {
 { #category : 'meta' }
 FamixTDefinedInModule classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TDefinedInModule super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -32,6 +33,7 @@ FamixTDefinedInModule classSide >> annotation [
 FamixTDefinedInModule >> parentModule [
 	"Relation named: #parentModule type: #FamixTModule opposite: #moduleEntities"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'Module that contains the definition of this entity'>
 	<container>
@@ -41,6 +43,7 @@ FamixTDefinedInModule >> parentModule [
 { #category : 'accessing' }
 FamixTDefinedInModule >> parentModule: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	parentModule := anObject
 ]

--- a/src/Famix-Traits/FamixTDereferencedInvocation.trait.st
+++ b/src/Famix-Traits/FamixTDereferencedInvocation.trait.st
@@ -51,6 +51,7 @@ Trait {
 { #category : 'meta' }
 FamixTDereferencedInvocation classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TDereferencedInvocation super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -60,6 +61,7 @@ FamixTDereferencedInvocation classSide >> annotation [
 FamixTDereferencedInvocation >> referencer [
 	"Relation named: #referencer type: #FamixTWithDereferencedInvocations opposite: #dereferencedInvocations"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'Structural entity that references the BehaviouralEntity invoked'>
 	^ referencer
@@ -68,6 +70,7 @@ FamixTDereferencedInvocation >> referencer [
 { #category : 'accessing' }
 FamixTDereferencedInvocation >> referencer: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	referencer := anObject
 ]

--- a/src/Famix-Traits/FamixTEntityTyping.trait.st
+++ b/src/Famix-Traits/FamixTEntityTyping.trait.st
@@ -38,6 +38,7 @@ Trait {
 { #category : 'meta' }
 FamixTEntityTyping classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TEntityTyping super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -47,6 +48,7 @@ FamixTEntityTyping classSide >> annotation [
 FamixTEntityTyping >> declaredType [
 	"Relation named: #declaredType type: #FamixTType opposite: #incomingTypings"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'Type of the entity.'>
 	<target>
@@ -56,6 +58,7 @@ FamixTEntityTyping >> declaredType [
 { #category : 'accessing' }
 FamixTEntityTyping >> declaredType: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	declaredType := anObject
 ]
@@ -64,6 +67,7 @@ FamixTEntityTyping >> declaredType: anObject [
 FamixTEntityTyping >> typedEntity [
 	"Relation named: #typedEntity type: #FamixTTypedEntity opposite: #typing"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'Entity deckaring the type.'>
 	<derived>
@@ -74,6 +78,7 @@ FamixTEntityTyping >> typedEntity [
 { #category : 'accessing' }
 FamixTEntityTyping >> typedEntity: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	typedEntity := anObject
 ]

--- a/src/Famix-Traits/FamixTEnum.trait.st
+++ b/src/Famix-Traits/FamixTEnum.trait.st
@@ -57,6 +57,7 @@ Trait {
 { #category : 'meta' }
 FamixTEnum classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TEnum super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>

--- a/src/Famix-Traits/FamixTEnumValue.trait.st
+++ b/src/Famix-Traits/FamixTEnumValue.trait.st
@@ -59,6 +59,7 @@ Trait {
 { #category : 'meta' }
 FamixTEnumValue classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TEnumValue super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -67,6 +68,7 @@ FamixTEnumValue classSide >> annotation [
 { #category : 'testing' }
 FamixTEnumValue >> isEnumValue [
 
+	<ignoreForCoverage>
 	<generated>
 	^ true
 ]
@@ -88,6 +90,7 @@ FamixTEnumValue >> mooseNameSeparator [
 FamixTEnumValue >> parentEnum [
 	"Relation named: #parentEnum type: #FamixTWithEnumValues opposite: #enumValues"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'The Enum declaring this value. It offers the implementation of belongsTo'>
 	<container>
@@ -97,6 +100,7 @@ FamixTEnumValue >> parentEnum [
 { #category : 'accessing' }
 FamixTEnumValue >> parentEnum: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	parentEnum := anObject
 ]

--- a/src/Famix-Traits/FamixTException.trait.st
+++ b/src/Famix-Traits/FamixTException.trait.st
@@ -59,6 +59,7 @@ Trait {
 { #category : 'meta' }
 FamixTException classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TException super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -67,6 +68,7 @@ FamixTException classSide >> annotation [
 { #category : 'testing' }
 FamixTException >> isException [
 
+	<ignoreForCoverage>
 	<generated>
 	^ true
 ]

--- a/src/Famix-Traits/FamixTFile.trait.st
+++ b/src/Famix-Traits/FamixTFile.trait.st
@@ -38,6 +38,7 @@ Trait {
 { #category : 'meta' }
 FamixTFile classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TFile super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -45,6 +46,8 @@ FamixTFile classSide >> annotation [
 
 { #category : 'groups' }
 FamixTFile classSide >> annotationFamixFileGroup [
+
+	<ignoreForCoverage>
 	<generated>
 	<mooseGroup>
 	^ FamixFileGroup
@@ -71,6 +74,7 @@ FamixTFile >> averageNumberOfCharactersPerLine [
 FamixTFile >> entities [
 	"Relation named: #entities type: #FamixTWithFiles opposite: #containerFiles"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'List of entities defined in the file'>
 	<derived>
@@ -80,6 +84,7 @@ FamixTFile >> entities [
 { #category : 'accessing' }
 FamixTFile >> entities: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	entities value: anObject
 ]

--- a/src/Famix-Traits/FamixTFileAnchor.trait.st
+++ b/src/Famix-Traits/FamixTFileAnchor.trait.st
@@ -26,6 +26,7 @@ Trait {
 { #category : 'meta' }
 FamixTFileAnchor classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TFileAnchor super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -52,6 +53,7 @@ FamixTFileAnchor >> containerFiles [
 FamixTFileAnchor >> correspondingFile [
 
 	<FMProperty: #correspondingFile type: #FamixTFile>
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'File associated to this source anchor'>
 	^ correspondingFile
@@ -59,6 +61,7 @@ FamixTFileAnchor >> correspondingFile [
 
 { #category : 'accessing' }
 FamixTFileAnchor >> correspondingFile: anObject [
+	<ignoreForCoverage>
 	<generated>
 	correspondingFile := anObject
 ]
@@ -81,6 +84,7 @@ FamixTFileAnchor >> encoding [
 
 { #category : 'accessing' }
 FamixTFileAnchor >> encoding: anObject [
+	<ignoreForCoverage>
 	<generated>
 	encoding := anObject
 ]
@@ -99,6 +103,7 @@ FamixTFileAnchor >> endPos [
 FamixTFileAnchor >> fileName [
 
 	<FMProperty: #fileName type: #String>
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'Name of the source file'>
 	^ fileName
@@ -147,6 +152,7 @@ FamixTFileAnchor >> isContiguousWith: anotherFileAnchor [
 { #category : 'testing' }
 FamixTFileAnchor >> isFileAnchor [
 
+	<ignoreForCoverage>
 	<generated>
 	^ true
 ]

--- a/src/Famix-Traits/FamixTFileInclude.trait.st
+++ b/src/Famix-Traits/FamixTFileInclude.trait.st
@@ -30,6 +30,7 @@ Trait {
 { #category : 'meta' }
 FamixTFileInclude classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TFileInclude super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -39,6 +40,7 @@ FamixTFileInclude classSide >> annotation [
 FamixTFileInclude >> source [
 	"Relation named: #source type: #FamixTWithFileIncludes opposite: #outgoingIncludeRelations"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'The file that is including'>
 	^ source
@@ -47,6 +49,7 @@ FamixTFileInclude >> source [
 { #category : 'accessing' }
 FamixTFileInclude >> source: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	source := anObject
 ]
@@ -55,6 +58,7 @@ FamixTFileInclude >> source: anObject [
 FamixTFileInclude >> target [
 	"Relation named: #target type: #FamixTWithFileIncludes opposite: #incomingIncludeRelations"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'The file that is included'>
 	^ target
@@ -63,6 +67,7 @@ FamixTFileInclude >> target [
 { #category : 'accessing' }
 FamixTFileInclude >> target: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	target := anObject
 ]

--- a/src/Famix-Traits/FamixTFileNavigation.trait.st
+++ b/src/Famix-Traits/FamixTFileNavigation.trait.st
@@ -31,6 +31,7 @@ Trait {
 { #category : 'meta' }
 FamixTFileNavigation classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TFileNavigation super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -63,6 +64,7 @@ FamixTFileNavigation classSide >> fileName: aString startLine: anInteger startCo
 FamixTFileNavigation >> endColumn [
 
 	<FMProperty: #endColumn type: #Number>
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'Number of the end column'>
 	^ endColumn
@@ -70,6 +72,7 @@ FamixTFileNavigation >> endColumn [
 
 { #category : 'accessing' }
 FamixTFileNavigation >> endColumn: anObject [
+	<ignoreForCoverage>
 	<generated>
 	endColumn := anObject
 ]
@@ -78,6 +81,7 @@ FamixTFileNavigation >> endColumn: anObject [
 FamixTFileNavigation >> endLine [
 
 	<FMProperty: #endLine type: #Number>
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'Number of the end line'>
 	^ endLine
@@ -85,6 +89,7 @@ FamixTFileNavigation >> endLine [
 
 { #category : 'accessing' }
 FamixTFileNavigation >> endLine: anObject [
+	<ignoreForCoverage>
 	<generated>
 	endLine := anObject
 ]
@@ -176,6 +181,7 @@ FamixTFileNavigation >> sourceText [
 FamixTFileNavigation >> startColumn [
 
 	<FMProperty: #startColumn type: #Number>
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'Number of the start column'>
 	^ startColumn
@@ -183,6 +189,7 @@ FamixTFileNavigation >> startColumn [
 
 { #category : 'accessing' }
 FamixTFileNavigation >> startColumn: anObject [
+	<ignoreForCoverage>
 	<generated>
 	startColumn := anObject
 ]
@@ -191,6 +198,7 @@ FamixTFileNavigation >> startColumn: anObject [
 FamixTFileNavigation >> startLine [
 
 	<FMProperty: #startLine type: #Number>
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'Number of the start line'>
 	^ startLine
@@ -198,6 +206,7 @@ FamixTFileNavigation >> startLine [
 
 { #category : 'accessing' }
 FamixTFileNavigation >> startLine: anObject [
+	<ignoreForCoverage>
 	<generated>
 	startLine := anObject
 ]

--- a/src/Famix-Traits/FamixTFileSystemEntity.trait.st
+++ b/src/Famix-Traits/FamixTFileSystemEntity.trait.st
@@ -31,6 +31,7 @@ Trait {
 { #category : 'meta' }
 FamixTFileSystemEntity classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TFileSystemEntity super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -121,6 +122,7 @@ FamixTFileSystemEntity >> numberOfLinesOfText [
 FamixTFileSystemEntity >> parentFolder [
 	"Relation named: #parentFolder type: #FamixTFolder opposite: #childrenFileSystemEntities"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'Folder entity containing this file.'>
 	<container>

--- a/src/Famix-Traits/FamixTFolder.trait.st
+++ b/src/Famix-Traits/FamixTFolder.trait.st
@@ -38,6 +38,7 @@ Trait {
 { #category : 'meta' }
 FamixTFolder classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TFolder super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -45,6 +46,8 @@ FamixTFolder classSide >> annotation [
 
 { #category : 'groups' }
 FamixTFolder classSide >> annotationFamixFolderGroup [
+
+	<ignoreForCoverage>
 	<generated>
 	<mooseGroup>
 	^ FamixFolderGroup
@@ -57,6 +60,8 @@ FamixTFolder >> addChildFileSystemEntity: aFileOrFolder [
 
 { #category : 'adding' }
 FamixTFolder >> addChildrenFileSystemEntity: anObject [
+
+	<ignoreForCoverage>
 	<generated>
 	^ self childrenFileSystemEntities add: anObject
 ]
@@ -81,6 +86,7 @@ FamixTFolder >> allRecursiveFolders [
 FamixTFolder >> childrenFileSystemEntities [
 	"Relation named: #childrenFileSystemEntities type: #FamixTFileSystemEntity opposite: #parentFolder"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'List of entities contained in this folder.'>
 	<derived>
@@ -90,6 +96,7 @@ FamixTFolder >> childrenFileSystemEntities [
 { #category : 'accessing' }
 FamixTFolder >> childrenFileSystemEntities: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	childrenFileSystemEntities value: anObject
 ]

--- a/src/Famix-Traits/FamixTFunction.trait.st
+++ b/src/Famix-Traits/FamixTFunction.trait.st
@@ -59,6 +59,7 @@ Trait {
 { #category : 'meta' }
 FamixTFunction classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TFunction super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -68,6 +69,7 @@ FamixTFunction classSide >> annotation [
 FamixTFunction >> functionOwner [
 	"Relation named: #functionOwner type: #FamixTWithFunctions opposite: #functions"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'The container defining the function. The function is placed in a container, because certain languages can nest functions in functions.'>
 	<container>
@@ -85,6 +87,7 @@ FamixTFunction >> functionOwner: anObject [
 { #category : 'testing' }
 FamixTFunction >> isFunction [
 
+	<ignoreForCoverage>
 	<generated>
 	^ true
 ]

--- a/src/Famix-Traits/FamixTGlobalVariable.trait.st
+++ b/src/Famix-Traits/FamixTGlobalVariable.trait.st
@@ -50,6 +50,7 @@ Trait {
 { #category : 'meta' }
 FamixTGlobalVariable classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TGlobalVariable super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -57,6 +58,8 @@ FamixTGlobalVariable classSide >> annotation [
 
 { #category : 'groups' }
 FamixTGlobalVariable classSide >> annotationFamixGlobalVariableGroup [
+
+	<ignoreForCoverage>
 	<generated>
 	<mooseGroup>
 	^ FamixGlobalVariableGroup
@@ -65,6 +68,7 @@ FamixTGlobalVariable classSide >> annotationFamixGlobalVariableGroup [
 { #category : 'testing' }
 FamixTGlobalVariable >> isGlobalVariable [
 
+	<ignoreForCoverage>
 	<generated>
 	^ true
 ]
@@ -73,6 +77,7 @@ FamixTGlobalVariable >> isGlobalVariable [
 FamixTGlobalVariable >> parentScope [
 	"Relation named: #parentScope type: #FamixTWithGlobalVariables opposite: #globalVariables"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'Scope declaring the global variable. belongsTo implementation'>
 	<container>
@@ -82,6 +87,7 @@ FamixTGlobalVariable >> parentScope [
 { #category : 'accessing' }
 FamixTGlobalVariable >> parentScope: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	parentScope := anObject
 ]

--- a/src/Famix-Traits/FamixTHasImmediateSource.trait.st
+++ b/src/Famix-Traits/FamixTHasImmediateSource.trait.st
@@ -33,6 +33,7 @@ Trait {
 { #category : 'meta' }
 FamixTHasImmediateSource classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #THasImmediateSource super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -55,6 +56,7 @@ FamixTHasImmediateSource classSide >> source: aString model: aMooseModel [
 { #category : 'testing' }
 FamixTHasImmediateSource >> hasImmediateSource [
 
+	<ignoreForCoverage>
 	<generated>
 	^ true
 ]
@@ -68,6 +70,7 @@ FamixTHasImmediateSource >> hasSource [
 FamixTHasImmediateSource >> source [
 
 	<FMProperty: #source type: #String>
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'Actual source code of the source entity'>
 	^ source
@@ -75,6 +78,7 @@ FamixTHasImmediateSource >> source [
 
 { #category : 'accessing' }
 FamixTHasImmediateSource >> source: anObject [
+	<ignoreForCoverage>
 	<generated>
 	source := anObject
 ]

--- a/src/Famix-Traits/FamixTHasKind.trait.st
+++ b/src/Famix-Traits/FamixTHasKind.trait.st
@@ -22,6 +22,7 @@ Trait {
 { #category : 'meta' }
 FamixTHasKind classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #THasKind super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -120,6 +121,7 @@ FamixTHasKind >> isSetter [
 FamixTHasKind >> kind [
 
 	<FMProperty: #kind type: #String>
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'Tag indicating a setter, getter, constant method'>
 	^ kind
@@ -127,6 +129,7 @@ FamixTHasKind >> kind [
 
 { #category : 'accessing' }
 FamixTHasKind >> kind: anObject [
+	<ignoreForCoverage>
 	<generated>
 	kind := anObject
 ]

--- a/src/Famix-Traits/FamixTHasSignature.trait.st
+++ b/src/Famix-Traits/FamixTHasSignature.trait.st
@@ -22,6 +22,7 @@ Trait {
 { #category : 'meta' }
 FamixTHasSignature classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #THasSignature super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -31,6 +32,7 @@ FamixTHasSignature classSide >> annotation [
 FamixTHasSignature >> signature [
 
 	<FMProperty: #signature type: #String>
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'Signature of the message being sent'>
 	^ signature
@@ -38,6 +40,7 @@ FamixTHasSignature >> signature [
 
 { #category : 'accessing' }
 FamixTHasSignature >> signature: anObject [
+	<ignoreForCoverage>
 	<generated>
 	signature := anObject
 ]

--- a/src/Famix-Traits/FamixTHasVisibility.trait.st
+++ b/src/Famix-Traits/FamixTHasVisibility.trait.st
@@ -20,6 +20,7 @@ Trait {
 { #category : 'meta' }
 FamixTHasVisibility classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #THasVisibility super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -109,6 +110,7 @@ FamixTHasVisibility >> isPublic: aBoolean [
 FamixTHasVisibility >> visibility [
 
 	<FMProperty: #visibility type: #String>
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'Visibility of the entity'>
 	^ visibility
@@ -116,6 +118,7 @@ FamixTHasVisibility >> visibility [
 
 { #category : 'accessing' }
 FamixTHasVisibility >> visibility: anObject [
+	<ignoreForCoverage>
 	<generated>
 	visibility := anObject
 ]

--- a/src/Famix-Traits/FamixTImplementable.trait.st
+++ b/src/Famix-Traits/FamixTImplementable.trait.st
@@ -25,6 +25,7 @@ Trait {
 { #category : 'meta' }
 FamixTImplementable classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TImplementable super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -32,6 +33,8 @@ FamixTImplementable classSide >> annotation [
 
 { #category : 'adding' }
 FamixTImplementable >> addImplementation: anObject [
+
+	<ignoreForCoverage>
 	<generated>
 	^ self implementations add: anObject
 ]
@@ -40,6 +43,7 @@ FamixTImplementable >> addImplementation: anObject [
 FamixTImplementable >> implementations [
 	"Relation named: #implementations type: #FamixTImplementation opposite: #interface"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'Implementation relationships.'>
 	<derived>
@@ -49,6 +53,7 @@ FamixTImplementable >> implementations [
 { #category : 'accessing' }
 FamixTImplementable >> implementations: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	implementations value: anObject
 ]

--- a/src/Famix-Traits/FamixTImplementation.trait.st
+++ b/src/Famix-Traits/FamixTImplementation.trait.st
@@ -38,6 +38,7 @@ Trait {
 { #category : 'meta' }
 FamixTImplementation classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TImplementation super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -47,6 +48,7 @@ FamixTImplementation classSide >> annotation [
 FamixTImplementation >> implementingClass [
 	"Relation named: #implementingClass type: #FamixTCanImplement opposite: #interfaceImplementations"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'Class linked to in this relationship. from-side of the association'>
 	<source>
@@ -56,6 +58,7 @@ FamixTImplementation >> implementingClass [
 { #category : 'accessing' }
 FamixTImplementation >> implementingClass: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	implementingClass := anObject
 ]
@@ -64,6 +67,7 @@ FamixTImplementation >> implementingClass: anObject [
 FamixTImplementation >> interface [
 	"Relation named: #interface type: #FamixTImplementable opposite: #implementations"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'Interface linked to in this relationship. to-side of the association'>
 	<target>
@@ -73,6 +77,7 @@ FamixTImplementation >> interface [
 { #category : 'accessing' }
 FamixTImplementation >> interface: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	interface := anObject
 ]

--- a/src/Famix-Traits/FamixTImplicitVariable.trait.st
+++ b/src/Famix-Traits/FamixTImplicitVariable.trait.st
@@ -49,6 +49,7 @@ Trait {
 { #category : 'meta' }
 FamixTImplicitVariable classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TImplicitVariable super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -73,6 +74,7 @@ FamixTImplicitVariable >> declaredType [
 { #category : 'testing' }
 FamixTImplicitVariable >> isImplicitVariable [
 
+	<ignoreForCoverage>
 	<generated>
 	^ true
 ]
@@ -93,6 +95,7 @@ FamixTImplicitVariable >> isSuper [
 FamixTImplicitVariable >> parentBehaviouralEntity [
 	"Relation named: #parentBehaviouralEntity type: #FamixTWithImplicitVariables opposite: #implicitVariables"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'The behaviour containing this implicit variable. belongsTo implementation'>
 	<container>

--- a/src/Famix-Traits/FamixTImport.trait.st
+++ b/src/Famix-Traits/FamixTImport.trait.st
@@ -38,6 +38,7 @@ Trait {
 { #category : 'meta' }
 FamixTImport classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TImport super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -47,6 +48,7 @@ FamixTImport classSide >> annotation [
 FamixTImport >> importedEntity [
 	"Relation named: #importedEntity type: #FamixTImportable opposite: #incomingImports"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'Imported entity'>
 	<target>
@@ -56,6 +58,7 @@ FamixTImport >> importedEntity [
 { #category : 'accessing' }
 FamixTImport >> importedEntity: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	importedEntity := anObject
 ]
@@ -64,6 +67,7 @@ FamixTImport >> importedEntity: anObject [
 FamixTImport >> importingEntity [
 	"Relation named: #importingEntity type: #FamixTWithImports opposite: #imports"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'Importing entity'>
 	<source>
@@ -73,6 +77,7 @@ FamixTImport >> importingEntity [
 { #category : 'accessing' }
 FamixTImport >> importingEntity: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	importingEntity := anObject
 ]

--- a/src/Famix-Traits/FamixTImportable.trait.st
+++ b/src/Famix-Traits/FamixTImportable.trait.st
@@ -23,6 +23,7 @@ Trait {
 { #category : 'meta' }
 FamixTImportable classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TImportable super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -30,6 +31,8 @@ FamixTImportable classSide >> annotation [
 
 { #category : 'adding' }
 FamixTImportable >> addIncomingImport: anObject [
+
+	<ignoreForCoverage>
 	<generated>
 	^ self incomingImports add: anObject
 ]
@@ -38,6 +41,7 @@ FamixTImportable >> addIncomingImport: anObject [
 FamixTImportable >> incomingImports [
 	"Relation named: #incomingImports type: #FamixTImport opposite: #importedEntity"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'List of imports of this entity'>
 	<derived>
@@ -47,6 +51,7 @@ FamixTImportable >> incomingImports [
 { #category : 'accessing' }
 FamixTImportable >> incomingImports: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	incomingImports value: anObject
 ]

--- a/src/Famix-Traits/FamixTIndexedFileNavigation.trait.st
+++ b/src/Famix-Traits/FamixTIndexedFileNavigation.trait.st
@@ -27,6 +27,7 @@ Trait {
 { #category : 'meta' }
 FamixTIndexedFileNavigation classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TIndexedFileNavigation super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -102,6 +103,7 @@ FamixTIndexedFileNavigation >> endLine [
 FamixTIndexedFileNavigation >> endPos [
 
 	<FMProperty: #endPos type: #Number>
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'Stop position in the source'>
 	^ endPos
@@ -109,6 +111,7 @@ FamixTIndexedFileNavigation >> endPos [
 
 { #category : 'accessing' }
 FamixTIndexedFileNavigation >> endPos: anObject [
+	<ignoreForCoverage>
 	<generated>
 	endPos := anObject
 ]
@@ -172,6 +175,7 @@ FamixTIndexedFileNavigation >> startLine [
 FamixTIndexedFileNavigation >> startPos [
 
 	<FMProperty: #startPos type: #Number>
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'Start position in the source'>
 	^ startPos
@@ -179,6 +183,7 @@ FamixTIndexedFileNavigation >> startPos [
 
 { #category : 'accessing' }
 FamixTIndexedFileNavigation >> startPos: anObject [
+	<ignoreForCoverage>
 	<generated>
 	startPos := anObject
 ]

--- a/src/Famix-Traits/FamixTInheritance.trait.st
+++ b/src/Famix-Traits/FamixTInheritance.trait.st
@@ -38,6 +38,7 @@ Trait {
 { #category : 'meta' }
 FamixTInheritance classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TInheritance super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -54,6 +55,7 @@ FamixTInheritance >> displayStringOn: aStream [
 { #category : 'testing' }
 FamixTInheritance >> isInheritance [
 
+	<ignoreForCoverage>
 	<generated>
 	^ true
 ]
@@ -62,6 +64,7 @@ FamixTInheritance >> isInheritance [
 FamixTInheritance >> subclass [
 	"Relation named: #subclass type: #FamixTWithInheritances opposite: #superInheritances"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'Subclass linked to in this relationship. from-side of the association'>
 	<source>
@@ -71,6 +74,7 @@ FamixTInheritance >> subclass [
 { #category : 'accessing' }
 FamixTInheritance >> subclass: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	subclass := anObject
 ]
@@ -79,6 +83,7 @@ FamixTInheritance >> subclass: anObject [
 FamixTInheritance >> superclass [
 	"Relation named: #superclass type: #FamixTWithInheritances opposite: #subInheritances"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'Superclass linked to in this relationship. to-side of the association'>
 	<target>
@@ -88,6 +93,7 @@ FamixTInheritance >> superclass [
 { #category : 'accessing' }
 FamixTInheritance >> superclass: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	superclass := anObject
 ]

--- a/src/Famix-Traits/FamixTInvocable.trait.st
+++ b/src/Famix-Traits/FamixTInvocable.trait.st
@@ -23,6 +23,7 @@ Trait {
 { #category : 'meta' }
 FamixTInvocable classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TInvocable super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -37,6 +38,7 @@ FamixTInvocable >> addIncomingInvocation: anInvocation [
 FamixTInvocable >> incomingInvocations [
 	"Relation named: #incomingInvocations type: #FamixTInvocation opposite: #candidates"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'Incoming invocations from other behaviours computed by the candidate operator.'>
 	<derived>
@@ -46,6 +48,7 @@ FamixTInvocable >> incomingInvocations [
 { #category : 'accessing' }
 FamixTInvocable >> incomingInvocations: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	incomingInvocations value: anObject
 ]

--- a/src/Famix-Traits/FamixTInvocation.trait.st
+++ b/src/Famix-Traits/FamixTInvocation.trait.st
@@ -57,6 +57,7 @@ Trait {
 { #category : 'meta' }
 FamixTInvocation classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TInvocation super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -64,6 +65,8 @@ FamixTInvocation classSide >> annotation [
 
 { #category : 'groups' }
 FamixTInvocation classSide >> annotationFamixInvocationGroup [
+
+	<ignoreForCoverage>
 	<generated>
 	<mooseGroup>
 	^ FamixInvocationGroup
@@ -83,6 +86,7 @@ FamixTInvocation >> anyCandidate [
 FamixTInvocation >> candidates [
 	"Relation named: #candidates type: #FamixTInvocable opposite: #incomingInvocations"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'List of candidate behavioural entities for receiving the invocation'>
 	<target>
@@ -92,6 +96,7 @@ FamixTInvocation >> candidates [
 { #category : 'accessing' }
 FamixTInvocation >> candidates: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	candidates value: anObject
 ]
@@ -150,6 +155,7 @@ FamixTInvocation >> invokedEntity: anEntity [
 { #category : 'testing' }
 FamixTInvocation >> isInvocation [
 
+	<ignoreForCoverage>
 	<generated>
 	^ true
 ]
@@ -174,6 +180,7 @@ FamixTInvocation >> isSuperInvocation [
 FamixTInvocation >> receiver [
 	"Relation named: #receiver type: #FamixTInvocationsReceiver opposite: #receivingInvocations"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'Named entity (variable, class...) receiving the invocation. to-side of the association'>
 	^ receiver
@@ -182,6 +189,7 @@ FamixTInvocation >> receiver [
 { #category : 'accessing' }
 FamixTInvocation >> receiver: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	receiver := anObject
 ]
@@ -190,6 +198,7 @@ FamixTInvocation >> receiver: anObject [
 FamixTInvocation >> sender [
 	"Relation named: #sender type: #FamixTWithInvocations opposite: #outgoingInvocations"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'Behavioural entity making the call. from-side of the association'>
 	<source>
@@ -199,6 +208,7 @@ FamixTInvocation >> sender [
 { #category : 'accessing' }
 FamixTInvocation >> sender: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	sender := anObject
 ]

--- a/src/Famix-Traits/FamixTInvocationsReceiver.trait.st
+++ b/src/Famix-Traits/FamixTInvocationsReceiver.trait.st
@@ -23,6 +23,7 @@ Trait {
 { #category : 'meta' }
 FamixTInvocationsReceiver classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TInvocationsReceiver super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -37,6 +38,7 @@ FamixTInvocationsReceiver >> addReceivingInvocation: anInvocation [
 FamixTInvocationsReceiver >> receivingInvocations [
 	"Relation named: #receivingInvocations type: #FamixTInvocation opposite: #receiver"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'List of invocations performed on this entity (considered as the receiver)'>
 	<derived>
@@ -46,6 +48,7 @@ FamixTInvocationsReceiver >> receivingInvocations [
 { #category : 'accessing' }
 FamixTInvocationsReceiver >> receivingInvocations: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	receivingInvocations value: anObject
 ]

--- a/src/Famix-Traits/FamixTLCOMMetrics.trait.st
+++ b/src/Famix-Traits/FamixTLCOMMetrics.trait.st
@@ -8,6 +8,7 @@ Trait {
 { #category : 'meta' }
 FamixTLCOMMetrics classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TLCOMMetrics super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>

--- a/src/Famix-Traits/FamixTLambda.trait.st
+++ b/src/Famix-Traits/FamixTLambda.trait.st
@@ -57,6 +57,7 @@ Trait {
 { #category : 'meta' }
 FamixTLambda classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TLambda super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -66,6 +67,7 @@ FamixTLambda classSide >> annotation [
 FamixTLambda >> lambdaContainer [
 	"Relation named: #lambdaContainer type: #FamixTWithLambdas opposite: #lambdas"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'The container defining the lambda expression. The lambda is placed in a container, because certain languages can nest lambdas in lambdas.'>
 	<container>
@@ -75,6 +77,7 @@ FamixTLambda >> lambdaContainer [
 { #category : 'accessing' }
 FamixTLambda >> lambdaContainer: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	lambdaContainer := anObject
 ]

--- a/src/Famix-Traits/FamixTLocalVariable.trait.st
+++ b/src/Famix-Traits/FamixTLocalVariable.trait.st
@@ -49,6 +49,7 @@ Trait {
 { #category : 'meta' }
 FamixTLocalVariable classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TLocalVariable super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -65,6 +66,7 @@ FamixTLocalVariable >> displayStringOn: aStream [
 { #category : 'testing' }
 FamixTLocalVariable >> isLocalVariable [
 
+	<ignoreForCoverage>
 	<generated>
 	^ true
 ]
@@ -73,6 +75,7 @@ FamixTLocalVariable >> isLocalVariable [
 FamixTLocalVariable >> parentBehaviouralEntity [
 	"Relation named: #parentBehaviouralEntity type: #FamixTWithLocalVariables opposite: #localVariables"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'Behavioural entity declaring this local variable. belongsTo implementation'>
 	<container>

--- a/src/Famix-Traits/FamixTMethod.trait.st
+++ b/src/Famix-Traits/FamixTMethod.trait.st
@@ -62,6 +62,7 @@ Trait {
 { #category : 'meta' }
 FamixTMethod classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TMethod super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -69,6 +70,8 @@ FamixTMethod classSide >> annotation [
 
 { #category : 'groups' }
 FamixTMethod classSide >> annotationFamixMethodGroup [
+
+	<ignoreForCoverage>
 	<generated>
 	<mooseGroup>
 	^ FamixMethodGroup
@@ -144,6 +147,7 @@ FamixTMethod >> isInitializer [
 { #category : 'testing' }
 FamixTMethod >> isMethod [
 
+	<ignoreForCoverage>
 	<generated>
 	^ true
 ]
@@ -187,6 +191,7 @@ FamixTMethod >> overridingMethods [
 FamixTMethod >> parentType [
 	"Relation named: #parentType type: #FamixTWithMethods opposite: #methods"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'Type declaring the method. It provides the implementation for belongsTo.'>
 	<container>

--- a/src/Famix-Traits/FamixTMethodMetrics.trait.st
+++ b/src/Famix-Traits/FamixTMethodMetrics.trait.st
@@ -8,6 +8,7 @@ Trait {
 { #category : 'meta' }
 FamixTMethodMetrics classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TMethodMetrics super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>

--- a/src/Famix-Traits/FamixTModule.trait.st
+++ b/src/Famix-Traits/FamixTModule.trait.st
@@ -26,6 +26,7 @@ Trait {
 { #category : 'meta' }
 FamixTModule classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TModule super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -41,6 +42,7 @@ FamixTModule >> addModuleEntity: anObject [
 { #category : 'testing' }
 FamixTModule >> isModule [
 
+	<ignoreForCoverage>
 	<generated>
 	^ true
 ]
@@ -49,6 +51,7 @@ FamixTModule >> isModule [
 FamixTModule >> moduleEntities [
 	"Relation named: #moduleEntities type: #FamixTDefinedInModule opposite: #parentModule"
 
+	<ignoreForCoverage>
 	<generated>
 	<derived>
 	^ moduleEntities
@@ -57,6 +60,7 @@ FamixTModule >> moduleEntities [
 { #category : 'accessing' }
 FamixTModule >> moduleEntities: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	moduleEntities value: anObject
 ]

--- a/src/Famix-Traits/FamixTMultipleFileAnchor.trait.st
+++ b/src/Famix-Traits/FamixTMultipleFileAnchor.trait.st
@@ -31,6 +31,7 @@ Trait {
 { #category : 'meta' }
 FamixTMultipleFileAnchor classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TMultipleFileAnchor super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -102,6 +103,7 @@ FamixTMultipleFileAnchor >> fileAnchors [
 
 { #category : 'accessing' }
 FamixTMultipleFileAnchor >> fileAnchors: anObject [
+	<ignoreForCoverage>
 	<generated>
 	fileAnchors := anObject
 ]

--- a/src/Famix-Traits/FamixTNamedEntity.trait.st
+++ b/src/Famix-Traits/FamixTNamedEntity.trait.st
@@ -20,6 +20,7 @@ Trait {
 { #category : 'meta' }
 FamixTNamedEntity classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TNamedEntity super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -61,6 +62,7 @@ FamixTNamedEntity >> mooseNameOn: stream [
 FamixTNamedEntity >> name [
 
 	<FMProperty: #name type: #String>
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'Basic name of the entity, not full reference.'>
 	^ name

--- a/src/Famix-Traits/FamixTNamespace.trait.st
+++ b/src/Famix-Traits/FamixTNamespace.trait.st
@@ -35,6 +35,7 @@ Trait {
 { #category : 'meta' }
 FamixTNamespace classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TNamespace super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -42,6 +43,8 @@ FamixTNamespace classSide >> annotation [
 
 { #category : 'groups' }
 FamixTNamespace classSide >> annotationFamixNamespaceGroup [
+
+	<ignoreForCoverage>
 	<generated>
 	<mooseGroup>
 	^ FamixNamespaceGroup
@@ -50,6 +53,7 @@ FamixTNamespace classSide >> annotationFamixNamespaceGroup [
 { #category : 'testing' }
 FamixTNamespace >> isNamespace [
 
+	<ignoreForCoverage>
 	<generated>
 	^ true
 ]

--- a/src/Famix-Traits/FamixTPackage.trait.st
+++ b/src/Famix-Traits/FamixTPackage.trait.st
@@ -41,6 +41,7 @@ Trait {
 { #category : 'meta' }
 FamixTPackage classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TPackage super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -48,6 +49,8 @@ FamixTPackage classSide >> annotation [
 
 { #category : 'groups' }
 FamixTPackage classSide >> annotationFamixPackageGroup [
+
+	<ignoreForCoverage>
 	<generated>
 	<mooseGroup>
 	^ FamixPackageGroup
@@ -63,6 +66,7 @@ FamixTPackage >> addChildEntity: anObject [
 FamixTPackage >> childEntities [
 	"Relation named: #childEntities type: #FamixTPackageable opposite: #parentPackage"
 
+	<ignoreForCoverage>
 	<generated>
 	<derived>
 	^ childEntities
@@ -71,6 +75,7 @@ FamixTPackage >> childEntities [
 { #category : 'accessing' }
 FamixTPackage >> childEntities: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	childEntities value: anObject
 ]
@@ -78,6 +83,7 @@ FamixTPackage >> childEntities: anObject [
 { #category : 'testing' }
 FamixTPackage >> isPackage [
 
+	<ignoreForCoverage>
 	<generated>
 	^ true
 ]

--- a/src/Famix-Traits/FamixTPackageable.trait.st
+++ b/src/Famix-Traits/FamixTPackageable.trait.st
@@ -23,6 +23,7 @@ Trait {
 { #category : 'meta' }
 FamixTPackageable classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TPackageable super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -38,6 +39,7 @@ FamixTPackageable >> isExtension [
 FamixTPackageable >> parentPackage [
 	"Relation named: #parentPackage type: #FamixTPackage opposite: #childEntities"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'Package containing the entity in the code structure (if applicable)'>
 	<container>
@@ -47,6 +49,7 @@ FamixTPackageable >> parentPackage [
 { #category : 'accessing' }
 FamixTPackageable >> parentPackage: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	parentPackage := anObject
 ]

--- a/src/Famix-Traits/FamixTParameter.trait.st
+++ b/src/Famix-Traits/FamixTParameter.trait.st
@@ -59,6 +59,7 @@ Trait {
 { #category : 'meta' }
 FamixTParameter classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TParameter super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -76,6 +77,7 @@ FamixTParameter >> displayStringOn: aStream [
 FamixTParameter >> parentBehaviouralEntity [
 	"Relation named: #parentBehaviouralEntity type: #FamixTWithParameters opposite: #parameters"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'Behavioural entity containing this parameter. belongsTo implementation'>
 	<container>

--- a/src/Famix-Traits/FamixTParametricAssociation.trait.st
+++ b/src/Famix-Traits/FamixTParametricAssociation.trait.st
@@ -25,6 +25,7 @@ Trait {
 { #category : 'meta' }
 FamixTParametricAssociation classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TParametricAssociation super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -32,6 +33,8 @@ FamixTParametricAssociation classSide >> annotation [
 
 { #category : 'adding' }
 FamixTParametricAssociation >> addConcretization: anObject [
+
+	<ignoreForCoverage>
 	<generated>
 	^ self concretizations add: anObject
 ]
@@ -40,6 +43,7 @@ FamixTParametricAssociation >> addConcretization: anObject [
 FamixTParametricAssociation >> concretizations [
 	"Relation named: #concretizations type: #FamixTConcretization opposite: #triggeringAssociation"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'The parameter concretizations associated with this association.'>
 	<derived>
@@ -49,6 +53,7 @@ FamixTParametricAssociation >> concretizations [
 { #category : 'accessing' }
 FamixTParametricAssociation >> concretizations: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	concretizations value: anObject
 ]
@@ -56,6 +61,7 @@ FamixTParametricAssociation >> concretizations: anObject [
 { #category : 'testing' }
 FamixTParametricAssociation >> isParametricAssociation [
 
+	<ignoreForCoverage>
 	<generated>
 	^ true
 ]

--- a/src/Famix-Traits/FamixTParametricEntity.trait.st
+++ b/src/Famix-Traits/FamixTParametricEntity.trait.st
@@ -32,6 +32,7 @@ Trait {
 { #category : 'meta' }
 FamixTParametricEntity classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TParametricEntity super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -39,6 +40,8 @@ FamixTParametricEntity classSide >> annotation [
 
 { #category : 'adding' }
 FamixTParametricEntity >> addTypeParameter: anObject [
+
+	<ignoreForCoverage>
 	<generated>
 	^ self typeParameters add: anObject
 ]
@@ -83,6 +86,7 @@ FamixTParametricEntity >> isGenericEntity [
 { #category : 'testing' }
 FamixTParametricEntity >> isParametricEntity [
 
+	<ignoreForCoverage>
 	<generated>
 	^ true
 ]
@@ -91,6 +95,7 @@ FamixTParametricEntity >> isParametricEntity [
 FamixTParametricEntity >> typeParameters [
 	"Relation named: #typeParameters type: #FamixTTypeParameter opposite: #genericEntity"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'The type parameters of this parametric entity. They can any type with the exception of primitive types'>
 	<derived>
@@ -100,6 +105,7 @@ FamixTParametricEntity >> typeParameters [
 { #category : 'accessing' }
 FamixTParametricEntity >> typeParameters: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	typeParameters value: anObject
 ]

--- a/src/Famix-Traits/FamixTPrimitiveType.trait.st
+++ b/src/Famix-Traits/FamixTPrimitiveType.trait.st
@@ -40,6 +40,7 @@ Trait {
 { #category : 'meta' }
 FamixTPrimitiveType classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TPrimitiveType super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -48,6 +49,7 @@ FamixTPrimitiveType classSide >> annotation [
 { #category : 'testing' }
 FamixTPrimitiveType >> isPrimitiveType [
 
+	<ignoreForCoverage>
 	<generated>
 	^ true
 ]

--- a/src/Famix-Traits/FamixTReference.trait.st
+++ b/src/Famix-Traits/FamixTReference.trait.st
@@ -51,6 +51,7 @@ Trait {
 { #category : 'meta' }
 FamixTReference classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TReference super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -64,6 +65,7 @@ FamixTReference classSide >> source: source target: target [
 { #category : 'testing' }
 FamixTReference >> isReference [
 
+	<ignoreForCoverage>
 	<generated>
 	^ true
 ]
@@ -72,6 +74,7 @@ FamixTReference >> isReference [
 FamixTReference >> referencer [
 	"Relation named: #referencer type: #FamixTWithReferences opposite: #outgoingReferences"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'Source entity making the reference. from-side of the association'>
 	<source>
@@ -81,6 +84,7 @@ FamixTReference >> referencer [
 { #category : 'accessing' }
 FamixTReference >> referencer: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	referencer := anObject
 ]
@@ -89,6 +93,7 @@ FamixTReference >> referencer: anObject [
 FamixTReference >> referredEntity [
 	"Relation named: #referredEntity type: #FamixTReferenceable opposite: #incomingReferences"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'Target entity referenced. to-side of the association'>
 	<target>
@@ -98,6 +103,7 @@ FamixTReference >> referredEntity [
 { #category : 'accessing' }
 FamixTReference >> referredEntity: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	referredEntity := anObject
 ]

--- a/src/Famix-Traits/FamixTReferenceable.trait.st
+++ b/src/Famix-Traits/FamixTReferenceable.trait.st
@@ -35,6 +35,7 @@ Trait {
 { #category : 'meta' }
 FamixTReferenceable classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TReferenceable super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -49,6 +50,7 @@ FamixTReferenceable >> addIncomingReference: aReference [
 FamixTReferenceable >> incomingReferences [
 	"Relation named: #incomingReferences type: #FamixTReference opposite: #referredEntity"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'References to this entity by other entities.'>
 	<derived>
@@ -58,6 +60,7 @@ FamixTReferenceable >> incomingReferences [
 { #category : 'accessing' }
 FamixTReferenceable >> incomingReferences: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	incomingReferences value: anObject
 ]

--- a/src/Famix-Traits/FamixTRelativeSourceAnchor.trait.st
+++ b/src/Famix-Traits/FamixTRelativeSourceAnchor.trait.st
@@ -51,6 +51,7 @@ Trait {
 { #category : 'meta' }
 FamixTRelativeSourceAnchor classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TRelativeSourceAnchor super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -73,6 +74,7 @@ FamixTRelativeSourceAnchor >> endLine [
 FamixTRelativeSourceAnchor >> endPos [
 
 	<FMProperty: #endPos type: #Number>
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'Stop position in the source'>
 	^ endPos
@@ -80,6 +82,7 @@ FamixTRelativeSourceAnchor >> endPos [
 
 { #category : 'accessing' }
 FamixTRelativeSourceAnchor >> endPos: anObject [
+	<ignoreForCoverage>
 	<generated>
 	endPos := anObject
 ]
@@ -104,6 +107,7 @@ FamixTRelativeSourceAnchor >> initializeStartAndEndLineFrom: sourceText [
 FamixTRelativeSourceAnchor >> relatedAnchor [
 
 	<FMProperty: #relatedAnchor type: #FamixTSourceAnchor>
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'Source anchor to which I am relative.'>
 	^ relatedAnchor
@@ -111,6 +115,7 @@ FamixTRelativeSourceAnchor >> relatedAnchor [
 
 { #category : 'accessing' }
 FamixTRelativeSourceAnchor >> relatedAnchor: anObject [
+	<ignoreForCoverage>
 	<generated>
 	relatedAnchor := anObject
 ]
@@ -137,6 +142,7 @@ FamixTRelativeSourceAnchor >> startLine [
 FamixTRelativeSourceAnchor >> startPos [
 
 	<FMProperty: #startPos type: #Number>
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'Start position in the source'>
 	^ startPos
@@ -144,6 +150,7 @@ FamixTRelativeSourceAnchor >> startPos [
 
 { #category : 'accessing' }
 FamixTRelativeSourceAnchor >> startPos: anObject [
+	<ignoreForCoverage>
 	<generated>
 	startPos := anObject
 ]

--- a/src/Famix-Traits/FamixTShadowable.trait.st
+++ b/src/Famix-Traits/FamixTShadowable.trait.st
@@ -48,6 +48,7 @@ Trait {
 { #category : 'meta' }
 FamixTShadowable classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TShadowable super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -55,6 +56,8 @@ FamixTShadowable classSide >> annotation [
 
 { #category : 'adding' }
 FamixTShadowable >> addShadowingEntity: anObject [
+
+	<ignoreForCoverage>
 	<generated>
 	^ self shadowingEntities add: anObject
 ]
@@ -62,6 +65,7 @@ FamixTShadowable >> addShadowingEntity: anObject [
 { #category : 'testing' }
 FamixTShadowable >> isShadowable [
 
+	<ignoreForCoverage>
 	<generated>
 	^ true
 ]
@@ -76,6 +80,7 @@ FamixTShadowable >> isShadowed [
 FamixTShadowable >> shadowingEntities [
 	"Relation named: #shadowingEntities type: #FamixTShadower opposite: #shadowedEntity"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'Entities shadowing me in my defining scope.'>
 	<derived>
@@ -85,6 +90,7 @@ FamixTShadowable >> shadowingEntities [
 { #category : 'accessing' }
 FamixTShadowable >> shadowingEntities: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	shadowingEntities value: anObject
 ]

--- a/src/Famix-Traits/FamixTShadower.trait.st
+++ b/src/Famix-Traits/FamixTShadower.trait.st
@@ -48,6 +48,7 @@ Trait {
 { #category : 'meta' }
 FamixTShadower classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TShadower super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -57,6 +58,7 @@ FamixTShadower classSide >> annotation [
 FamixTShadower >> shadowedEntity [
 	"Relation named: #shadowedEntity type: #FamixTShadowable opposite: #shadowingEntities"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'Entity that is been shadowed by myself in my defining scope.'>
 	^ shadowedEntity
@@ -65,6 +67,7 @@ FamixTShadower >> shadowedEntity [
 { #category : 'accessing' }
 FamixTShadower >> shadowedEntity: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	shadowedEntity := anObject
 ]

--- a/src/Famix-Traits/FamixTSourceAnchor.trait.st
+++ b/src/Famix-Traits/FamixTSourceAnchor.trait.st
@@ -25,6 +25,7 @@ Trait {
 { #category : 'meta' }
 FamixTSourceAnchor classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TSourceAnchor super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -58,6 +59,7 @@ FamixTSourceAnchor >> containerFiles [
 FamixTSourceAnchor >> element [
 	"Relation named: #element type: #FamixTSourceEntity opposite: #sourceAnchor"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'Enable the accessibility to the famix entity that this class is a source pointer for'>
 	^ element
@@ -66,6 +68,7 @@ FamixTSourceAnchor >> element [
 { #category : 'accessing' }
 FamixTSourceAnchor >> element: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	element := anObject
 ]

--- a/src/Famix-Traits/FamixTSourceEntity.trait.st
+++ b/src/Famix-Traits/FamixTSourceEntity.trait.st
@@ -25,6 +25,7 @@ Trait {
 { #category : 'meta' }
 FamixTSourceEntity classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TSourceEntity super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -126,6 +127,7 @@ FamixTSourceEntity >> shouldCountChildrenForLinesOfCodeIfNoSourceAnchor [
 FamixTSourceEntity >> sourceAnchor [
 	"Relation named: #sourceAnchor type: #FamixTSourceAnchor opposite: #element"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'SourceAnchor entity linking to the original source code for this entity'>
 	<derived>
@@ -135,6 +137,7 @@ FamixTSourceEntity >> sourceAnchor [
 { #category : 'accessing' }
 FamixTSourceEntity >> sourceAnchor: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	sourceAnchor := anObject
 ]

--- a/src/Famix-Traits/FamixTSourceLanguage.trait.st
+++ b/src/Famix-Traits/FamixTSourceLanguage.trait.st
@@ -28,6 +28,7 @@ Trait {
 { #category : 'meta' }
 FamixTSourceLanguage classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TSourceLanguage super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -67,6 +68,7 @@ FamixTSourceLanguage >> mooseNameOn: aStream [
 FamixTSourceLanguage >> sourcedEntities [
 	"Relation named: #sourcedEntities type: #FamixTWithSourceLanguages opposite: #declaredSourceLanguage"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'References to the entities saying explicitly that are written in this language.'>
 	<derived>
@@ -76,6 +78,7 @@ FamixTSourceLanguage >> sourcedEntities [
 { #category : 'accessing' }
 FamixTSourceLanguage >> sourcedEntities: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	sourcedEntities value: anObject
 ]

--- a/src/Famix-Traits/FamixTStructuralEntity.trait.st
+++ b/src/Famix-Traits/FamixTStructuralEntity.trait.st
@@ -41,6 +41,7 @@ Trait {
 { #category : 'meta' }
 FamixTStructuralEntity classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TStructuralEntity super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -49,6 +50,7 @@ FamixTStructuralEntity classSide >> annotation [
 { #category : 'testing' }
 FamixTStructuralEntity >> isStructuralEntity [
 
+	<ignoreForCoverage>
 	<generated>
 	^ true
 ]

--- a/src/Famix-Traits/FamixTTemplate.trait.st
+++ b/src/Famix-Traits/FamixTTemplate.trait.st
@@ -29,6 +29,7 @@ Trait {
 { #category : 'meta' }
 FamixTTemplate classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TTemplate super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -45,6 +46,7 @@ FamixTTemplate >> addTemplateUser: anObject [
 FamixTTemplate >> templateOwner [
 	"Relation named: #templateOwner type: #FamixTWithTemplates opposite: #templates"
 
+	<ignoreForCoverage>
 	<generated>
 	<container>
 	^ templateOwner
@@ -53,6 +55,7 @@ FamixTTemplate >> templateOwner [
 { #category : 'accessing' }
 FamixTTemplate >> templateOwner: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	templateOwner := anObject
 ]
@@ -61,6 +64,7 @@ FamixTTemplate >> templateOwner: anObject [
 FamixTTemplate >> templateUsers [
 	"Relation named: #templateUsers type: #FamixTTemplateUser opposite: #template"
 
+	<ignoreForCoverage>
 	<generated>
 	<derived>
 	^ templateUsers
@@ -69,6 +73,7 @@ FamixTTemplate >> templateUsers [
 { #category : 'accessing' }
 FamixTTemplate >> templateUsers: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	templateUsers value: anObject
 ]

--- a/src/Famix-Traits/FamixTTemplateUser.trait.st
+++ b/src/Famix-Traits/FamixTTemplateUser.trait.st
@@ -23,6 +23,7 @@ Trait {
 { #category : 'meta' }
 FamixTTemplateUser classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TTemplateUser super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -32,6 +33,7 @@ FamixTTemplateUser classSide >> annotation [
 FamixTTemplateUser >> template [
 	"Relation named: #template type: #FamixTTemplate opposite: #templateUsers"
 
+	<ignoreForCoverage>
 	<generated>
 	^ template
 ]
@@ -39,6 +41,7 @@ FamixTTemplateUser >> template [
 { #category : 'accessing' }
 FamixTTemplateUser >> template: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	template := anObject
 ]

--- a/src/Famix-Traits/FamixTThrowable.trait.st
+++ b/src/Famix-Traits/FamixTThrowable.trait.st
@@ -29,6 +29,7 @@ Trait {
 { #category : 'meta' }
 FamixTThrowable classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TThrowable super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -36,18 +37,24 @@ FamixTThrowable classSide >> annotation [
 
 { #category : 'adding' }
 FamixTThrowable >> addCatchingEntity: anObject [
+
+	<ignoreForCoverage>
 	<generated>
 	^ self catchingEntities add: anObject
 ]
 
 { #category : 'adding' }
 FamixTThrowable >> addDeclaringEntity: anObject [
+
+	<ignoreForCoverage>
 	<generated>
 	^ self declaringEntities add: anObject
 ]
 
 { #category : 'adding' }
 FamixTThrowable >> addThrowingEntity: anObject [
+
+	<ignoreForCoverage>
 	<generated>
 	^ self throwingEntities add: anObject
 ]
@@ -56,6 +63,7 @@ FamixTThrowable >> addThrowingEntity: anObject [
 FamixTThrowable >> catchingEntities [
 	"Relation named: #catchingEntities type: #FamixTWithExceptions opposite: #caughtExceptions"
 
+	<ignoreForCoverage>
 	<generated>
 	<derived>
 	^ catchingEntities
@@ -64,6 +72,7 @@ FamixTThrowable >> catchingEntities [
 { #category : 'accessing' }
 FamixTThrowable >> catchingEntities: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	catchingEntities value: anObject
 ]
@@ -72,6 +81,7 @@ FamixTThrowable >> catchingEntities: anObject [
 FamixTThrowable >> declaringEntities [
 	"Relation named: #declaringEntities type: #FamixTWithExceptions opposite: #declaredExceptions"
 
+	<ignoreForCoverage>
 	<generated>
 	<derived>
 	^ declaringEntities
@@ -80,6 +90,7 @@ FamixTThrowable >> declaringEntities [
 { #category : 'accessing' }
 FamixTThrowable >> declaringEntities: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	declaringEntities value: anObject
 ]
@@ -88,6 +99,7 @@ FamixTThrowable >> declaringEntities: anObject [
 FamixTThrowable >> throwingEntities [
 	"Relation named: #throwingEntities type: #FamixTWithExceptions opposite: #thrownExceptions"
 
+	<ignoreForCoverage>
 	<generated>
 	<derived>
 	^ throwingEntities
@@ -96,6 +108,7 @@ FamixTThrowable >> throwingEntities [
 { #category : 'accessing' }
 FamixTThrowable >> throwingEntities: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	throwingEntities value: anObject
 ]

--- a/src/Famix-Traits/FamixTTrait.trait.st
+++ b/src/Famix-Traits/FamixTTrait.trait.st
@@ -31,6 +31,7 @@ Trait {
 { #category : 'meta' }
 FamixTTrait classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TTrait super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -47,6 +48,7 @@ FamixTTrait >> addIncomingTraitUsage: anObject [
 FamixTTrait >> incomingTraitUsages [
 	"Relation named: #incomingTraitUsages type: #FamixTTraitUsage opposite: #trait"
 
+	<ignoreForCoverage>
 	<generated>
 	<derived>
 	^ incomingTraitUsages
@@ -55,6 +57,7 @@ FamixTTrait >> incomingTraitUsages [
 { #category : 'accessing' }
 FamixTTrait >> incomingTraitUsages: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	incomingTraitUsages value: anObject
 ]
@@ -63,6 +66,7 @@ FamixTTrait >> incomingTraitUsages: anObject [
 FamixTTrait >> traitOwner [
 	"Relation named: #traitOwner type: #FamixTWithTraits opposite: #traits"
 
+	<ignoreForCoverage>
 	<generated>
 	<container>
 	^ traitOwner
@@ -71,6 +75,7 @@ FamixTTrait >> traitOwner [
 { #category : 'accessing' }
 FamixTTrait >> traitOwner: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	traitOwner := anObject
 ]

--- a/src/Famix-Traits/FamixTTraitUsage.trait.st
+++ b/src/Famix-Traits/FamixTTraitUsage.trait.st
@@ -38,6 +38,7 @@ Trait {
 { #category : 'meta' }
 FamixTTraitUsage classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TTraitUsage super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -47,6 +48,7 @@ FamixTTraitUsage classSide >> annotation [
 FamixTTraitUsage >> trait [
 	"Relation named: #trait type: #FamixTTrait opposite: #incomingTraitUsages"
 
+	<ignoreForCoverage>
 	<generated>
 	<source>
 	^ trait
@@ -55,6 +57,7 @@ FamixTTraitUsage >> trait [
 { #category : 'accessing' }
 FamixTTraitUsage >> trait: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	trait := anObject
 ]
@@ -63,6 +66,7 @@ FamixTTraitUsage >> trait: anObject [
 FamixTTraitUsage >> user [
 	"Relation named: #user type: #FamixTTraitUser opposite: #traitUsages"
 
+	<ignoreForCoverage>
 	<generated>
 	<target>
 	^ user
@@ -71,6 +75,7 @@ FamixTTraitUsage >> user [
 { #category : 'accessing' }
 FamixTTraitUsage >> user: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	user := anObject
 ]

--- a/src/Famix-Traits/FamixTTraitUser.trait.st
+++ b/src/Famix-Traits/FamixTTraitUser.trait.st
@@ -23,6 +23,7 @@ Trait {
 { #category : 'meta' }
 FamixTTraitUser classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TTraitUser super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -30,6 +31,8 @@ FamixTTraitUser classSide >> annotation [
 
 { #category : 'adding' }
 FamixTTraitUser >> addTraitUsage: anObject [
+
+	<ignoreForCoverage>
 	<generated>
 	^ self traitUsages add: anObject
 ]
@@ -38,6 +41,7 @@ FamixTTraitUser >> addTraitUsage: anObject [
 FamixTTraitUser >> traitUsages [
 	"Relation named: #traitUsages type: #FamixTTraitUsage opposite: #user"
 
+	<ignoreForCoverage>
 	<generated>
 	<derived>
 	^ traitUsages
@@ -46,6 +50,7 @@ FamixTTraitUser >> traitUsages [
 { #category : 'accessing' }
 FamixTTraitUser >> traitUsages: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	traitUsages value: anObject
 ]

--- a/src/Famix-Traits/FamixTType.trait.st
+++ b/src/Famix-Traits/FamixTType.trait.st
@@ -50,6 +50,7 @@ Trait {
 { #category : 'meta' }
 FamixTType classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TType super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -57,6 +58,8 @@ FamixTType classSide >> annotation [
 
 { #category : 'groups' }
 FamixTType classSide >> annotationFamixTypeGroup [
+
+	<ignoreForCoverage>
 	<generated>
 	<mooseGroup>
 	^ FamixTypeGroup
@@ -64,6 +67,8 @@ FamixTType classSide >> annotationFamixTypeGroup [
 
 { #category : 'adding' }
 FamixTType >> addIncomingTyping: anObject [
+
+	<ignoreForCoverage>
 	<generated>
 	^ self incomingTypings add: anObject
 ]
@@ -87,6 +92,7 @@ FamixTType >> entityHasIncomingTypeDeclarations [
 FamixTType >> incomingTypings [
 	"Relation named: #incomingTypings type: #FamixTEntityTyping opposite: #declaredType"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'Relations to the entities that have this as type.'>
 	<derived>
@@ -96,6 +102,7 @@ FamixTType >> incomingTypings [
 { #category : 'accessing' }
 FamixTType >> incomingTypings: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	incomingTypings value: anObject
 ]
@@ -103,6 +110,7 @@ FamixTType >> incomingTypings: anObject [
 { #category : 'testing' }
 FamixTType >> isType [
 
+	<ignoreForCoverage>
 	<generated>
 	^ true
 ]
@@ -141,6 +149,7 @@ FamixTType >> realType [
 FamixTType >> typeContainer [
 	"Relation named: #typeContainer type: #FamixTWithTypes opposite: #types"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'Container entity to which this type belongs. Container is a namespace, not a package (Smalltalk).'>
 	<container>

--- a/src/Famix-Traits/FamixTTypeAlias.trait.st
+++ b/src/Famix-Traits/FamixTTypeAlias.trait.st
@@ -28,6 +28,7 @@ Trait {
 { #category : 'meta' }
 FamixTTypeAlias classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TTypeAlias super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -37,6 +38,7 @@ FamixTTypeAlias classSide >> annotation [
 FamixTTypeAlias >> aliasedType [
 	"Relation named: #aliasedType type: #FamixTWithTypeAliases opposite: #typeAliases"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'Points to the actual type.'>
 	^ aliasedType
@@ -45,6 +47,7 @@ FamixTTypeAlias >> aliasedType [
 { #category : 'accessing' }
 FamixTTypeAlias >> aliasedType: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	aliasedType := anObject
 ]

--- a/src/Famix-Traits/FamixTTypeArgument.trait.st
+++ b/src/Famix-Traits/FamixTTypeArgument.trait.st
@@ -25,6 +25,7 @@ Trait {
 { #category : 'meta' }
 FamixTTypeArgument classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TTypeArgument super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -32,6 +33,8 @@ FamixTTypeArgument classSide >> annotation [
 
 { #category : 'adding' }
 FamixTTypeArgument >> addOutgoingConcretization: anObject [
+
+	<ignoreForCoverage>
 	<generated>
 	^ self outgoingConcretizations add: anObject
 ]
@@ -40,6 +43,7 @@ FamixTTypeArgument >> addOutgoingConcretization: anObject [
 FamixTTypeArgument >> outgoingConcretizations [
 	"Relation named: #outgoingConcretizations type: #FamixTConcretization opposite: #typeArgument"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'Concretizations where this type is the type argument.'>
 	<derived>
@@ -49,6 +53,7 @@ FamixTTypeArgument >> outgoingConcretizations [
 { #category : 'accessing' }
 FamixTTypeArgument >> outgoingConcretizations: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	outgoingConcretizations value: anObject
 ]

--- a/src/Famix-Traits/FamixTTypeParameter.trait.st
+++ b/src/Famix-Traits/FamixTTypeParameter.trait.st
@@ -31,6 +31,7 @@ Trait {
 { #category : 'meta' }
 FamixTTypeParameter classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TTypeParameter super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -38,6 +39,8 @@ FamixTTypeParameter classSide >> annotation [
 
 { #category : 'adding' }
 FamixTTypeParameter >> addConcretization: anObject [
+
+	<ignoreForCoverage>
 	<generated>
 	^ self concretizations add: anObject
 ]
@@ -46,6 +49,7 @@ FamixTTypeParameter >> addConcretization: anObject [
 FamixTTypeParameter >> concretizations [
 	"Relation named: #concretizations type: #FamixTConcretization opposite: #typeParameter"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'Known concretizations of this type parameter.'>
 	<derived>
@@ -55,6 +59,7 @@ FamixTTypeParameter >> concretizations [
 { #category : 'accessing' }
 FamixTTypeParameter >> concretizations: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	concretizations value: anObject
 ]
@@ -63,6 +68,7 @@ FamixTTypeParameter >> concretizations: anObject [
 FamixTTypeParameter >> genericEntity [
 	"Relation named: #genericEntity type: #FamixTParametricEntity opposite: #typeParameters"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'Generic entity that declares this type parameter.'>
 	^ genericEntity
@@ -71,6 +77,7 @@ FamixTTypeParameter >> genericEntity [
 { #category : 'accessing' }
 FamixTTypeParameter >> genericEntity: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	genericEntity := anObject
 ]

--- a/src/Famix-Traits/FamixTTypedEntity.trait.st
+++ b/src/Famix-Traits/FamixTTypedEntity.trait.st
@@ -23,6 +23,7 @@ Trait {
 { #category : 'meta' }
 FamixTTypedEntity classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TTypedEntity super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -55,6 +56,7 @@ FamixTTypedEntity >> hasDeclaredType [
 FamixTTypedEntity >> typing [
 	"Relation named: #typing type: #FamixTEntityTyping opposite: #typedEntity"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'Association linking this entity to its declared type.'>
 	^ typing
@@ -63,6 +65,7 @@ FamixTTypedEntity >> typing [
 { #category : 'accessing' }
 FamixTTypedEntity >> typing: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	typing := anObject
 ]

--- a/src/Famix-Traits/FamixTUnknownVariable.trait.st
+++ b/src/Famix-Traits/FamixTUnknownVariable.trait.st
@@ -39,6 +39,7 @@ Trait {
 { #category : 'meta' }
 FamixTUnknownVariable classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TUnknownVariable super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>

--- a/src/Famix-Traits/FamixTWithAccesses.trait.st
+++ b/src/Famix-Traits/FamixTWithAccesses.trait.st
@@ -23,6 +23,7 @@ Trait {
 { #category : 'meta' }
 FamixTWithAccesses classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TWithAccesses super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -32,6 +33,7 @@ FamixTWithAccesses classSide >> annotation [
 FamixTWithAccesses >> accesses [
 	"Relation named: #accesses type: #FamixTAccess opposite: #accessor"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'Accesses to variables made by this behaviour.'>
 	<derived>
@@ -41,6 +43,7 @@ FamixTWithAccesses >> accesses [
 { #category : 'accessing' }
 FamixTWithAccesses >> accesses: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	accesses value: anObject
 ]

--- a/src/Famix-Traits/FamixTWithAnnotationInstances.trait.st
+++ b/src/Famix-Traits/FamixTWithAnnotationInstances.trait.st
@@ -23,6 +23,7 @@ Trait {
 { #category : 'meta' }
 FamixTWithAnnotationInstances classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TWithAnnotationInstances super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -60,6 +61,7 @@ FamixTWithAnnotationInstances >> annotationInstanceNamed: anAnnotationName ifAbs
 FamixTWithAnnotationInstances >> annotationInstances [
 	"Relation named: #annotationInstances type: #FamixTAnnotationInstance opposite: #annotatedEntity"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'This property corresponds to the set of annotations associated to the entity'>
 	<derived>
@@ -69,6 +71,7 @@ FamixTWithAnnotationInstances >> annotationInstances [
 { #category : 'accessing' }
 FamixTWithAnnotationInstances >> annotationInstances: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	annotationInstances value: anObject
 ]

--- a/src/Famix-Traits/FamixTWithAnnotationTypes.trait.st
+++ b/src/Famix-Traits/FamixTWithAnnotationTypes.trait.st
@@ -23,6 +23,7 @@ Trait {
 { #category : 'meta' }
 FamixTWithAnnotationTypes classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TWithAnnotationTypes super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -38,6 +39,7 @@ FamixTWithAnnotationTypes >> addDefinedAnnotationType: aDefinedAnnotationType [
 FamixTWithAnnotationTypes >> definedAnnotationTypes [
 	"Relation named: #definedAnnotationTypes type: #FamixTAnnotationType opposite: #annotationTypesContainer"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'The container in which the AnnotationTypes may be declared'>
 	<derived>
@@ -47,6 +49,7 @@ FamixTWithAnnotationTypes >> definedAnnotationTypes [
 { #category : 'accessing' }
 FamixTWithAnnotationTypes >> definedAnnotationTypes: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	definedAnnotationTypes value: anObject
 ]

--- a/src/Famix-Traits/FamixTWithAttributes.trait.st
+++ b/src/Famix-Traits/FamixTWithAttributes.trait.st
@@ -23,6 +23,7 @@ Trait {
 { #category : 'meta' }
 FamixTWithAttributes classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TWithAttributes super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -37,6 +38,7 @@ FamixTWithAttributes >> addAttribute: anAttribute [
 FamixTWithAttributes >> attributes [
 	"Relation named: #attributes type: #FamixTAttribute opposite: #parentType"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'List of attributes declared by this type.'>
 	<derived>
@@ -46,6 +48,7 @@ FamixTWithAttributes >> attributes [
 { #category : 'accessing' }
 FamixTWithAttributes >> attributes: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	attributes value: anObject
 ]

--- a/src/Famix-Traits/FamixTWithClasses.trait.st
+++ b/src/Famix-Traits/FamixTWithClasses.trait.st
@@ -22,6 +22,7 @@ Trait {
 { #category : 'meta' }
 FamixTWithClasses classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TWithClasses super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>

--- a/src/Famix-Traits/FamixTWithComments.trait.st
+++ b/src/Famix-Traits/FamixTWithComments.trait.st
@@ -23,6 +23,7 @@ Trait {
 { #category : 'meta' }
 FamixTWithComments classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TWithComments super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -39,6 +40,7 @@ FamixTWithComments >> addComment: aComment [
 FamixTWithComments >> comments [
 	"Relation named: #comments type: #FamixTComment opposite: #commentedEntity"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'List of comments for the entity'>
 	<derived>
@@ -48,6 +50,7 @@ FamixTWithComments >> comments [
 { #category : 'accessing' }
 FamixTWithComments >> comments: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	comments value: anObject
 ]

--- a/src/Famix-Traits/FamixTWithCompilationUnits.trait.st
+++ b/src/Famix-Traits/FamixTWithCompilationUnits.trait.st
@@ -23,6 +23,7 @@ Trait {
 { #category : 'meta' }
 FamixTWithCompilationUnits classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TWithCompilationUnits super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -32,6 +33,7 @@ FamixTWithCompilationUnits classSide >> annotation [
 FamixTWithCompilationUnits >> compilationUnit [
 	"Relation named: #compilationUnit type: #FamixTCompilationUnit opposite: #compilationUnitOwner"
 
+	<ignoreForCoverage>
 	<generated>
 	<derived>
 	^ compilationUnit
@@ -40,6 +42,7 @@ FamixTWithCompilationUnits >> compilationUnit [
 { #category : 'accessing' }
 FamixTWithCompilationUnits >> compilationUnit: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	compilationUnit := anObject
 ]

--- a/src/Famix-Traits/FamixTWithDereferencedInvocations.trait.st
+++ b/src/Famix-Traits/FamixTWithDereferencedInvocations.trait.st
@@ -23,6 +23,7 @@ Trait {
 { #category : 'meta' }
 FamixTWithDereferencedInvocations classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TWithDereferencedInvocations super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -37,6 +38,7 @@ FamixTWithDereferencedInvocations >> addDereferencedInvocation: aDeferencedInvoc
 FamixTWithDereferencedInvocations >> dereferencedInvocations [
 	"Relation named: #dereferencedInvocations type: #FamixTDereferencedInvocation opposite: #referencer"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'List of invocations performed on BehaviouralEntities referenced by this entity'>
 	<derived>
@@ -46,6 +48,7 @@ FamixTWithDereferencedInvocations >> dereferencedInvocations [
 { #category : 'accessing' }
 FamixTWithDereferencedInvocations >> dereferencedInvocations: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	dereferencedInvocations value: anObject
 ]

--- a/src/Famix-Traits/FamixTWithEnumValues.trait.st
+++ b/src/Famix-Traits/FamixTWithEnumValues.trait.st
@@ -23,6 +23,7 @@ Trait {
 { #category : 'meta' }
 FamixTWithEnumValues classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TWithEnumValues super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -38,6 +39,7 @@ FamixTWithEnumValues >> addEnumValue: anObject [
 FamixTWithEnumValues >> enumValues [
 	"Relation named: #enumValues type: #FamixTEnumValue opposite: #parentEnum"
 
+	<ignoreForCoverage>
 	<generated>
 	<derived>
 	^ enumValues
@@ -46,6 +48,7 @@ FamixTWithEnumValues >> enumValues [
 { #category : 'accessing' }
 FamixTWithEnumValues >> enumValues: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	enumValues value: anObject
 ]

--- a/src/Famix-Traits/FamixTWithExceptions.trait.st
+++ b/src/Famix-Traits/FamixTWithExceptions.trait.st
@@ -27,6 +27,7 @@ Trait {
 { #category : 'meta' }
 FamixTWithExceptions classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TWithExceptions super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -34,18 +35,24 @@ FamixTWithExceptions classSide >> annotation [
 
 { #category : 'adding' }
 FamixTWithExceptions >> addCaughtException: anObject [
+
+	<ignoreForCoverage>
 	<generated>
 	^ self caughtExceptions add: anObject
 ]
 
 { #category : 'adding' }
 FamixTWithExceptions >> addDeclaredException: anObject [
+
+	<ignoreForCoverage>
 	<generated>
 	^ self declaredExceptions add: anObject
 ]
 
 { #category : 'adding' }
 FamixTWithExceptions >> addThrownException: anObject [
+
+	<ignoreForCoverage>
 	<generated>
 	^ self thrownExceptions add: anObject
 ]
@@ -63,6 +70,7 @@ FamixTWithExceptions >> allExceptions [
 FamixTWithExceptions >> caughtExceptions [
 	"Relation named: #caughtExceptions type: #FamixTThrowable opposite: #catchingEntities"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'The exceptions caught by the method'>
 	^ caughtExceptions
@@ -71,6 +79,7 @@ FamixTWithExceptions >> caughtExceptions [
 { #category : 'accessing' }
 FamixTWithExceptions >> caughtExceptions: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	caughtExceptions value: anObject
 ]
@@ -79,6 +88,7 @@ FamixTWithExceptions >> caughtExceptions: anObject [
 FamixTWithExceptions >> declaredExceptions [
 	"Relation named: #declaredExceptions type: #FamixTThrowable opposite: #declaringEntities"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'The exceptions declared by the method'>
 	^ declaredExceptions
@@ -87,6 +97,7 @@ FamixTWithExceptions >> declaredExceptions [
 { #category : 'accessing' }
 FamixTWithExceptions >> declaredExceptions: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	declaredExceptions value: anObject
 ]
@@ -95,6 +106,7 @@ FamixTWithExceptions >> declaredExceptions: anObject [
 FamixTWithExceptions >> thrownExceptions [
 	"Relation named: #thrownExceptions type: #FamixTThrowable opposite: #throwingEntities"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'The exceptions thrown by the method'>
 	^ thrownExceptions
@@ -103,6 +115,7 @@ FamixTWithExceptions >> thrownExceptions [
 { #category : 'accessing' }
 FamixTWithExceptions >> thrownExceptions: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	thrownExceptions value: anObject
 ]

--- a/src/Famix-Traits/FamixTWithFileIncludes.trait.st
+++ b/src/Famix-Traits/FamixTWithFileIncludes.trait.st
@@ -25,6 +25,7 @@ Trait {
 { #category : 'meta' }
 FamixTWithFileIncludes classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TWithFileIncludes super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -46,6 +47,7 @@ FamixTWithFileIncludes >> addOutgoingIncludeRelation: anObject [
 FamixTWithFileIncludes >> incomingIncludeRelations [
 	"Relation named: #incomingIncludeRelations type: #FamixTFileInclude opposite: #target"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'The include entities that have this file as a target.'>
 	<derived>
@@ -55,6 +57,7 @@ FamixTWithFileIncludes >> incomingIncludeRelations [
 { #category : 'accessing' }
 FamixTWithFileIncludes >> incomingIncludeRelations: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	incomingIncludeRelations value: anObject
 ]
@@ -63,6 +66,7 @@ FamixTWithFileIncludes >> incomingIncludeRelations: anObject [
 FamixTWithFileIncludes >> outgoingIncludeRelations [
 	"Relation named: #outgoingIncludeRelations type: #FamixTFileInclude opposite: #source"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'The include entities that have this file as a source.'>
 	<derived>
@@ -72,6 +76,7 @@ FamixTWithFileIncludes >> outgoingIncludeRelations [
 { #category : 'accessing' }
 FamixTWithFileIncludes >> outgoingIncludeRelations: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	outgoingIncludeRelations value: anObject
 ]

--- a/src/Famix-Traits/FamixTWithFiles.trait.st
+++ b/src/Famix-Traits/FamixTWithFiles.trait.st
@@ -23,6 +23,7 @@ Trait {
 { #category : 'meta' }
 FamixTWithFiles classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TWithFiles super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -38,6 +39,7 @@ FamixTWithFiles >> addContainerFile: anObject [
 FamixTWithFiles >> containerFiles [
 	"Relation named: #containerFiles type: #FamixTFile opposite: #entities"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'List of files containing the entity'>
 	^ containerFiles
@@ -46,6 +48,7 @@ FamixTWithFiles >> containerFiles [
 { #category : 'accessing' }
 FamixTWithFiles >> containerFiles: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	containerFiles value: anObject
 ]

--- a/src/Famix-Traits/FamixTWithFunctions.trait.st
+++ b/src/Famix-Traits/FamixTWithFunctions.trait.st
@@ -23,6 +23,7 @@ Trait {
 { #category : 'meta' }
 FamixTWithFunctions classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TWithFunctions super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -38,6 +39,7 @@ FamixTWithFunctions >> addFunction: anObject [
 FamixTWithFunctions >> functions [
 	"Relation named: #functions type: #FamixTFunction opposite: #functionOwner"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'Functions defined in the container, if any.'>
 	<derived>
@@ -47,6 +49,7 @@ FamixTWithFunctions >> functions [
 { #category : 'accessing' }
 FamixTWithFunctions >> functions: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	functions value: anObject
 ]

--- a/src/Famix-Traits/FamixTWithGlobalVariables.trait.st
+++ b/src/Famix-Traits/FamixTWithGlobalVariables.trait.st
@@ -25,6 +25,7 @@ Trait {
 { #category : 'meta' }
 FamixTWithGlobalVariables classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TWithGlobalVariables super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -32,6 +33,8 @@ FamixTWithGlobalVariables classSide >> annotation [
 
 { #category : 'adding' }
 FamixTWithGlobalVariables >> addGlobalVariable: anObject [
+
+	<ignoreForCoverage>
 	<generated>
 	^ self globalVariables add: anObject
 ]
@@ -40,6 +43,7 @@ FamixTWithGlobalVariables >> addGlobalVariable: anObject [
 FamixTWithGlobalVariables >> globalVariables [
 	"Relation named: #globalVariables type: #FamixTGlobalVariable opposite: #parentScope"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'Global variables defined in the scope, if any.'>
 	<derived>
@@ -49,6 +53,7 @@ FamixTWithGlobalVariables >> globalVariables [
 { #category : 'accessing' }
 FamixTWithGlobalVariables >> globalVariables: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	globalVariables value: anObject
 ]

--- a/src/Famix-Traits/FamixTWithImplicitVariables.trait.st
+++ b/src/Famix-Traits/FamixTWithImplicitVariables.trait.st
@@ -23,6 +23,7 @@ Trait {
 { #category : 'meta' }
 FamixTWithImplicitVariables classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TWithImplicitVariables super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -37,6 +38,7 @@ FamixTWithImplicitVariables >> addImplicitVariable: anImplicitVariable [
 FamixTWithImplicitVariables >> implicitVariables [
 	"Relation named: #implicitVariables type: #FamixTImplicitVariable opposite: #parentBehaviouralEntity"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'Implicit variables used locally by this behaviour.'>
 	<derived>
@@ -46,6 +48,7 @@ FamixTWithImplicitVariables >> implicitVariables [
 { #category : 'accessing' }
 FamixTWithImplicitVariables >> implicitVariables: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	implicitVariables value: anObject
 ]

--- a/src/Famix-Traits/FamixTWithImports.trait.st
+++ b/src/Famix-Traits/FamixTWithImports.trait.st
@@ -23,6 +23,7 @@ Trait {
 { #category : 'meta' }
 FamixTWithImports classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TWithImports super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -30,6 +31,8 @@ FamixTWithImports classSide >> annotation [
 
 { #category : 'adding' }
 FamixTWithImports >> addImport: anObject [
+
+	<ignoreForCoverage>
 	<generated>
 	^ self imports add: anObject
 ]
@@ -38,6 +41,7 @@ FamixTWithImports >> addImport: anObject [
 FamixTWithImports >> imports [
 	"Relation named: #imports type: #FamixTImport opposite: #importingEntity"
 
+	<ignoreForCoverage>
 	<generated>
 	<derived>
 	^ imports
@@ -46,6 +50,7 @@ FamixTWithImports >> imports [
 { #category : 'accessing' }
 FamixTWithImports >> imports: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	imports value: anObject
 ]

--- a/src/Famix-Traits/FamixTWithInheritances.trait.st
+++ b/src/Famix-Traits/FamixTWithInheritances.trait.st
@@ -29,6 +29,7 @@ Trait {
 { #category : 'meta' }
 FamixTWithInheritances classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TWithInheritances super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -142,6 +143,7 @@ FamixTWithInheritances >> numberOfSubclasses: aNumber [
 FamixTWithInheritances >> subInheritances [
 	"Relation named: #subInheritances type: #FamixTInheritance opposite: #superclass"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'Subinheritance relationships, i.e. known subclasses of this type.'>
 	<derived>
@@ -151,6 +153,7 @@ FamixTWithInheritances >> subInheritances [
 { #category : 'accessing' }
 FamixTWithInheritances >> subInheritances: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	subInheritances value: anObject
 ]
@@ -191,6 +194,7 @@ FamixTWithInheritances >> subclassHierarchyGroup [
 FamixTWithInheritances >> superInheritances [
 	"Relation named: #superInheritances type: #FamixTInheritance opposite: #subclass"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'Superinheritance relationships, i.e. known superclasses of this type.'>
 	<derived>
@@ -200,6 +204,7 @@ FamixTWithInheritances >> superInheritances [
 { #category : 'accessing' }
 FamixTWithInheritances >> superInheritances: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	superInheritances value: anObject
 ]

--- a/src/Famix-Traits/FamixTWithInvocations.trait.st
+++ b/src/Famix-Traits/FamixTWithInvocations.trait.st
@@ -23,6 +23,7 @@ Trait {
 { #category : 'meta' }
 FamixTWithInvocations classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TWithInvocations super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -46,6 +47,7 @@ FamixTWithInvocations >> numberOfOutgoingInvocations [
 FamixTWithInvocations >> outgoingInvocations [
 	"Relation named: #outgoingInvocations type: #FamixTInvocation opposite: #sender"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'Outgoing invocations sent by this behaviour.'>
 	<derived>
@@ -55,6 +57,7 @@ FamixTWithInvocations >> outgoingInvocations [
 { #category : 'accessing' }
 FamixTWithInvocations >> outgoingInvocations: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	outgoingInvocations value: anObject
 ]

--- a/src/Famix-Traits/FamixTWithLambdas.trait.st
+++ b/src/Famix-Traits/FamixTWithLambdas.trait.st
@@ -25,6 +25,7 @@ Trait {
 { #category : 'meta' }
 FamixTWithLambdas classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TWithLambdas super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -32,6 +33,8 @@ FamixTWithLambdas classSide >> annotation [
 
 { #category : 'adding' }
 FamixTWithLambdas >> addLambda: anObject [
+
+	<ignoreForCoverage>
 	<generated>
 	^ self lambdas add: anObject
 ]
@@ -40,6 +43,7 @@ FamixTWithLambdas >> addLambda: anObject [
 FamixTWithLambdas >> lambdas [
 	"Relation named: #lambdas type: #FamixTLambda opposite: #lambdaContainer"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'Lambdas defined in the container, if any.'>
 	<derived>
@@ -49,6 +53,7 @@ FamixTWithLambdas >> lambdas [
 { #category : 'accessing' }
 FamixTWithLambdas >> lambdas: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	lambdas value: anObject
 ]

--- a/src/Famix-Traits/FamixTWithLocalVariables.trait.st
+++ b/src/Famix-Traits/FamixTWithLocalVariables.trait.st
@@ -23,6 +23,7 @@ Trait {
 { #category : 'meta' }
 FamixTWithLocalVariables classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TWithLocalVariables super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -37,6 +38,7 @@ FamixTWithLocalVariables >> addLocalVariable: aLocalVariable [
 FamixTWithLocalVariables >> localVariables [
 	"Relation named: #localVariables type: #FamixTLocalVariable opposite: #parentBehaviouralEntity"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'Variables locally defined by this behaviour.'>
 	<derived>
@@ -46,6 +48,7 @@ FamixTWithLocalVariables >> localVariables [
 { #category : 'accessing' }
 FamixTWithLocalVariables >> localVariables: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	localVariables value: anObject
 ]

--- a/src/Famix-Traits/FamixTWithMethods.trait.st
+++ b/src/Famix-Traits/FamixTWithMethods.trait.st
@@ -23,6 +23,7 @@ Trait {
 { #category : 'meta' }
 FamixTWithMethods classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TWithMethods super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -44,6 +45,7 @@ FamixTWithMethods >> implements: aString [
 FamixTWithMethods >> methods [
 	"Relation named: #methods type: #FamixTMethod opposite: #parentType"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'Methods declared by this type.'>
 	<derived>
@@ -53,6 +55,7 @@ FamixTWithMethods >> methods [
 { #category : 'accessing' }
 FamixTWithMethods >> methods: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	methods value: anObject
 ]

--- a/src/Famix-Traits/FamixTWithParameters.trait.st
+++ b/src/Famix-Traits/FamixTWithParameters.trait.st
@@ -23,6 +23,7 @@ Trait {
 { #category : 'meta' }
 FamixTWithParameters classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TWithParameters super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -51,6 +52,7 @@ FamixTWithParameters >> numberOfParameters: aNumber [
 FamixTWithParameters >> parameters [
 	"Relation named: #parameters type: #FamixTParameter opposite: #parentBehaviouralEntity"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'List of formal parameters declared by this behaviour.'>
 	<derived>
@@ -60,6 +62,7 @@ FamixTWithParameters >> parameters [
 { #category : 'accessing' }
 FamixTWithParameters >> parameters: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	parameters value: anObject
 ]

--- a/src/Famix-Traits/FamixTWithReferences.trait.st
+++ b/src/Famix-Traits/FamixTWithReferences.trait.st
@@ -23,6 +23,7 @@ Trait {
 { #category : 'meta' }
 FamixTWithReferences classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TWithReferences super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -37,6 +38,7 @@ FamixTWithReferences >> addOutgoingReference: aReference [
 FamixTWithReferences >> outgoingReferences [
 	"Relation named: #outgoingReferences type: #FamixTReference opposite: #referencer"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'References from this entity to other entities.'>
 	<derived>
@@ -46,6 +48,7 @@ FamixTWithReferences >> outgoingReferences [
 { #category : 'accessing' }
 FamixTWithReferences >> outgoingReferences: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	outgoingReferences value: anObject
 ]

--- a/src/Famix-Traits/FamixTWithSourceLanguages.trait.st
+++ b/src/Famix-Traits/FamixTWithSourceLanguages.trait.st
@@ -23,6 +23,7 @@ Trait {
 { #category : 'meta' }
 FamixTWithSourceLanguages classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TWithSourceLanguages super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -32,6 +33,7 @@ FamixTWithSourceLanguages classSide >> annotation [
 FamixTWithSourceLanguages >> declaredSourceLanguage [
 	"Relation named: #declaredSourceLanguage type: #FamixTSourceLanguage opposite: #sourcedEntities"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'The declared SourceLanguage for the source code of this entity'>
 	^ declaredSourceLanguage
@@ -40,6 +42,7 @@ FamixTWithSourceLanguages >> declaredSourceLanguage [
 { #category : 'accessing' }
 FamixTWithSourceLanguages >> declaredSourceLanguage: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	declaredSourceLanguage := anObject
 ]

--- a/src/Famix-Traits/FamixTWithStatements.trait.st
+++ b/src/Famix-Traits/FamixTWithStatements.trait.st
@@ -35,6 +35,7 @@ Trait {
 { #category : 'meta' }
 FamixTWithStatements classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TWithStatements super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -48,6 +49,7 @@ FamixTWithStatements >> computeCyclomaticComplexity [
 { #category : 'testing' }
 FamixTWithStatements >> isBehavioural [
 
+	<ignoreForCoverage>
 	<generated>
 	^ true
 ]

--- a/src/Famix-Traits/FamixTWithTemplates.trait.st
+++ b/src/Famix-Traits/FamixTWithTemplates.trait.st
@@ -23,6 +23,7 @@ Trait {
 { #category : 'meta' }
 FamixTWithTemplates classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TWithTemplates super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -38,6 +39,7 @@ FamixTWithTemplates >> addTemplate: anObject [
 FamixTWithTemplates >> templates [
 	"Relation named: #templates type: #FamixTTemplate opposite: #templateOwner"
 
+	<ignoreForCoverage>
 	<generated>
 	<derived>
 	^ templates
@@ -46,6 +48,7 @@ FamixTWithTemplates >> templates [
 { #category : 'accessing' }
 FamixTWithTemplates >> templates: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	templates value: anObject
 ]

--- a/src/Famix-Traits/FamixTWithTraits.trait.st
+++ b/src/Famix-Traits/FamixTWithTraits.trait.st
@@ -23,6 +23,7 @@ Trait {
 { #category : 'meta' }
 FamixTWithTraits classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TWithTraits super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -38,6 +39,7 @@ FamixTWithTraits >> addTrait: anObject [
 FamixTWithTraits >> traits [
 	"Relation named: #traits type: #FamixTTrait opposite: #traitOwner"
 
+	<ignoreForCoverage>
 	<generated>
 	<derived>
 	^ traits
@@ -46,6 +48,7 @@ FamixTWithTraits >> traits [
 { #category : 'accessing' }
 FamixTWithTraits >> traits: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	traits value: anObject
 ]

--- a/src/Famix-Traits/FamixTWithTypeAliases.trait.st
+++ b/src/Famix-Traits/FamixTWithTypeAliases.trait.st
@@ -23,6 +23,7 @@ Trait {
 { #category : 'meta' }
 FamixTWithTypeAliases classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TWithTypeAliases super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -30,6 +31,8 @@ FamixTWithTypeAliases classSide >> annotation [
 
 { #category : 'adding' }
 FamixTWithTypeAliases >> addTypeAlias: anObject [
+
+	<ignoreForCoverage>
 	<generated>
 	^ self typeAliases add: anObject
 ]
@@ -46,6 +49,7 @@ FamixTWithTypeAliases >> allTypeAliases [
 FamixTWithTypeAliases >> typeAliases [
 	"Relation named: #typeAliases type: #FamixTTypeAlias opposite: #aliasedType"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'Aliases'>
 	<derived>
@@ -55,6 +59,7 @@ FamixTWithTypeAliases >> typeAliases [
 { #category : 'accessing' }
 FamixTWithTypeAliases >> typeAliases: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	typeAliases value: anObject
 ]

--- a/src/Famix-Traits/FamixTWithTypes.trait.st
+++ b/src/Famix-Traits/FamixTWithTypes.trait.st
@@ -23,6 +23,7 @@ Trait {
 { #category : 'meta' }
 FamixTWithTypes classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TWithTypes super: #Object>
 	<package: #'Famix-Traits'>
 	<generated>
@@ -56,6 +57,7 @@ FamixTWithTypes >> allRecursiveTypesDo: aBlock [
 FamixTWithTypes >> types [
 	"Relation named: #types type: #FamixTType opposite: #typeContainer"
 
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'Types contained (declared) in this entity, if any.
 #types is declared in ContainerEntity because different kinds of container can embed types. Types are usually contained in a Famix.Namespace. But types can also be contained in a Famix.Class or Famix.Method (in Java with inner classes for example). Famix.Function can also contain some types such as structs.'>
@@ -66,6 +68,7 @@ FamixTWithTypes >> types [
 { #category : 'accessing' }
 FamixTWithTypes >> types: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	types value: anObject
 ]

--- a/src/Famix-Visitor-Generation/FmxMBMethodsFactory.extension.st
+++ b/src/Famix-Visitor-Generation/FmxMBMethodsFactory.extension.st
@@ -5,6 +5,7 @@ FmxMBMethodsFactory class >> acceptFor: aName [
 
 	^ 'accept: aVisitor
 
+	<ignoreForCoverage>
 	<generated>
 	^ aVisitor visit{1}: self' format: { aName }
 ]
@@ -19,6 +20,7 @@ FmxMBMethodsFactory class >> visitBehavioral: aBehavioral builder: aBuilder [
 				                ifFalse: [ 'a' ]) , aBehavioral name capitalized.
 			  aStream << ('visit{1}: {2}
 
+	<ignoreForCoverage>
 	<generated>
 ' format: {
 					   aBehavioral fullName.
@@ -93,6 +95,7 @@ FmxMBMethodsFactory class >> visitCollection [
 
 	^ 'visitCollection: aCollection
 
+	<ignoreForCoverage>
 	<generated>
 	^ aCollection collect: [ :each | each accept: self ]'
 ]
@@ -102,6 +105,7 @@ FmxMBMethodsFactory class >> visitEntity [
 
 	^ 'visitEntity: aFamixEntity
 
+	<ignoreForCoverage>
 	<generated>
 	^ aFamixEntity ifNotNil: [ aFamixEntity accept: self ]'
 ]

--- a/src/FamixDocumentor-TestMetaModel/FDClass1.class.st
+++ b/src/FamixDocumentor-TestMetaModel/FDClass1.class.st
@@ -26,6 +26,7 @@ Class {
 { #category : 'meta' }
 FDClass1 class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Class1 super: #FDEntity>
 	<package: #'FamixDocumentor-TestMetaModel'>
 	<generated>
@@ -35,6 +36,7 @@ FDClass1 class >> annotation [
 FDClass1 >> myTrait [
 	"Relation named: #myTrait type: #FDTrait4 opposite: #class1"
 
+	<ignoreForCoverage>
 	<generated>
 	^ myTrait
 ]
@@ -42,6 +44,7 @@ FDClass1 >> myTrait [
 { #category : 'accessing' }
 FDClass1 >> myTrait: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	myTrait := anObject
 ]

--- a/src/FamixDocumentor-TestMetaModel/FDClass2.class.st
+++ b/src/FamixDocumentor-TestMetaModel/FDClass2.class.st
@@ -9,6 +9,7 @@ Class {
 { #category : 'meta' }
 FDClass2 class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Class2 super: #FDClass1>
 	<package: #'FamixDocumentor-TestMetaModel'>
 	<generated>

--- a/src/FamixDocumentor-TestMetaModel/FDEntity.class.st
+++ b/src/FamixDocumentor-TestMetaModel/FDEntity.class.st
@@ -9,6 +9,7 @@ Class {
 { #category : 'meta' }
 FDEntity class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Entity super: #MooseEntity>
 	<package: #'FamixDocumentor-TestMetaModel'>
 	<generated>
@@ -18,6 +19,7 @@ FDEntity class >> annotation [
 { #category : 'testing' }
 FDEntity class >> isAbstract [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self == FDEntity
 ]
@@ -25,6 +27,7 @@ FDEntity class >> isAbstract [
 { #category : 'meta' }
 FDEntity class >> metamodel [
 
+	<ignoreForCoverage>
 	<generated>
 	^ FDModel metamodel
 ]

--- a/src/FamixDocumentor-TestMetaModel/FDModel.class.st
+++ b/src/FamixDocumentor-TestMetaModel/FDModel.class.st
@@ -11,6 +11,7 @@ Class {
 { #category : 'meta' }
 FDModel class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Model super: #MooseModel>
 	<package: #'FamixDocumentor-TestMetaModel'>
 	<generated>

--- a/src/FamixDocumentor-TestMetaModel/FDTEntityCreator.trait.st
+++ b/src/FamixDocumentor-TestMetaModel/FDTEntityCreator.trait.st
@@ -14,6 +14,7 @@ Trait {
 { #category : 'meta' }
 FDTEntityCreator classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TEntityCreator super: #Object>
 	<package: #'FamixDocumentor-TestMetaModel'>
 	<generated>
@@ -22,6 +23,7 @@ FDTEntityCreator classSide >> annotation [
 { #category : 'entity creation' }
 FDTEntityCreator >> newClass1 [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FDClass1 new
 ]
@@ -29,6 +31,7 @@ FDTEntityCreator >> newClass1 [
 { #category : 'entity creation' }
 FDTEntityCreator >> newClass2 [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: FDClass2 new
 ]

--- a/src/FamixDocumentor-TestMetaModel/FDTrait1.trait.st
+++ b/src/FamixDocumentor-TestMetaModel/FDTrait1.trait.st
@@ -8,6 +8,7 @@ Trait {
 { #category : 'meta' }
 FDTrait1 classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Trait1 super: #Object>
 	<package: #'FamixDocumentor-TestMetaModel'>
 	<generated>

--- a/src/FamixDocumentor-TestMetaModel/FDTrait2.trait.st
+++ b/src/FamixDocumentor-TestMetaModel/FDTrait2.trait.st
@@ -10,6 +10,7 @@ Trait {
 { #category : 'meta' }
 FDTrait2 classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Trait2 super: #Object>
 	<package: #'FamixDocumentor-TestMetaModel'>
 	<generated>

--- a/src/FamixDocumentor-TestMetaModel/FDTrait3.trait.st
+++ b/src/FamixDocumentor-TestMetaModel/FDTrait3.trait.st
@@ -10,6 +10,7 @@ Trait {
 { #category : 'meta' }
 FDTrait3 classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Trait3 super: #Object>
 	<package: #'FamixDocumentor-TestMetaModel'>
 	<generated>

--- a/src/FamixDocumentor-TestMetaModel/FDTrait4.trait.st
+++ b/src/FamixDocumentor-TestMetaModel/FDTrait4.trait.st
@@ -34,6 +34,7 @@ Trait {
 { #category : 'meta' }
 FDTrait4 classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Trait4 super: #Object>
 	<package: #'FamixDocumentor-TestMetaModel'>
 	<generated>
@@ -41,6 +42,8 @@ FDTrait4 classSide >> annotation [
 
 { #category : 'adding' }
 FDTrait4 >> addClass1: anObject [
+
+	<ignoreForCoverage>
 	<generated>
 	^ self class1 add: anObject
 ]
@@ -49,6 +52,7 @@ FDTrait4 >> addClass1: anObject [
 FDTrait4 >> class1 [
 	"Relation named: #class1 type: #FDClass1 opposite: #myTrait"
 
+	<ignoreForCoverage>
 	<generated>
 	<derived>
 	^ class1
@@ -57,6 +61,7 @@ FDTrait4 >> class1 [
 { #category : 'accessing' }
 FDTrait4 >> class1: anObject [
 
+	<ignoreForCoverage>
 	<generated>
 	class1 value: anObject
 ]
@@ -65,6 +70,7 @@ FDTrait4 >> class1: anObject [
 FDTrait4 >> otherProp [
 
 	<FMProperty: #otherProp type: #Object>
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'Another property in the trait'>
 	^ otherProp
@@ -72,6 +78,7 @@ FDTrait4 >> otherProp [
 
 { #category : 'accessing' }
 FDTrait4 >> otherProp: anObject [
+	<ignoreForCoverage>
 	<generated>
 	otherProp := anObject
 ]
@@ -80,6 +87,7 @@ FDTrait4 >> otherProp: anObject [
 FDTrait4 >> someProp [
 
 	<FMProperty: #someProp type: #String>
+	<ignoreForCoverage>
 	<generated>
 	<FMComment: 'A property in the trait'>
 	^ someProp
@@ -87,6 +95,7 @@ FDTrait4 >> someProp [
 
 { #category : 'accessing' }
 FDTrait4 >> someProp: anObject [
+	<ignoreForCoverage>
 	<generated>
 	someProp := anObject
 ]

--- a/src/Moose-Core-Tests-Entities/MooseMSEImporterTestAttribute.class.st
+++ b/src/Moose-Core-Tests-Entities/MooseMSEImporterTestAttribute.class.st
@@ -45,6 +45,7 @@ Class {
 { #category : 'meta' }
 MooseMSEImporterTestAttribute class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Attribute super: #MooseMSEImporterTestNamedEntity>
 	<package: #'Moose-Core-Tests-Entities'>
 	<generated>

--- a/src/Moose-Core-Tests-Entities/MooseMSEImporterTestClass.class.st
+++ b/src/Moose-Core-Tests-Entities/MooseMSEImporterTestClass.class.st
@@ -55,6 +55,7 @@ Class {
 { #category : 'meta' }
 MooseMSEImporterTestClass class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Class super: #MooseMSEImporterTestNamedEntity>
 	<package: #'Moose-Core-Tests-Entities'>
 	<generated>

--- a/src/Moose-Core-Tests-Entities/MooseMSEImporterTestComment.class.st
+++ b/src/Moose-Core-Tests-Entities/MooseMSEImporterTestComment.class.st
@@ -28,6 +28,7 @@ Class {
 { #category : 'meta' }
 MooseMSEImporterTestComment class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Comment super: #MooseMSEImporterTestSourcedEntity>
 	<package: #'Moose-Core-Tests-Entities'>
 	<generated>

--- a/src/Moose-Core-Tests-Entities/MooseMSEImporterTestEntity.class.st
+++ b/src/Moose-Core-Tests-Entities/MooseMSEImporterTestEntity.class.st
@@ -9,6 +9,7 @@ Class {
 { #category : 'meta' }
 MooseMSEImporterTestEntity class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Entity super: #MooseEntity>
 	<package: #'Moose-Core-Tests-Entities'>
 	<generated>
@@ -18,6 +19,7 @@ MooseMSEImporterTestEntity class >> annotation [
 { #category : 'testing' }
 MooseMSEImporterTestEntity class >> isAbstract [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self == MooseMSEImporterTestEntity
 ]
@@ -25,6 +27,7 @@ MooseMSEImporterTestEntity class >> isAbstract [
 { #category : 'meta' }
 MooseMSEImporterTestEntity class >> metamodel [
 
+	<ignoreForCoverage>
 	<generated>
 	^ MooseMSEImporterTestModel metamodel
 ]
@@ -32,6 +35,7 @@ MooseMSEImporterTestEntity class >> metamodel [
 { #category : 'testing' }
 MooseMSEImporterTestEntity >> canBeStub [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -39,6 +43,7 @@ MooseMSEImporterTestEntity >> canBeStub [
 { #category : 'testing' }
 MooseMSEImporterTestEntity >> hasImmediateSource [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -46,6 +51,7 @@ MooseMSEImporterTestEntity >> hasImmediateSource [
 { #category : 'testing' }
 MooseMSEImporterTestEntity >> isAssociation [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -53,6 +59,7 @@ MooseMSEImporterTestEntity >> isAssociation [
 { #category : 'testing' }
 MooseMSEImporterTestEntity >> isAttribute [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -60,6 +67,7 @@ MooseMSEImporterTestEntity >> isAttribute [
 { #category : 'testing' }
 MooseMSEImporterTestEntity >> isBehavioural [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -67,6 +75,7 @@ MooseMSEImporterTestEntity >> isBehavioural [
 { #category : 'testing' }
 MooseMSEImporterTestEntity >> isClass [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -74,6 +83,7 @@ MooseMSEImporterTestEntity >> isClass [
 { #category : 'testing' }
 MooseMSEImporterTestEntity >> isComment [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -81,6 +91,7 @@ MooseMSEImporterTestEntity >> isComment [
 { #category : 'testing' }
 MooseMSEImporterTestEntity >> isInheritance [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -88,6 +99,7 @@ MooseMSEImporterTestEntity >> isInheritance [
 { #category : 'testing' }
 MooseMSEImporterTestEntity >> isMethod [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -95,6 +107,7 @@ MooseMSEImporterTestEntity >> isMethod [
 { #category : 'testing' }
 MooseMSEImporterTestEntity >> isNamedEntity [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -102,6 +115,7 @@ MooseMSEImporterTestEntity >> isNamedEntity [
 { #category : 'testing' }
 MooseMSEImporterTestEntity >> isNamespace [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -109,6 +123,7 @@ MooseMSEImporterTestEntity >> isNamespace [
 { #category : 'testing' }
 MooseMSEImporterTestEntity >> isPackage [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -116,6 +131,7 @@ MooseMSEImporterTestEntity >> isPackage [
 { #category : 'testing' }
 MooseMSEImporterTestEntity >> isPrimitiveType [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -123,6 +139,7 @@ MooseMSEImporterTestEntity >> isPrimitiveType [
 { #category : 'testing' }
 MooseMSEImporterTestEntity >> isQueryable [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -130,6 +147,7 @@ MooseMSEImporterTestEntity >> isQueryable [
 { #category : 'testing' }
 MooseMSEImporterTestEntity >> isStructuralEntity [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]
@@ -137,6 +155,7 @@ MooseMSEImporterTestEntity >> isStructuralEntity [
 { #category : 'testing' }
 MooseMSEImporterTestEntity >> isType [
 
+	<ignoreForCoverage>
 	<generated>
 	^ false
 ]

--- a/src/Moose-Core-Tests-Entities/MooseMSEImporterTestEntityTyping.class.st
+++ b/src/Moose-Core-Tests-Entities/MooseMSEImporterTestEntityTyping.class.st
@@ -35,6 +35,7 @@ Class {
 { #category : 'meta' }
 MooseMSEImporterTestEntityTyping class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #EntityTyping super: #MooseMSEImporterTestEntity>
 	<package: #'Moose-Core-Tests-Entities'>
 	<generated>

--- a/src/Moose-Core-Tests-Entities/MooseMSEImporterTestInheritance.class.st
+++ b/src/Moose-Core-Tests-Entities/MooseMSEImporterTestInheritance.class.st
@@ -35,6 +35,7 @@ Class {
 { #category : 'meta' }
 MooseMSEImporterTestInheritance class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Inheritance super: #MooseMSEImporterTestEntity>
 	<package: #'Moose-Core-Tests-Entities'>
 	<generated>

--- a/src/Moose-Core-Tests-Entities/MooseMSEImporterTestMethod.class.st
+++ b/src/Moose-Core-Tests-Entities/MooseMSEImporterTestMethod.class.st
@@ -56,6 +56,7 @@ Class {
 { #category : 'meta' }
 MooseMSEImporterTestMethod class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Method super: #MooseMSEImporterTestNamedEntity>
 	<package: #'Moose-Core-Tests-Entities'>
 	<generated>

--- a/src/Moose-Core-Tests-Entities/MooseMSEImporterTestModel.class.st
+++ b/src/Moose-Core-Tests-Entities/MooseMSEImporterTestModel.class.st
@@ -10,6 +10,8 @@ Class {
 
 { #category : 'accessing' }
 MooseMSEImporterTestModel class >> allSubmetamodelsPackagesNames [
+
+	<ignoreForCoverage>
 	<generated>
 	^ #(#'Moose-Query' #'Famix-Traits')
 ]
@@ -17,6 +19,7 @@ MooseMSEImporterTestModel class >> allSubmetamodelsPackagesNames [
 { #category : 'meta' }
 MooseMSEImporterTestModel class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Model super: #MooseModel>
 	<package: #'Moose-Core-Tests-Entities'>
 	<generated>

--- a/src/Moose-Core-Tests-Entities/MooseMSEImporterTestNamedEntity.class.st
+++ b/src/Moose-Core-Tests-Entities/MooseMSEImporterTestNamedEntity.class.st
@@ -20,6 +20,7 @@ Class {
 { #category : 'meta' }
 MooseMSEImporterTestNamedEntity class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #NamedEntity super: #MooseMSEImporterTestEntity>
 	<package: #'Moose-Core-Tests-Entities'>
 	<generated>
@@ -29,6 +30,7 @@ MooseMSEImporterTestNamedEntity class >> annotation [
 { #category : 'testing' }
 MooseMSEImporterTestNamedEntity class >> isAbstract [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self == MooseMSEImporterTestNamedEntity
 ]
@@ -36,6 +38,7 @@ MooseMSEImporterTestNamedEntity class >> isAbstract [
 { #category : 'testing' }
 MooseMSEImporterTestNamedEntity >> isNamedEntity [
 
+	<ignoreForCoverage>
 	<generated>
 	^ true
 ]

--- a/src/Moose-Core-Tests-Entities/MooseMSEImporterTestNamespace.class.st
+++ b/src/Moose-Core-Tests-Entities/MooseMSEImporterTestNamespace.class.st
@@ -35,6 +35,7 @@ Class {
 { #category : 'meta' }
 MooseMSEImporterTestNamespace class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Namespace super: #MooseMSEImporterTestNamedEntity>
 	<package: #'Moose-Core-Tests-Entities'>
 	<generated>

--- a/src/Moose-Core-Tests-Entities/MooseMSEImporterTestPackage.class.st
+++ b/src/Moose-Core-Tests-Entities/MooseMSEImporterTestPackage.class.st
@@ -41,6 +41,7 @@ Class {
 { #category : 'meta' }
 MooseMSEImporterTestPackage class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #Package super: #MooseMSEImporterTestNamedEntity>
 	<package: #'Moose-Core-Tests-Entities'>
 	<generated>

--- a/src/Moose-Core-Tests-Entities/MooseMSEImporterTestPrimitiveType.class.st
+++ b/src/Moose-Core-Tests-Entities/MooseMSEImporterTestPrimitiveType.class.st
@@ -41,6 +41,7 @@ Class {
 { #category : 'meta' }
 MooseMSEImporterTestPrimitiveType class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #PrimitiveType super: #MooseMSEImporterTestEntity>
 	<package: #'Moose-Core-Tests-Entities'>
 	<generated>

--- a/src/Moose-Core-Tests-Entities/MooseMSEImporterTestSourceAnchor.class.st
+++ b/src/Moose-Core-Tests-Entities/MooseMSEImporterTestSourceAnchor.class.st
@@ -23,6 +23,7 @@ Class {
 { #category : 'meta' }
 MooseMSEImporterTestSourceAnchor class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #SourceAnchor super: #MooseMSEImporterTestEntity>
 	<package: #'Moose-Core-Tests-Entities'>
 	<generated>
@@ -32,6 +33,7 @@ MooseMSEImporterTestSourceAnchor class >> annotation [
 { #category : 'testing' }
 MooseMSEImporterTestSourceAnchor class >> isAbstract [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self == MooseMSEImporterTestSourceAnchor
 ]

--- a/src/Moose-Core-Tests-Entities/MooseMSEImporterTestSourceLanguage.class.st
+++ b/src/Moose-Core-Tests-Entities/MooseMSEImporterTestSourceLanguage.class.st
@@ -23,6 +23,7 @@ Class {
 { #category : 'meta' }
 MooseMSEImporterTestSourceLanguage class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #SourceLanguage super: #MooseMSEImporterTestEntity>
 	<package: #'Moose-Core-Tests-Entities'>
 	<generated>

--- a/src/Moose-Core-Tests-Entities/MooseMSEImporterTestSourceTextAnchor.class.st
+++ b/src/Moose-Core-Tests-Entities/MooseMSEImporterTestSourceTextAnchor.class.st
@@ -29,6 +29,7 @@ Class {
 { #category : 'meta' }
 MooseMSEImporterTestSourceTextAnchor class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #SourceTextAnchor super: #MooseMSEImporterTestSourceAnchor>
 	<package: #'Moose-Core-Tests-Entities'>
 	<generated>

--- a/src/Moose-Core-Tests-Entities/MooseMSEImporterTestSourcedEntity.class.st
+++ b/src/Moose-Core-Tests-Entities/MooseMSEImporterTestSourcedEntity.class.st
@@ -23,6 +23,7 @@ Class {
 { #category : 'meta' }
 MooseMSEImporterTestSourcedEntity class >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #SourcedEntity super: #MooseMSEImporterTestEntity>
 	<package: #'Moose-Core-Tests-Entities'>
 	<generated>
@@ -32,6 +33,7 @@ MooseMSEImporterTestSourcedEntity class >> annotation [
 { #category : 'testing' }
 MooseMSEImporterTestSourcedEntity class >> isAbstract [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self == MooseMSEImporterTestSourcedEntity
 ]

--- a/src/Moose-Core-Tests-Entities/MooseMSEImporterTestTEntityCreator.trait.st
+++ b/src/Moose-Core-Tests-Entities/MooseMSEImporterTestTEntityCreator.trait.st
@@ -14,6 +14,7 @@ Trait {
 { #category : 'meta' }
 MooseMSEImporterTestTEntityCreator classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TEntityCreator super: #Object>
 	<package: #'Moose-Core-Tests-Entities'>
 	<generated>
@@ -22,6 +23,7 @@ MooseMSEImporterTestTEntityCreator classSide >> annotation [
 { #category : 'entity creation' }
 MooseMSEImporterTestTEntityCreator >> newAttribute [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: MooseMSEImporterTestAttribute new
 ]
@@ -29,6 +31,7 @@ MooseMSEImporterTestTEntityCreator >> newAttribute [
 { #category : 'entity creation' }
 MooseMSEImporterTestTEntityCreator >> newAttributeNamed: aName [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: (MooseMSEImporterTestAttribute named: aName)
 ]
@@ -36,6 +39,7 @@ MooseMSEImporterTestTEntityCreator >> newAttributeNamed: aName [
 { #category : 'entity creation' }
 MooseMSEImporterTestTEntityCreator >> newClass [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: MooseMSEImporterTestClass new
 ]
@@ -43,6 +47,7 @@ MooseMSEImporterTestTEntityCreator >> newClass [
 { #category : 'entity creation' }
 MooseMSEImporterTestTEntityCreator >> newClassNamed: aName [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: (MooseMSEImporterTestClass named: aName)
 ]
@@ -50,6 +55,7 @@ MooseMSEImporterTestTEntityCreator >> newClassNamed: aName [
 { #category : 'entity creation' }
 MooseMSEImporterTestTEntityCreator >> newComment [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: MooseMSEImporterTestComment new
 ]
@@ -57,6 +63,7 @@ MooseMSEImporterTestTEntityCreator >> newComment [
 { #category : 'entity creation' }
 MooseMSEImporterTestTEntityCreator >> newEntityTyping [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: MooseMSEImporterTestEntityTyping new
 ]
@@ -64,6 +71,7 @@ MooseMSEImporterTestTEntityCreator >> newEntityTyping [
 { #category : 'entity creation' }
 MooseMSEImporterTestTEntityCreator >> newInheritance [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: MooseMSEImporterTestInheritance new
 ]
@@ -71,6 +79,7 @@ MooseMSEImporterTestTEntityCreator >> newInheritance [
 { #category : 'entity creation' }
 MooseMSEImporterTestTEntityCreator >> newMethod [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: MooseMSEImporterTestMethod new
 ]
@@ -78,6 +87,7 @@ MooseMSEImporterTestTEntityCreator >> newMethod [
 { #category : 'entity creation' }
 MooseMSEImporterTestTEntityCreator >> newMethodNamed: aName [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: (MooseMSEImporterTestMethod named: aName)
 ]
@@ -85,6 +95,7 @@ MooseMSEImporterTestTEntityCreator >> newMethodNamed: aName [
 { #category : 'entity creation' }
 MooseMSEImporterTestTEntityCreator >> newNamespace [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: MooseMSEImporterTestNamespace new
 ]
@@ -92,6 +103,7 @@ MooseMSEImporterTestTEntityCreator >> newNamespace [
 { #category : 'entity creation' }
 MooseMSEImporterTestTEntityCreator >> newNamespaceNamed: aName [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: (MooseMSEImporterTestNamespace named: aName)
 ]
@@ -99,6 +111,7 @@ MooseMSEImporterTestTEntityCreator >> newNamespaceNamed: aName [
 { #category : 'entity creation' }
 MooseMSEImporterTestTEntityCreator >> newPackage [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: MooseMSEImporterTestPackage new
 ]
@@ -106,6 +119,7 @@ MooseMSEImporterTestTEntityCreator >> newPackage [
 { #category : 'entity creation' }
 MooseMSEImporterTestTEntityCreator >> newPackageNamed: aName [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: (MooseMSEImporterTestPackage named: aName)
 ]
@@ -113,6 +127,7 @@ MooseMSEImporterTestTEntityCreator >> newPackageNamed: aName [
 { #category : 'entity creation' }
 MooseMSEImporterTestTEntityCreator >> newPrimitiveType [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: MooseMSEImporterTestPrimitiveType new
 ]
@@ -120,6 +135,7 @@ MooseMSEImporterTestTEntityCreator >> newPrimitiveType [
 { #category : 'entity creation' }
 MooseMSEImporterTestTEntityCreator >> newPrimitiveTypeNamed: aName [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: (MooseMSEImporterTestPrimitiveType named: aName)
 ]
@@ -127,6 +143,7 @@ MooseMSEImporterTestTEntityCreator >> newPrimitiveTypeNamed: aName [
 { #category : 'entity creation' }
 MooseMSEImporterTestTEntityCreator >> newSourceLanguage [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: MooseMSEImporterTestSourceLanguage new
 ]
@@ -134,6 +151,7 @@ MooseMSEImporterTestTEntityCreator >> newSourceLanguage [
 { #category : 'entity creation' }
 MooseMSEImporterTestTEntityCreator >> newSourceTextAnchor [
 
+	<ignoreForCoverage>
 	<generated>
 	^ self add: MooseMSEImporterTestSourceTextAnchor new
 ]

--- a/src/Moose-Query/TAssociationMetaLevelDependency.trait.st
+++ b/src/Moose-Query/TAssociationMetaLevelDependency.trait.st
@@ -13,6 +13,7 @@ Trait {
 { #category : 'meta' }
 TAssociationMetaLevelDependency classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TAssociationMetaLevelDependency super: #Object>
 	<package: #'Moose-Query'>
 	<generated>

--- a/src/Moose-Query/TEntityMetaLevelDependency.trait.st
+++ b/src/Moose-Query/TEntityMetaLevelDependency.trait.st
@@ -91,6 +91,7 @@ TEntityMetaLevelDependency classSide >> allOutgoingAssociationTypesIn: aMetamode
 { #category : 'meta' }
 TEntityMetaLevelDependency classSide >> annotation [
 
+	<ignoreForCoverage>
 	<FMClass: #TEntityMetaLevelDependency super: #Object>
 	<package: #'Moose-Query'>
 	<generated>
@@ -645,6 +646,7 @@ TEntityMetaLevelDependency >> isIncludedIn: anEntity containerSelectorsCache: co
 { #category : 'testing' }
 TEntityMetaLevelDependency >> isQueryable [
 
+	<ignoreForCoverage>
 	<generated>
 	^ true
 ]


### PR DESCRIPTION
In order to be able to have a more precise coverage, I propose to add the #ignoreForCoverage pragma to all generated methods. The generated code is already tested in Famix, there is no need to test them again in each project 