### PR TITLE
Fix random bug in tests

### DIFF
--- a/src/Famix-MetamodelBuilder-Tests/FmxMBGeneratorCleaningStrategyTest.class.st
+++ b/src/Famix-MetamodelBuilder-Tests/FmxMBGeneratorCleaningStrategyTest.class.st
@@ -131,11 +131,10 @@ FmxMBGeneratorCleaningStrategyTest >> setUp [
 { #category : 'running' }
 FmxMBGeneratorCleaningStrategyTest >> tearDown [
 
-	[
-		self packageName asPackage removeFromSystem.
-		'Famix-MetamodelBuilder-TestsResources-Entities' asPackage removeFromSystem ]
-		on: NotFound
-		do: [ ].
+	{
+		self packageName.
+		'Famix-MetamodelBuilder-TestsResources-Entities' } do: [ :packageName | (packageName asPackageIfAbsent: [ nil ]) ifNotNil: #removeFromSystem ].
+
 	super tearDown
 ]
 


### PR DESCRIPTION
This should fix Famix for Pharo 14 and mostly, it allows to not destroy an image if we get the bug. Else it is impossible to regenerate metamodels anymore once we hit it 